### PR TITLE
fix: analytics import and persist frontend settings

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -13,6 +13,26 @@ import {
 } from "recharts";
 import { api } from "../api";
 import "./Dashboard.css";
+import { useSettings } from "../context/SettingsContext";
+
+function formatAmount(value: number, currency: string) {
+  if (currency === "XLM") {
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }) + " XLM";
+  }
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency as any,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  } catch (e) {
+    return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ` ${currency}`;
+  }
+}
 
 interface DashboardStats {
   totalDistributed: number;
@@ -32,6 +52,7 @@ interface DashboardProps {
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
+  const { settings } = useSettings();
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -121,16 +142,12 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
         <>
           {/* KPI Cards */}
           <div className="kpi-cards">
-            <div className="kpi-card kpi-distributed">
-              <div className="kpi-label">Total Distributed</div>
-              <div className="kpi-value">
-                {stats.totalDistributed.toLocaleString("en-US", {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}
+              <div className="kpi-card kpi-distributed">
+                <div className="kpi-label">Total Distributed</div>
+                <div className="kpi-value">
+                  {formatAmount(stats.totalDistributed, settings.displayCurrency)}
+                </div>
               </div>
-              <div className="kpi-unit">XLM</div>
-            </div>
 
             <div className="kpi-card kpi-transactions">
               <div className="kpi-label">Total Transactions</div>
@@ -141,10 +158,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
             <div className="kpi-card kpi-average">
               <div className="kpi-label">Average Payout</div>
               <div className="kpi-value">
-                {stats.averagePayout.toLocaleString("en-US", {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}
+                {formatAmount(stats.averagePayout, settings.displayCurrency)}
               </div>
               <div className="kpi-unit">per transaction</div>
             </div>
@@ -178,7 +192,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
                       type="monotone"
                       dataKey="amount"
                       stroke="#667eea"
-                      name="Total Amount (XLM)"
+                      name={`Total Amount (${settings.displayCurrency})`}
                       strokeWidth={2}
                       dot={{ fill: "#667eea", r: 4 }}
                     />
@@ -227,10 +241,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
                       </div>
                       <div className="earner-stats">
                         <span className="earner-amount">
-                          {earner.totalEarned.toLocaleString("en-US", {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })} XLM
+                          {formatAmount(earner.totalEarned, settings.displayCurrency)}
                         </span>
                         <span className="earner-count">
                           {earner.payouts} payouts
@@ -274,10 +285,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
                           {collab.address.slice(-6)}
                         </td>
                         <td className="text-right">
-                          {collab.totalEarned.toLocaleString("en-US", {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
+                          {formatAmount(collab.totalEarned, settings.displayCurrency)}
                         </td>
                         <td className="text-right">{collab.payoutCount}</td>
                         <td className="text-right">

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { api } from "../api";
+import { useSettings } from "../context/SettingsContext";
 
 interface Props {
   contractId: string;
@@ -12,6 +13,7 @@ export default function DistributeForm({
   walletAddress,
   onSuccess,
 }: Props) {
+  const { settings } = useSettings();
   const [tokenId, setTokenId] = useState("");
   const [amount, setAmount] = useState("");
   const [status, setStatus] = useState<{
@@ -25,6 +27,11 @@ export default function DistributeForm({
       return setStatus({ type: "error", msg: "Enter a contract ID first." });
     if (!tokenId || !amount)
       return setStatus({ type: "error", msg: "Fill in token and amount." });
+
+    const numeric = parseFloat(amount);
+    if (numeric < settings.minPayoutAmount) {
+      return setStatus({ type: "error", msg: `Amount is below minimum payout (${settings.minPayoutAmount}).` });
+    }
 
     setLoading(true);
     setStatus({ type: "info", msg: "Building transaction…" });

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useTheme } from "../context/ThemeContext";
+import { useSettings } from "../context/SettingsContext";
 import "./Settings.css";
 
 interface SettingsProps {
@@ -8,26 +9,19 @@ interface SettingsProps {
 
 export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
   const { isDark, toggleTheme } = useTheme();
-  const [settings, setSettings] = useState({
-    autoSaveAuditLog: true,
-    notifyOnDistribution: true,
-    displayCurrency: "XLM",
-    maxPayoutsPerTransaction: 10,
-    minPayoutAmount: 0.1,
-    enableEmailNotifications: false,
-    emailAddress: "",
-  });
+  const { settings, updateSettings } = useSettings();
+  const [localSettings, setLocalSettings] = useState(() => ({ ...settings }));
 
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
 
-  const handleToggle = (key: keyof typeof settings) => {
-    const newValue = !settings[key];
-    setSettings({ ...settings, [key]: newValue });
+  const handleToggle = (key: keyof typeof localSettings) => {
+    const newValue = !localSettings[key];
+    setLocalSettings({ ...localSettings, [key]: newValue });
     showSaveStatus("Saving...");
   };
 
-  const handleChange = (key: keyof typeof settings, value: string | number) => {
-    setSettings({ ...settings, [key]: value });
+  const handleChange = (key: keyof typeof localSettings, value: string | number) => {
+    setLocalSettings({ ...localSettings, [key]: value });
   };
 
   const handleDarkMode = () => {
@@ -36,8 +30,8 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
   };
 
   const handleSave = () => {
-    // Save to localStorage for persistence
-    localStorage.setItem("royaltySplitterSettings", JSON.stringify(settings));
+    // Persist via SettingsContext (saves to localStorage)
+    updateSettings(localSettings);
     showSaveStatus("✓ Settings saved successfully!");
   };
 
@@ -49,11 +43,9 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
         displayCurrency: "XLM",
         maxPayoutsPerTransaction: 10,
         minPayoutAmount: 0.1,
-        enableEmailNotifications: false,
-        emailAddress: "",
       };
-      setSettings(defaults);
-      localStorage.removeItem("royaltySplitterSettings");
+      setLocalSettings(defaults);
+      updateSettings(defaults);
       showSaveStatus("✓ Settings reset to defaults!");
     }
   };
@@ -88,7 +80,7 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
             </div>
             <select
               id="currency"
-              value={settings.displayCurrency}
+              value={localSettings.displayCurrency}
               onChange={(e) => handleChange("displayCurrency", e.target.value)}
               className="setting-select"
             >
@@ -131,7 +123,7 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
               type="number"
               min="1"
               max="100"
-              value={settings.maxPayoutsPerTransaction}
+              value={localSettings.maxPayoutsPerTransaction}
               onChange={(e) =>
                 handleChange(
                   "maxPayoutsPerTransaction",
@@ -154,7 +146,7 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
               type="number"
               min="0.1"
               step="0.1"
-              value={settings.minPayoutAmount}
+              value={localSettings.minPayoutAmount}
               onChange={(e) =>
                 handleChange("minPayoutAmount", parseFloat(e.target.value))
               }
@@ -171,12 +163,12 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
             </div>
             <button
               className={`toggle-btn ${
-                settings.autoSaveAuditLog ? "active" : ""
+                localSettings.autoSaveAuditLog ? "active" : ""
               }`}
               onClick={() => handleToggle("autoSaveAuditLog")}
               id="autoSave"
             >
-              {settings.autoSaveAuditLog ? "ON" : "OFF"}
+              {localSettings.autoSaveAuditLog ? "ON" : "OFF"}
             </button>
           </div>
         </section>
@@ -185,60 +177,23 @@ export const Settings: React.FC<SettingsProps> = ({ contractId }) => {
         <section className="settings-section">
           <h2 className="section-title">Notifications</h2>
 
-          <div className="setting-item">
-            <div className="setting-label">
-              <label htmlFor="notifyDist">Notify on Distribution</label>
-              <p className="setting-description">
-                Send notification when distributions are processed
-              </p>
-            </div>
-            <button
-              className={`toggle-btn ${
-                settings.notifyOnDistribution ? "active" : ""
-              }`}
-              onClick={() => handleToggle("notifyOnDistribution")}
-              id="notifyDist"
-            >
-              {settings.notifyOnDistribution ? "ON" : "OFF"}
-            </button>
-          </div>
-
-          <div className="setting-item">
-            <div className="setting-label">
-              <label htmlFor="emailNotif">Email Notifications</label>
-              <p className="setting-description">
-                Receive email updates about your distributions
-              </p>
-            </div>
-            <button
-              className={`toggle-btn ${
-                settings.enableEmailNotifications ? "active" : ""
-              }`}
-              onClick={() => handleToggle("enableEmailNotifications")}
-              id="emailNotif"
-            >
-              {settings.enableEmailNotifications ? "ON" : "OFF"}
-            </button>
-          </div>
-
-          {settings.enableEmailNotifications && (
             <div className="setting-item">
               <div className="setting-label">
-                <label htmlFor="emailAddr">Email Address</label>
+                <label htmlFor="notifyDist">Notify on Distribution</label>
                 <p className="setting-description">
-                  Where to send notification emails
+                  Send notification when distributions are processed
                 </p>
               </div>
-              <input
-                id="emailAddr"
-                type="email"
-                value={settings.emailAddress}
-                onChange={(e) => handleChange("emailAddress", e.target.value)}
-                className="setting-input"
-                placeholder="your@email.com"
-              />
+              <button
+                className={`toggle-btn ${
+                  localSettings.notifyOnDistribution ? "active" : ""
+                }`}
+                onClick={() => handleToggle("notifyOnDistribution")}
+                id="notifyDist"
+              >
+                {localSettings.notifyOnDistribution ? "ON" : "OFF"}
+              </button>
             </div>
-          )}
         </section>
 
         {/* About Section */}

--- a/frontend/src/context/SettingsContext.tsx
+++ b/frontend/src/context/SettingsContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+interface SettingsType {
+  autoSaveAuditLog: boolean;
+  notifyOnDistribution: boolean;
+  displayCurrency: "XLM" | "USD" | "EUR";
+  maxPayoutsPerTransaction: number;
+  minPayoutAmount: number;
+}
+
+interface SettingsContextType {
+  settings: SettingsType;
+  updateSettings: (patch: Partial<SettingsType>) => void;
+}
+
+const DEFAULTS: SettingsType = {
+  autoSaveAuditLog: true,
+  notifyOnDistribution: true,
+  displayCurrency: "XLM",
+  maxPayoutsPerTransaction: 10,
+  minPayoutAmount: 0.1,
+};
+
+const SettingsContext = createContext<SettingsContextType | undefined>(
+  undefined,
+);
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [settings, setSettings] = useState<SettingsType>(() => {
+    try {
+      const raw = localStorage.getItem("royaltySplitterSettings");
+      if (raw) return { ...DEFAULTS, ...JSON.parse(raw) };
+    } catch (_) {}
+    return DEFAULTS;
+  });
+
+  useEffect(() => {
+    // Persist settings whenever they change
+    try {
+      localStorage.setItem("royaltySplitterSettings", JSON.stringify(settings));
+    } catch (_) {}
+  }, [settings]);
+
+  const updateSettings = (patch: Partial<SettingsType>) =>
+    setSettings((s) => ({ ...s, ...patch }));
+
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error("useSettings must be used within SettingsProvider");
+  return ctx;
+};
+
+export default SettingsProvider;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ThemeProvider } from "./context/ThemeContext";
+import { SettingsProvider } from "./context/SettingsContext";
 import "./modern-styles.css";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider>
-      <App />
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
     </ThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
This PR fixes a runtime import error in the analytics route by replacing the nonexistent getDatabase factory with the default db instance and inlining the analytics SQL, restoring the /api/analytics/:contractId endpoint to a working state. On the frontend, a SettingsContext was added to persist royaltySplitterSettings across page refreshes, with the display currency wired into Dashboard amount formatting, the minPayoutAmount enforced as a submission guard in DistributeForm, and the dead email notification UI removed.
Closed #53 