### PR TITLE
fix: deduplicate secondary sales and use on-chain royalty rate

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -75,6 +75,7 @@ export function initializeDatabase() {
     CREATE INDEX IF NOT EXISTS idx_secondary_distributions_contractId ON secondary_royalty_distributions(contractId);
     CREATE INDEX IF NOT EXISTS idx_audit_contractId ON audit_log(contractId);
     CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_secondary_sales_dedup ON secondary_sales(contractId, nftId, previousOwner, newOwner, salePrice, saleToken);
   `);
 }
 

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -4,6 +4,7 @@ import {
   addressToScVal,
   i128ToScVal,
   u32ToScVal,
+  getRoyaltyRateFromContract,
 } from "../stellar.js";
 import {
   recordTransaction,
@@ -59,8 +60,11 @@ secondaryRoyaltyRouter.post("/", async (req, res, next) => {
         .json({ error: "Royalty rate must be between 0 and 10000 basis points." });
     }
 
-    // Calculate royalty amount
-    const royaltyAmount = Math.floor((salePrice * royaltyRate) / 10000);
+    // Fetch on-chain royalty rate instead of trusting client-supplied value
+    const onChainRate = await getRoyaltyRateFromContract(contractId);
+
+    // Calculate royalty amount using on-chain rate
+    const royaltyAmount = Math.floor((salePrice * onChainRate) / 10000);
 
     if (royaltyAmount <= 0) {
       return res.status(400).json({ error: "Calculated royalty amount is zero." });
@@ -71,20 +75,27 @@ secondaryRoyaltyRouter.post("/", async (req, res, next) => {
       contractId,
       "secondary_royalty",
       walletAddress,
-      { salePrice: salePrice.toString(), nftId, saleToken, royaltyRate }
+      { salePrice: salePrice.toString(), nftId, saleToken, royaltyRate: onChainRate }
     );
 
-    // Record the secondary sale
-    recordSecondarySale(
-      contractId,
-      nftId,
-      previousOwner,
-      newOwner,
-      salePrice,
-      saleToken,
-      royaltyAmount,
-      royaltyRate
-    );
+    // Record the secondary sale (unique constraint prevents duplicates)
+    try {
+      recordSecondarySale(
+        contractId,
+        nftId,
+        previousOwner,
+        newOwner,
+        salePrice,
+        saleToken,
+        royaltyAmount,
+        onChainRate
+      );
+    } catch (err) {
+      if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
+        return res.status(409).json({ error: "This sale has already been recorded." });
+      }
+      throw err;
+    }
 
     // Build transaction to record royalty in contract
     const txXdr = await buildTx(walletAddress, contractId, "record_secondary_royalty", [
@@ -97,15 +108,14 @@ secondaryRoyaltyRouter.post("/", async (req, res, next) => {
       nftId,
       salePrice: salePrice.toString(),
       royaltyAmount: royaltyAmount.toString(),
-      royaltyRate,
+      royaltyRateUsed: onChainRate,
     });
 
     res.json({
       xdr: txXdr,
       transactionId,
       royaltyAmount,
-      salePriceInput: salePrice,
-      royaltyRateInput: royaltyRate,
+      royaltyRateUsed: onChainRate,
     });
   } catch (err) {
     next(err);

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Shared Soroban RPC client and helpers.
  * Real transactions are assembled here and returned as XDR so the
  * frontend can sign them with Freighter before submission.
@@ -11,6 +11,7 @@ import {
   BASE_FEE,
   nativeToScVal,
   Address,
+  Account,
   xdr,
 } from "@stellar/stellar-sdk";
 
@@ -42,7 +43,7 @@ export async function buildTx(callerAddress, contractId, method, args = []) {
   return prepared.toXDR();
 }
 
-// ── ScVal helpers ────────────────────────────────────────────────────────────
+// ── ScVal helpers ────────────────────────────────────────────────────────
 
 export function addressToScVal(addr) {
   return new Address(addr).toScVal();
@@ -58,4 +59,27 @@ export function i128ToScVal(n) {
 
 export function vecToScVal(items) {
   return xdr.ScVal.scvVec(items);
+}
+
+/**
+ * Fetch the royalty rate from the contract using a read-only simulation.
+ * Returns the rate as a u32 (basis points), or 0 on error.
+ */
+export async function getRoyaltyRateFromContract(contractId) {
+  const contract = new Contract(contractId);
+  const dummyAccount = new Account(
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    "0",
+  );
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call("get_royalty_rate"))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(sim)) return 0;
+  return sim.result?.retval?.u32() ?? 0;
 }


### PR DESCRIPTION
fix: deduplicate secondary sales and use on-chain royalty rate

Closes #26 

Problem

Two bugs existed in the POST /api/secondary-royalty endpoint:

The royalty amount was calculated using the client-supplied royaltyRate, which could drift from the actual on-chain rate — allowing manipulation or inconsistency.
There was no deduplication — the same sale could be recorded multiple times, inflating the royalty pool.
Changes

stellar.js

Added getRoyaltyRateFromContract which simulates a read-only call to get_royalty_rate on the contract using a dummy account, returning the on-chain rate as basis points.
database.js

Added a unique index on secondary_sales(contractId, nftId, previousOwner, newOwner, salePrice, saleToken) to prevent duplicate sale records at the database level.
secondary-royalty.js

Replaced client-supplied royaltyRate with the on-chain rate fetched via getRoyaltyRateFromContract.
Wrapped recordSecondarySale in a try/catch — returns HTTP 409 if SQLITE_CONSTRAINT_UNIQUE is thrown.
Response now includes royaltyRateUsed so the frontend can verify which rate was applied.