### PR TITLE
fix: pagination total, distributed flag, address decoding, distribution_payouts contractId

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -62,6 +62,7 @@ export function initializeDatabase() {
     CREATE TABLE IF NOT EXISTS distribution_payouts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       transactionId INTEGER NOT NULL,
+      contractId TEXT NOT NULL DEFAULT '',
       collaboratorAddress TEXT NOT NULL,
       amountReceived TEXT NOT NULL,
       FOREIGN KEY(transactionId) REFERENCES transactions(id) ON DELETE CASCADE
@@ -77,6 +78,7 @@ export function initializeDatabase() {
       saleToken TEXT NOT NULL,
       royaltyAmount TEXT NOT NULL,
       royaltyRate INTEGER NOT NULL,
+      distributed INTEGER NOT NULL DEFAULT 0,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
       transactionHash TEXT
     );
@@ -111,6 +113,15 @@ export function initializeDatabase() {
     CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_secondary_sales_dedup ON secondary_sales(contractId, nftId, previousOwner, newOwner, salePrice, saleToken);
   `);
+
+  // Migration guards for existing databases
+  try {
+    db.exec(`ALTER TABLE secondary_sales ADD COLUMN distributed INTEGER NOT NULL DEFAULT 0`);
+  } catch (_) { /* column already exists */ }
+
+  try {
+    db.exec(`ALTER TABLE distribution_payouts ADD COLUMN contractId TEXT NOT NULL DEFAULT ''`);
+  } catch (_) { /* column already exists */ }
 }
 
 // Transaction tracking functions
@@ -160,16 +171,17 @@ export function updateTransactionStatus(
 
 export function addDistributionPayout(
   transactionId,
+  contractId,
   collaboratorAddress,
   amountReceived,
 ) {
   const stmt = db.prepare(`
     INSERT INTO distribution_payouts 
-    (transactionId, collaboratorAddress, amountReceived)
-    VALUES (?, ?, ?)
+    (transactionId, contractId, collaboratorAddress, amountReceived)
+    VALUES (?, ?, ?, ?)
   `);
 
-  stmt.run(transactionId, collaboratorAddress, amountReceived);
+  stmt.run(transactionId, contractId, collaboratorAddress, amountReceived);
 }
 
 export function getTransactionCount(contractId) {
@@ -310,8 +322,9 @@ export function recordSecondarySale(
 
 /**
  * Get all secondary sales for a contract with optional filtering.
+ * Pass undistributedOnly=true to return only rows where distributed = 0.
  */
-export function getSecondarySales(contractId, limit = 50, offset = 0, nftId = null) {
+export function getSecondarySales(contractId, limit = 50, offset = 0, nftId = null, undistributedOnly = false) {
   let query = `
     SELECT 
       id,
@@ -322,6 +335,7 @@ export function getSecondarySales(contractId, limit = 50, offset = 0, nftId = nu
       saleToken,
       royaltyAmount,
       royaltyRate,
+      distributed,
       timestamp,
       transactionHash
     FROM secondary_sales
@@ -334,11 +348,37 @@ export function getSecondarySales(contractId, limit = 50, offset = 0, nftId = nu
     params.push(nftId);
   }
 
+  if (undistributedOnly) {
+    query += ` AND distributed = 0`;
+  }
+
   query += ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`;
   params.push(limit, offset);
 
-  const stmt = db.prepare(query);
-  return stmt.all(...params);
+  return db.prepare(query).all(...params);
+}
+
+/**
+ * Count secondary sales for a contract (ignores LIMIT/OFFSET).
+ */
+export function countSecondarySales(contractId, nftId = null) {
+  let query = `SELECT COUNT(*) as total FROM secondary_sales WHERE contractId = ?`;
+  const params = [contractId];
+
+  if (nftId) {
+    query += ` AND nftId = ?`;
+    params.push(nftId);
+  }
+
+  return db.prepare(query).get(...params).total;
+}
+
+/**
+ * Mark an array of secondary sale IDs as distributed.
+ */
+export function markSalesDistributed(ids) {
+  const placeholders = ids.map(() => "?").join(",");
+  db.prepare(`UPDATE secondary_sales SET distributed = 1 WHERE id IN (${placeholders})`).run(...ids);
 }
 
 /**

--- a/backend/src/routes/collaborators.js
+++ b/backend/src/routes/collaborators.js
@@ -5,7 +5,7 @@ import {
   TransactionBuilder,
   BASE_FEE,
   Account,
-  xdr,
+  Address,
 } from "@stellar/stellar-sdk";
 import { server, networkPassphrase, addressToScVal } from "../stellar.js";
 
@@ -45,9 +45,7 @@ collaboratorsRouter.get("/:contractId", async (req, res, next) => {
     if (!resultVal) return res.json([]);
 
     const addresses =
-      resultVal.vec()?.map((scv) => {
-        return scv.address().accountId().ed25519().toString("hex");
-      }) ?? [];
+      resultVal.vec()?.map((scv) => Address.fromScVal(scv).toString()) ?? [];
 
     // Fetch share for each address
     const results = await Promise.all(

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -11,6 +11,8 @@ import {
   recordSecondarySale,
   recordSecondaryRoyaltyDistribution,
   getSecondarySales,
+  countSecondarySales,
+  markSalesDistributed,
   getSecondaryRoyaltyDistributions,
   getRoyaltyStatistics,
   updateTransactionHash,
@@ -195,8 +197,8 @@ secondaryRoyaltyRouter.post("/distribute", async (req, res, next) => {
       return res.status(400).json({ error: "Missing required fields." });
     }
 
-    // Get pending secondary sales
-    const pendingSales = getSecondarySales(contractId);
+    // Get pending (undistributed) secondary sales
+    const pendingSales = getSecondarySales(contractId, 1000, 0, null, true);
 
     if (pendingSales.length === 0) {
       return res.status(400).json({ error: "No pending secondary royalties to distribute." });
@@ -218,6 +220,9 @@ secondaryRoyaltyRouter.post("/distribute", async (req, res, next) => {
     const txXdr = await buildTx(walletAddress, contractId, "distribute_secondary_royalties", [
       addressToScVal(tokenId),
     ]);
+
+    // Mark sales as distributed
+    markSalesDistributed(pendingSales.map((s) => s.id));
 
     addAuditLog(contractId, "secondary_distribution_initiated", walletAddress, {
       transactionId,
@@ -281,8 +286,9 @@ secondaryRoyaltyRouter.get("/sales/:contractId", (req, res, next) => {
 
     const { nftId } = req.query;
     const sales = getSecondarySales(contractId, limit, offset, nftId);
+    const total = countSecondarySales(contractId, nftId);
 
-    res.json({ sales, total: sales.length });
+    res.json({ sales, total });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
closes #83 
closes #84 
closes #85 
closes #86 


 fix: pagination total, distributed flag, address decoding, distribution_payouts contractId
  
  backend/src/routes/secondary-royalty.js
  - GET /sales/:contractId now calls countSecondarySales() for a real COUNT(*)
    and returns { sales, total: realCount } instead of sales.length, so the
    frontend can calculate pages correctly regardless of limit/offset
  - POST /distribute now calls getSecondarySales with undistributedOnly=true so
    it only counts rows where distributed = 0; calls markSalesDistributed() after
    building the XDR to prevent double-distribution on subsequent calls
  
  backend/src/database.js
  - secondary_sales: added `distributed INTEGER NOT NULL DEFAULT 0` column
  - distribution_payouts: added `contractId TEXT NOT NULL DEFAULT ''` column
  - initializeDatabase: added two ALTER TABLE migration guards (try/catch) so
    existing databases gain both columns without requiring a manual migration
  - addDistributionPayout: added contractId as second parameter and stores it
  - getSecondarySales: added undistributedOnly param (appends AND distributed = 0
    when true); selects the distributed column in results
  - countSecondarySales(contractId, nftId): new function — COUNT(*) with no
    LIMIT/OFFSET, supports optional nftId filter
  - markSalesDistributed(ids): new function — bulk UPDATE distributed = 1 for
    the given sale IDs
  
  backend/src/routes/collaborators.js
  - Replaced xdr import with Address from @stellar/stellar-sdk
  - Fixed address decoding: scv.address().accountId().ed25519().toString("hex")
    produced a raw hex string; replaced with Address.fromScVal(scv).toString()
    which returns the correct G... Stellar public key format
