### PR TITLE
fix: validate royalty rate range in set-rate route

### DIFF
--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -136,7 +136,7 @@ secondaryRoyaltyRouter.post("/set-rate", validate(setRoyaltyRateSchema), async (
       return res.status(400).json({ error: "Missing required fields." });
     }
 
-    if (royaltyRate < 0 || royaltyRate > 10000) {
+    if (!Number.isInteger(royaltyRate) || royaltyRate < 0 || royaltyRate > 10000) {
       return res
         .status(400)
         .json({ error: "Royalty rate must be between 0 and 10000 basis points." });


### PR DESCRIPTION
                 
  PR 3 — `fix/royalty-rate-validation` → `main`                                                                       
                                                                                                                      
  fix: validate royalty rate range in set-rate route                                                                  
                                                                                                                      
  Closes #6                                                                                         
                                                                                                                      
  ## Problem                                                                                                          
  POST /api/secondary-royalty/set-rate only checked the numeric range of                                              
  `royaltyRate`. Non-integer floats (e.g. 99.5) passed the range check                                                
  and caused the smart contract to panic on-chain.                                                                    
                                                                                                                      
  ## Changes                                                                                                          
  - Added `Number.isInteger()` guard alongside the existing range check                                               
  - Any value that is negative, above 10 000, or non-integer →                                                        
    400 "Royalty rate must be between 0 and 10000 basis points."                                                      
                                                                                                                      
  ## Testing                                                                                                          
  - royaltyRate = -1 → 400                                                                                            
  - royaltyRate = 10001 → 400                                                                                         
  - royaltyRate = 99.5 → 400                                                                                          
  - royaltyRate = 500 → passes through unchanged                                                                      
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
