### PR TITLE
fix: handle missing Freighter wallet with user-friendly message

### DIFF
--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -18,12 +18,15 @@ declare global {
 export default function WalletConnect({ onConnect }: Props) {
   const [address, setAddress] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [freighterMissing, setFreighterMissing] = useState(false);
 
   async function connect() {
     setError("");
+    setFreighterMissing(false);
 
+    // Check at call-time, not render-time, so the extension has time to inject
     if (!window.freighter) {
-      setError("Freighter not found. Install it at freighter.app");
+      setFreighterMissing(true);
       return;
     }
 
@@ -38,22 +41,10 @@ export default function WalletConnect({ onConnect }: Props) {
 
   function disconnect() {
     setAddress(null);
+    setFreighterMissing(false);
+    setError("");
     onConnect(null);
     localStorage.removeItem("lastWalletAddress");
-  }
-
-  if (!window.freighter) {
-    return (
-      <div className="card">
-        <div className="wallet-row">
-          <span className="badge">Wallet</span>
-          <a href="https://freighter.app" target="_blank" rel="noreferrer">
-            Install Freighter
-          </a>
-        </div>
-        {error && <div className="status error">{error}</div>}
-      </div>
-    );
   }
 
   return (
@@ -75,6 +66,21 @@ export default function WalletConnect({ onConnect }: Props) {
           </button>
         )}
       </div>
+
+      {freighterMissing && (
+        <div className="status error">
+          Freighter wallet not found. Install it at{" "}
+          <a
+            href="https://freighter.app"
+            target="_blank"
+            rel="noreferrer"
+            className="freighter-link"
+          >
+            freighter.app
+          </a>
+        </div>
+      )}
+
       {error && <div className="status error">{error}</div>}
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -139,6 +139,13 @@ button:disabled {
   background: #450a0a;
   color: #fca5a5;
 }
+.status.error .freighter-link {
+  color: #fca5a5;
+  text-decoration: underline;
+}
+.status.error .freighter-link:hover {
+  color: #fff;
+}
 .status.info {
   background: #1e3a5f;
   color: #93c5fd;


### PR DESCRIPTION
Closes #3

## Changes
- Moved Freighter detection from render-time to call-time inside connect() so the extension has time to inject before the check runs
- Added reighterMissing state - shows inline message below the connect button when Freighter is absent
- Message reads: *"Freighter wallet not found. Install it at [freighter.app](https://freighter.app)"*
- No unhandled errors thrown when Freighter is absent
- Message only appears after a failed connect attempt, not on initial load
- Added .freighter-link CSS so the link is legible inside the red error div

## Testing
1. With Freighter **not installed** ? click Connect ? inline message appears with link
2. With Freighter **installed** ? click Connect ? normal auth flow, no message
3. Clear the error by disconnecting or successfully connecting