### PR TITLE
fix: remove secret key from .env.example and document all variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,23 @@
+# PORT — port the Express server listens on
 PORT=3001
+
+# STELLAR_NETWORK — testnet or mainnet
 STELLAR_NETWORK=testnet
-# Horizon RPC endpoint
-HORIZON_URL=https://horizon-testnet.stellar.org
-# Soroban RPC endpoint
+
+# SOROBAN_RPC_URL — Soroban RPC endpoint for smart contract interactions
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
-# Server-side signing key (only used for read-only simulation; real txs are signed client-side)
-SERVER_SECRET_KEY=S...
+
+# HORIZON_URL — Horizon REST API endpoint for account and transaction queries
+HORIZON_URL=https://horizon-testnet.stellar.org
+
+# FRONTEND_ORIGIN — allowed CORS origin (your frontend URL)
+FRONTEND_ORIGIN=http://localhost:5173
+
+# RATE_LIMIT_WINDOW_MS — sliding window duration for rate limiting in milliseconds (default: 15 minutes)
+RATE_LIMIT_WINDOW_MS=900000
+
+# RATE_LIMIT_MAX — max requests per window for read endpoints
+RATE_LIMIT_MAX=100
+
+# RATE_LIMIT_WRITE_MAX — max requests per window for write/mutation endpoints
+RATE_LIMIT_WRITE_MAX=10


### PR DESCRIPTION
Closes #27

## fix: remove secret key from .env.example and document all variables

### Problem
`SERVER_SECRET_KEY=S...` was present in `.env.example` with a comment
suggesting it's "only used for read-only simulation". This is misleading —
the variable isn't used anywhere in the codebase, and having any secret key
placeholder in a committed file encourages new contributors to paste real
keys and accidentally commit them.

### Changes
- Removed `SERVER_SECRET_KEY` from `.env.example` entirely
- Added all variables the app actually reads: `FRONTEND_ORIGIN`,
  `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `RATE_LIMIT_WRITE_MAX`
- Added a one-line comment above every variable explaining its purpose
- Verified `.gitignore` already covers `.env` and `backend/.env` (no change needed)

### Security
No real secrets were ever committed. This is a preventative cleanup to
remove the misleading placeholder before a contributor copies it into a
real `.env` file.
