### PR TITLE
fix: guard against division by zero in dashboard stats

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -249,10 +249,9 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
                       </div>
                     </div>
                     <div className="earner-percentage">
-                      {(
-                        (earner.totalEarned / stats.totalDistributed) *
-                        100
-                      ).toFixed(1)}
+                      {stats.totalDistributed > 0
+                        ? ((earner.totalEarned / stats.totalDistributed) * 100).toFixed(1)
+                        : "0.0"}
                       %
                     </div>
                   </div>
@@ -289,12 +288,12 @@ export const Dashboard: React.FC<DashboardProps> = ({ contractId }) => {
                         </td>
                         <td className="text-right">{collab.payoutCount}</td>
                         <td className="text-right">
-                          {(
-                            collab.totalEarned / collab.payoutCount
-                          ).toLocaleString("en-US", {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          })}
+                          {collab.payoutCount > 0
+                            ? (collab.totalEarned / collab.payoutCount).toLocaleString("en-US", {
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2,
+                              })
+                            : "0.00"}
                         </td>
                       </tr>
                     ))


### PR DESCRIPTION
Closes #9

- Top Earners percentage now shows 0.0% instead of NaN% when totalDistributed is 0
- Collaborator average payout now shows 0.00 instead of NaN when payoutCount is 0