### PR TITLE
fix: return 404 when confirming non-existent transaction

### DIFF
--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -80,9 +80,14 @@ router.post('/transaction/confirm/:txHash', async (req, res) => {
     const { txHash } = req.params;
     const { blockTime, errorMessage } = req.body;
 
-    // Prevent overwriting already-settled transactions
+    // Return 404 if transaction does not exist
     const existing = getTransactionDetails(txHash);
-    if (existing && existing.status !== 'pending') {
+    if (!existing) {
+      return res.status(404).json({ success: false, error: 'Transaction not found' });
+    }
+
+    // Prevent overwriting already-settled transactions
+    if (existing.status !== 'pending') {
       return res.status(409).json({
         success: false,
         error: `Transaction already ${existing.status}`


### PR DESCRIPTION
Closes #11

- Added existence check before updateTransactionStatus
- Returns 404 with error message if txHash not found
- Existing confirmed/failed transaction check preserved