### PR TITLE
Chore/database pragmas migrations

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -7,9 +7,43 @@ const dbPath = path.join(__dirname, "..", "audit.db");
 
 const db = new Database(dbPath);
 db.pragma("journal_mode = WAL");
+db.pragma("synchronous = NORMAL"); // safe with WAL, much faster
+db.pragma("cache_size = -64000"); // 64MB page cache
+db.pragma("foreign_keys = ON"); // enforce FK constraints
+db.pragma("temp_store = MEMORY"); // temp tables in memory
 
 // Initialize database schema
 export function initializeDatabase() {
+  // Migration version tracking
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version INTEGER PRIMARY KEY,
+      applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  const migrations = [
+    {
+      version: 1,
+      sql: `/* initial schema — already applied via CREATE TABLE IF NOT EXISTS */`,
+    },
+  ];
+
+  const applied = db
+    .prepare("SELECT version FROM schema_migrations")
+    .all()
+    .map((r) => r.version);
+
+  for (const migration of migrations) {
+    if (!applied.includes(migration.version)) {
+      db.exec(migration.sql);
+      db.prepare("INSERT INTO schema_migrations (version) VALUES (?)").run(
+        migration.version,
+      );
+      console.log(`Applied migration v${migration.version}`);
+    }
+  }
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS transactions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -373,6 +407,12 @@ export function getRoyaltyStatistics(contractId) {
     totalRoyaltiesGenerated: totalSales?.totalRoyalties || 0,
     lastDistribution: lastDistribution || null
   };
+}
+
+export function getMigrationVersion() {
+  return (
+    db.prepare("SELECT MAX(version) as v FROM schema_migrations").get()?.v ?? 0
+  );
 }
 
 export default db;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -9,7 +9,7 @@ import { collaboratorsRouter } from "./routes/collaborators.js";
 import { secondaryRoyaltyRouter } from "./routes/secondary-royalty.js";
 import historyRouter from "./routes/history.js";
 import { analyticsRouter } from "./routes/analytics.js";
-import { initializeDatabase } from "./database.js";
+import { initializeDatabase, getMigrationVersion } from "./database.js";
 
 // Initialize database on startup
 initializeDatabase();
@@ -26,7 +26,9 @@ app.use("/api", historyRouter);
 app.use("/api", analyticsRouter);
 
 // Health check
-app.get("/api/health", (_req, res) => res.json({ ok: true }));
+app.get("/api/health", (_req, res) =>
+  res.json({ ok: true, dbVersion: getMigrationVersion() }),
+);
 
 // Central error handler
 app.use((err, _req, res, _next) => {


### PR DESCRIPTION
**chore: add SQLite performance pragmas and migration versioning**

Closes #41 

**What changed:**
- Added `synchronous = NORMAL`, `cache_size = -64000` (64MB), `foreign_keys = ON`, and `temp_store = MEMORY` pragmas alongside the existing WAL setting
- Added `schema_migrations` table to track applied migrations with timestamps
- `initializeDatabase` now runs pending migrations in order and logs each one
- Added `getMigrationVersion()` export for health checks
- `/api/health` now returns `{ ok: true, dbVersion: N }`

**How to verify:**
- Start the server — console should log `Applied migration v1` on first run, nothing on subsequent runs
- `GET /api/health` returns `{ "ok": true, "dbVersion": 1 }`
- Adding a new migration object to the array will auto-apply it on next startup