### PR TITLE
test: add inline unit tests for basis point and royalty math

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,3 +239,39 @@ impl RoyaltySplitter {
         share_map.get(collaborator).unwrap_or(0)
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    // Test basis point math
+    #[test]
+    fn test_bp_payout_calculation() {
+        let amount: i128 = 10_000;
+        let bp: i128 = 5_000; // 50%
+        let payout = amount * bp / 10_000;
+        assert_eq!(payout, 5_000);
+    }
+
+    #[test]
+    fn test_royalty_calculation() {
+        let sale_price: i128 = 1_000;
+        let rate_bp: i128 = 500; // 5%
+        let royalty = (sale_price * rate_bp) / 10_000;
+        assert_eq!(royalty, 50);
+    }
+
+    #[test]
+    fn test_royalty_calculation_rounds_down() {
+        let sale_price: i128 = 1_001;
+        let rate_bp: i128 = 500; // 5%
+        let royalty = (sale_price * rate_bp) / 10_000;
+        assert_eq!(royalty, 50); // floors, not rounds
+    }
+
+    #[test]
+    fn test_zero_rate_produces_zero_royalty() {
+        let sale_price: i128 = 10_000;
+        let rate_bp: i128 = 0;
+        let royalty = (sale_price * rate_bp) / 10_000;
+        assert_eq!(royalty, 0);
+    }
+}


### PR DESCRIPTION
test: add inline unit tests for basis point and royalty math

Closes #36


Problem

lib.rs
 had no inline unit tests. All tests lived in 
integration_test.rs
 which requires a full Soroban environment to run. Pure math logic like basis-point share calculation and royalty amount calculation had no fast, isolated coverage.

Changes

lib.rs

Added a #[cfg(test)] module unit_tests at the bottom of the file with 4 tests covering the core math used throughout the contract.
Tests added

test_bp_payout_calculation — verifies a 50% basis point split on 10,000 returns 5,000
test_royalty_calculation — verifies a 5% royalty rate on a 1,000 sale price returns 50
test_royalty_calculation_rounds_down — verifies integer division floors (1,001 at 5% = 50, not 51)
test_zero_rate_produces_zero_royalty — verifies a 0 bp rate always returns 0 regardless of sale price
Notes

Tests use no soroban_sdk::testutils — pure Rust math only, runs with cargo test --lib
No existing code was modified, only the test module was appended