### PR TITLE
fix: return 409 if contract is already initialized before building XDR

### DIFF
--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { retryBuildTx, addressToScVal, u32ToScVal, vecToScVal } from "../stellar.js";
+import { retryBuildTx, addressToScVal, u32ToScVal, vecToScVal, isContractInitialized } from "../stellar.js";
 import { recordTransaction, addAuditLog } from "../database.js";
 import { validate, initializeSchema } from "../validation.js";
 
@@ -32,6 +32,16 @@ initializeRouter.post("/", validate(initializeSchema), async (req, res, next) =>
       return res
         .status(400)
         .json({ error: "Shares must sum to 10000 basis points" });
+    }
+
+    // Check if contract is already initialized on-chain
+    const alreadyInitialized = await isContractInitialized(contractId);
+    if (alreadyInitialized) {
+      return res
+        .status(409)
+        .json({ 
+          error: "Contract is already initialized. Cannot re-initialize an existing contract." 
+        });
     }
 
     // Record transaction in database for audit trail

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -115,3 +115,36 @@ export async function getRoyaltyRateFromContract(contractId) {
   if (SorobanRpc.Api.isSimulationError(sim)) return 0;
   return sim.result?.retval?.u32() ?? 0;
 }
+
+/**
+ * Check if a contract has been initialized by simulating get_admin().
+ * Returns true if initialized, false if not.
+ */
+export async function isContractInitialized(contractId) {
+  const contract = new Contract(contractId);
+  const dummyAccount = new Account(
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    "0",
+  );
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call("get_admin"))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  // If simulation succeeds, contract is initialized
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    const errorMsg = sim.error?.toString() || '';
+    // If error contains "not initialized", contract is not initialized
+    if (errorMsg.includes('not initialized')) {
+      return false;
+    }
+    // Other errors might mean contract doesn't exist or other issues
+    return false;
+  }
+  // Successfully got admin address, so contract is initialized
+  return true;
+}

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -130,7 +130,16 @@ export default function InitializeForm({
       onSuccess();
 
     } catch (e: unknown) {
-      setStatus({ type: "error", msg: e instanceof Error ? e.message : "Unknown error" });
+      // Handle 409 Conflict error specifically
+      const errorMessage = e instanceof Error ? e.message : "Unknown error";
+      if (errorMessage.includes('409') || errorMessage.includes('already initialized')) {
+        setStatus({ 
+          type: "error", 
+          msg: "⚠️ This contract is already initialized. You cannot re-initialize an existing contract." 
+        });
+      } else {
+        setStatus({ type: "error", msg: errorMessage });
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Closes #110

---

Closes #112

---

CRITICAL FIX:
- Add isContractInitialized() helper in stellar.js using get_admin() simulation
- Check initialization status BEFORE recording transaction in database
- Return 409 Conflict if contract is already initialized
- Prevents polluted audit trail with transactions that will always fail

FRONTEND:
- Enhance error handling in InitializeForm to detect 409 errors
- Display clear user-friendly message for already-initialized contracts
- Shows warning icon and explicit message about re-initialization

SECURITY:
- No DB record created for rejected initialization attempts
- Prevents duplicate initialization attacks
- Maintains clean audit trail

Issue #110