### PR TITLE
fix: add inline validation for contract ID input

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -79,6 +79,17 @@
   background: var(--bg-primary);
 }
 
+.contract-input--error {
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.15);
+}
+
+.contract-input-error {
+  margin: 4px 0 0 0;
+  font-size: 0.78rem;
+  color: #e53e3e;
+}
+
 .quick-actions {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,11 +23,16 @@ import DistributeSecondaryRoyalties from "./components/DistributeSecondaryRoyalt
 import ResaleHistory from "./components/ResaleHistory";
 import "./App.css";
 
+function isValidContractId(id: string): boolean {
+  return id.startsWith("C") && id.length === 56;
+}
+
 export default function App() {
   const [walletAddress, setWalletAddress] = useState<string | null>(null);
   const [contractId, setContractId] = useState(
     () => localStorage.getItem("lastContractId") ?? ""
   );
+  const [contractIdError, setContractIdError] = useState<string | null>(null);
   const [royaltyRate, setRoyaltyRate] = useState(500); // Default 5%
   const [currentPage, setCurrentPage] = useState("dashboard");
 
@@ -48,9 +53,18 @@ export default function App() {
 
   function handleContractChange(value: string) {
     setContractId(value);
-    if (value) localStorage.setItem("lastContractId", value);
-    else localStorage.removeItem("lastContractId");
+    if (!value) {
+      setContractIdError(null);
+      localStorage.removeItem("lastContractId");
+    } else if (!isValidContractId(value)) {
+      setContractIdError("Contract ID must start with C and be 56 characters");
+    } else {
+      setContractIdError(null);
+      localStorage.setItem("lastContractId", value);
+    }
   }
+
+  const contractIdValid = isValidContractId(contractId);
 
   const renderPage = () => {
     switch (currentPage) {
@@ -170,14 +184,17 @@ export default function App() {
           <div className="sidebar-card">
             <h3>📋 Contract ID</h3>
             <input
-              className="contract-input"
+              className={`contract-input${contractIdError ? " contract-input--error" : ""}`}
               placeholder="C..."
               value={contractId}
               onChange={(e) => handleContractChange(e.target.value)}
             />
+            {contractIdError && (
+              <p className="contract-input-error">{contractIdError}</p>
+            )}
           </div>
 
-          {contractId && (
+          {contractIdValid && (
             <div className="sidebar-card">
               <h3>📊 Quick Actions</h3>
               <div className="quick-actions">


### PR DESCRIPTION
Closes #5

## Changes
- Added isValidContractId() helper - checks that ID starts with C and is exactly 56 characters
- Contract ID input shows a red inline error message when the value is malformed
- Quick Actions sidebar is hidden until the contract ID is valid (replaces the previous contractId truthy check with contractIdValid)
- Error clears automatically when a valid ID is entered
- Added .contract-input--error and .contract-input-error CSS classes for the error state

## Testing
1. Type a partial ID ? error message appears, Quick Actions hidden
2. Paste a valid 56-char ID starting with C ? error clears, Quick Actions appear
3. Clear the input ? no error shown, Quick Actions hidden