### PR TITLE
fix: normalize royalty stats types and add stats endpoint caching

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -390,30 +390,47 @@ export function getSecondaryRoyaltyDistributions(contractId, limit = 50, offset 
 
 /**
  * Get royalty statistics for a contract.
+ * Always returns consistent types — numeric fields use toFixed(7) strings,
+ * counts are integers, and null is never returned for aggregates.
  */
 export function getRoyaltyStatistics(contractId) {
   const totalSalesStmt = db.prepare(`
-    SELECT COUNT(*) as count, SUM(CAST(royaltyAmount as REAL)) as totalRoyalties
+    SELECT
+      COUNT(*) as count,
+      COALESCE(SUM(CAST(royaltyAmount as REAL)), 0) as totalRoyalties,
+      COALESCE(SUM(CAST(salePrice as REAL)), 0) as totalVolume
     FROM secondary_sales
     WHERE contractId = ?
   `);
-
   const totalSales = totalSalesStmt.get(contractId);
 
-  const lastDistributionStmt = db.prepare(`
-    SELECT timestamp, totalRoyaltiesDistributed, numberOfSales
-    FROM secondary_royalty_distributions
+  const pendingPoolStmt = db.prepare(`
+    SELECT COALESCE(SUM(CAST(royaltyAmount as REAL)), 0) as pendingPool
+    FROM secondary_sales
     WHERE contractId = ?
-    ORDER BY timestamp DESC
+      AND timestamp > COALESCE(
+        (SELECT MAX(timestamp) FROM secondary_royalty_distributions WHERE contractId = ?),
+        '1970-01-01'
+      )
+  `);
+  const pendingPool = pendingPoolStmt.get(contractId, contractId);
+
+  const lastDistributionStmt = db.prepare(`
+    SELECT srd.timestamp, srd.totalRoyaltiesDistributed, srd.numberOfSales, t.txHash
+    FROM secondary_royalty_distributions srd
+    LEFT JOIN transactions t ON srd.transactionId = t.id
+    WHERE srd.contractId = ?
+    ORDER BY srd.timestamp DESC
     LIMIT 1
   `);
-
   const lastDistribution = lastDistributionStmt.get(contractId);
 
   return {
-    totalSecondarySales: totalSales?.count || 0,
-    totalRoyaltiesGenerated: totalSales?.totalRoyalties || 0,
-    lastDistribution: lastDistribution || null
+    totalSecondarySales: totalSales.count,
+    totalRoyaltiesGenerated: totalSales.totalRoyalties.toFixed(7),
+    totalVolume: totalSales.totalVolume.toFixed(7),
+    pendingRoyaltyPool: pendingPool.pendingPool.toFixed(7),
+    lastDistribution: lastDistribution || null,
   };
 }
 

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -222,8 +222,11 @@ secondaryRoyaltyRouter.post("/distribute", async (req, res, next) => {
 
 /**
  * GET /api/secondary-royalty/stats/:contractId
- * Returns royalty statistics for a contract
+ * Returns royalty statistics for a contract.
+ * Results are cached in-memory for 60 seconds to avoid hammering the DB.
  */
+const statsCache = new Map(); // key: contractId, value: { data, expiresAt }
+
 secondaryRoyaltyRouter.get("/stats/:contractId", (req, res, next) => {
   try {
     const { contractId } = req.params;
@@ -232,7 +235,13 @@ secondaryRoyaltyRouter.get("/stats/:contractId", (req, res, next) => {
       return res.status(400).json({ error: "Contract ID is required." });
     }
 
+    const cached = statsCache.get(contractId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return res.json(cached.data);
+    }
+
     const stats = getRoyaltyStatistics(contractId);
+    statsCache.set(contractId, { data: stats, expiresAt: Date.now() + 60_000 });
 
     res.json(stats);
   } catch (err) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,11 +66,14 @@ export interface SecondarySale {
 
 export interface RoyaltyStats {
   totalSecondarySales: number;
-  totalRoyaltiesGenerated: number | string;
+  totalRoyaltiesGenerated: string; // always 7 decimal places, never null
+  totalVolume: string;             // always 7 decimal places, never null
+  pendingRoyaltyPool: string;      // undistributed royalties, 7 decimal places
   lastDistribution: {
     timestamp: string;
     totalRoyaltiesDistributed: string;
     numberOfSales: number;
+    txHash: string | null;
   } | null;
 }
 


### PR DESCRIPTION
Closes #19

## Changes

### ackend/src/database.js - getRoyaltyStatistics
- Replaced bare SUM() with COALESCE(SUM(...), 0) so aggregates never return 
ull on empty tables
- Added 	otalVolume field (sum of salePrice)
- Added pendingRoyaltyPool - royalties accumulated since the last distribution (subquery on secondary_royalty_distributions)
- All numeric fields returned as .toFixed(7) strings for consistent rendering
- lastDistribution now includes 	xHash via a LEFT JOIN on 	ransactions

### ackend/src/routes/secondary-royalty.js - stats endpoint
- Added statsCache Map with 60-second TTL
- Cache hit returns immediately; cache miss queries DB and stores result
- Cache is keyed by contractId

### rontend/src/api.ts - RoyaltyStats interface
- 	otalRoyaltiesGenerated: 
umber | string ? string
- Added 	otalVolume: string
- Added pendingRoyaltyPool: string
- lastDistribution now includes 	xHash: string | null

## Testing
1. Fresh contract with zero sales ? all fields return "0.0000000", no nulls
2. After recording sales ? fields reflect correct totals
3. Two rapid requests to /stats/:contractId ? second is served from cache