### PR TITLE
feat: add pagination, error handling, and retry to ResaleHistory

### DIFF
--- a/frontend/src/components/ResaleHistory.css
+++ b/frontend/src/components/ResaleHistory.css
@@ -153,3 +153,93 @@
     font-size: 0.75rem;
   }
 }
+
+.resale-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.resale-header h3 {
+  margin: 0;
+}
+
+.refresh-btn {
+  padding: 0.4rem 0.9rem;
+  background: transparent;
+  border: 1px solid #0066cc;
+  color: #0066cc;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease;
+}
+
+.refresh-btn:hover {
+  background: #e8f0fe;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.error-banner button {
+  margin-left: auto;
+  padding: 0.3rem 0.75rem;
+  background: #721c24;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.error-banner button:hover {
+  background: #5a1520;
+}
+
+.loading-state {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.pagination button {
+  padding: 0.4rem 0.9rem;
+  background: #0066cc;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease;
+}
+
+.pagination button:hover:not(:disabled) {
+  background: #0052a3;
+}
+
+.pagination button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Closes #23

Type: FE
Component: frontend/src/components/ResaleHistory.tsx

## Summary
- Sales and distributions now fetch independently with separate error states
- Inline error banners with Retry button per tab
- Pagination (Previous / Next) with correct total counts for both tabs — PAGE_SIZE = 20
- Manual Refresh button in the card header reloads the active tab
- Offset resets to 0 when contractId changes
- No more silent console.error — all failures are visible to the user
