### PR TITLE
fix: decode collaborator addresses to Stellar G... format

### DIFF
--- a/backend/src/routes/collaborators.js
+++ b/backend/src/routes/collaborators.js
@@ -1,11 +1,11 @@
 import { Router } from "express";
 import {
+  Address,
   Contract,
   SorobanRpc,
   TransactionBuilder,
   BASE_FEE,
   Account,
-  xdr,
 } from "@stellar/stellar-sdk";
 import { server, networkPassphrase, addressToScVal } from "../stellar.js";
 
@@ -46,7 +46,7 @@ collaboratorsRouter.get("/:contractId", async (req, res, next) => {
 
     const addresses =
       resultVal.vec()?.map((scv) => {
-        return scv.address().accountId().ed25519().toString("hex");
+        return Address.fromScVal(scv).toString();
       }) ?? [];
 
     // Fetch share for each address


### PR DESCRIPTION
## Problem
`GET /api/collaborators/:contractId` was returning raw hex strings instead of valid Stellar public keys. The frontend `CollaboratorTable` received unusable values and rendered broken addresses.

## Changes
- Replaced `xdr` import with `Address` from `@stellar/stellar-sdk`
- Replaced `.address().accountId().ed25519().toString("hex")` with `Address.fromScVal(scv).toString()`

## Definition of Done
- [x] `GET /api/collaborators/:contractId` returns addresses in `G...` format
- [x] No raw hex strings returned
- [x] Collaborator table displays addresses correctly
closes #8