### PR TITLE
fix: validate contractId and pagination params in history routes

### DIFF
--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -7,6 +7,7 @@ import {
   addAuditLog,
   updateTransactionStatus
 } from '../database.js';
+import { validateContractId, parsePagination } from '../validation.js';
 
 const router = express.Router();
 
@@ -18,8 +19,11 @@ const router = express.Router();
 router.get('/history/:contractId', (req, res) => {
   try {
     const { contractId } = req.params;
-    const limit = Math.min(parseInt(req.query.limit) || 50, 100);
-    const offset = parseInt(req.query.offset) || 0;
+    if (!validateContractId(contractId, res)) return;
+
+    const pagination = parsePagination(req.query, res, 50, 100);
+    if (!pagination) return;
+    const { limit, offset } = pagination;
 
     const history = getTransactionHistory(contractId, limit, offset);
     const total = getTransactionCount(contractId);
@@ -31,10 +35,7 @@ router.get('/history/:contractId', (req, res) => {
     });
   } catch (error) {
     console.error('Error fetching transaction history:', error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    res.status(500).json({ success: false, error: error.message });
   }
 });
 
@@ -107,8 +108,11 @@ router.post('/transaction/confirm/:txHash', (req, res) => {
 router.get('/audit/:contractId', (req, res) => {
   try {
     const { contractId } = req.params;
-    const limit = Math.min(parseInt(req.query.limit) || 100, 200);
-    const offset = parseInt(req.query.offset) || 0;
+    if (!validateContractId(contractId, res)) return;
+
+    const pagination = parsePagination(req.query, res, 100, 200);
+    if (!pagination) return;
+    const { limit, offset } = pagination;
 
     const auditLog = getAuditLog(contractId, limit, offset);
 
@@ -119,10 +123,7 @@ router.get('/audit/:contractId', (req, res) => {
     });
   } catch (error) {
     console.error('Error fetching audit log:', error);
-    res.status(500).json({
-      success: false,
-      error: error.message
-    });
+    res.status(500).json({ success: false, error: error.message });
   }
 });
 

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -16,7 +16,7 @@ import {
   updateTransactionHash,
   addAuditLog,
 } from "../database.js";
-import { validate, recordSecondarySaleSchema, setRoyaltyRateSchema } from "../validation.js";
+import { validate, recordSecondarySaleSchema, setRoyaltyRateSchema, validateContractId, parsePagination } from "../validation.js";
 
 export const secondaryRoyaltyRouter = Router();
 
@@ -248,13 +248,14 @@ secondaryRoyaltyRouter.get("/stats/:contractId", (req, res, next) => {
 secondaryRoyaltyRouter.get("/sales/:contractId", (req, res, next) => {
   try {
     const { contractId } = req.params;
-    const { limit = 50, offset = 0, nftId } = req.query;
+    if (!validateContractId(contractId, res)) return;
 
-    if (!contractId) {
-      return res.status(400).json({ error: "Contract ID is required." });
-    }
+    const pagination = parsePagination(req.query, res, 50, 100);
+    if (!pagination) return;
+    const { limit, offset } = pagination;
 
-    const sales = getSecondarySales(contractId, parseInt(limit), parseInt(offset), nftId);
+    const { nftId } = req.query;
+    const sales = getSecondarySales(contractId, limit, offset, nftId);
 
     res.json({ sales, total: sales.length });
   } catch (err) {

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -64,3 +64,37 @@ export function validate(schema) {
     next();
   };
 }
+
+/**
+ * Validate a Stellar contract ID path param.
+ * Returns true if valid, otherwise sends a 400 and returns false.
+ */
+export function validateContractId(contractId, res) {
+  if (!/^C[A-Z2-7]{55}$/.test(contractId)) {
+    res.status(400).json({ success: false, error: "Invalid contract ID format" });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Parse and validate limit/offset query params.
+ * Returns { limit, offset } on success, or sends a 400 and returns null.
+ * @param {object} query - req.query
+ * @param {object} res   - express response
+ * @param {number} defaultLimit
+ * @param {number} maxLimit
+ */
+export function parsePagination(query, res, defaultLimit = 50, maxLimit = 100) {
+  if (query.limit !== undefined && isNaN(parseInt(query.limit))) {
+    res.status(400).json({ success: false, error: "limit must be a number" });
+    return null;
+  }
+  if (query.offset !== undefined && isNaN(parseInt(query.offset))) {
+    res.status(400).json({ success: false, error: "offset must be a number" });
+    return null;
+  }
+  const limit = Math.min(Math.max(parseInt(query.limit) || defaultLimit, 1), maxLimit);
+  const offset = Math.max(parseInt(query.offset) || 0, 0);
+  return { limit, offset };
+}


### PR DESCRIPTION
## Changes

### ackend/src/validation.js
- Added alidateContractId(contractId, res) - tests /^C[A-Z2-7]{55}$/, sends 400 and returns alse if invalid
- Added parsePagination(query, res, defaultLimit, maxLimit) - rejects non-numeric limit/offset with 400, clamps offset >= 0, clamps limit between 1 and maxLimit

this pr Closes #38 

### ackend/src/routes/history.js
- GET /api/history/:contractId - validates contractId + pagination
- GET /api/audit/:contractId - validates contractId + pagination

### ackend/src/routes/secondary-royalty.js
- GET /api/secondary-royalty/sales/:contractId - validates contractId + pagination

## Behaviour
| Input | Before | After |
|---|---|---|
| contractId = ../../etc/passwd | silently passed to DB | 400 Invalid contract ID format |
| limit=abc | NaN passed to SQLite (silent) | 400 limit must be a number |
| offset=-5 | -5 passed to SQLite (silent 0) | clamped to � |
| offset=abc | NaN passed to SQLite (silent) | 400 offset must be a number |