### PR TITLE
chore: add ESLint and Prettier to backend

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "env": { "node": true, "es2022": true },
+  "parserOptions": { "ecmaVersion": 2022, "sourceType": "module" },
+  "extends": ["eslint:recommended", "prettier"],
+  "rules": {
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "no-console": "off"
+  }
+}

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "node --watch src/index.js",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "lint": "eslint src/**/*.js",
+    "format": "prettier --write src/**/*.js",
+    "test": "echo \"No tests yet — see open issues\" && exit 0"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.0"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",


### PR DESCRIPTION
**chore: add ESLint and Prettier to backend**

Closes #32 

Sets up consistent code style enforcement for the backend so contributors aren't guessing on formatting rules.

**What changed:**
- Added `.eslintrc.json` — ESLint with `eslint:recommended` + `prettier` extends, warns on unused vars, allows console
- Added `.prettierrc` — double quotes, semicolons, `es5` trailing commas, 100 char print width
- Updated `package.json` with `lint`, `format`, and `test` scripts + `devDependencies` for `eslint`, `prettier`, `eslint-config-prettier`

**How to verify:**
```bash
npm install
npm run lint     # should run without crashing
npm run format   # formats all files in src/
npm test         # exits 0 with placeholder message
```

---

Swap `#[issue-number]` for the actual issue before submitting.