### PR TITLE
fix: contract status, balance distribute, wallet disconnect, sale validation (#101-#104)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,6 +11,7 @@ import { collaboratorsRouter } from "./routes/collaborators.js";
 import { secondaryRoyaltyRouter } from "./routes/secondary-royalty.js";
 import historyRouter from "./routes/history.js";
 import { analyticsRouter } from "./routes/analytics.js";
+import { contractRouter } from "./routes/contract.js";
 import { initializeDatabase, getMigrationVersion } from "./database.js";
 
 // Initialize database on startup
@@ -62,6 +63,7 @@ app.use("/api/collaborators", collaboratorsRouter);
 app.use("/api/secondary-royalty", secondaryRoyaltyRouter);
 app.use("/api", historyRouter);
 app.use("/api", analyticsRouter);
+app.use("/api/contract", contractRouter);
 
 // Health check
 app.get("/api/health", (_req, res) =>

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { isContractInitialized } from "../stellar.js";
+
+export const contractRouter = Router();
+
+contractRouter.get("/status/:contractId", async (req, res, next) => {
+  try {
+    const { contractId } = req.params;
+    if (!contractId || !/^C[A-Z2-7]{55}$/.test(contractId)) {
+      return res.status(400).json({ error: "Invalid contract ID" });
+    }
+    const initialized = await isContractInitialized(contractId);
+    res.json({ initialized });
+  } catch (err) {
+    next(err);
+  }
+});

--- a/backend/src/routes/distribute.js
+++ b/backend/src/routes/distribute.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { retryBuildTx, addressToScVal, i128ToScVal } from "../stellar.js";
+import { retryBuildTx, addressToScVal } from "../stellar.js";
 import { recordTransaction, addAuditLog } from "../database.js";
 import { validate, distributeSchema } from "../validation.js";
 
@@ -7,40 +7,26 @@ export const distributeRouter = Router();
 
 /**
  * POST /api/distribute
- * Body: { contractId, walletAddress, tokenId, amount }
+ * Body: { contractId, walletAddress, tokenId }
  * Returns: { xdr, transactionId } — unsigned transaction XDR + tracking ID
  */
 distributeRouter.post("/", validate(distributeSchema), async (req, res, next) => {
   try {
-    const { contractId, walletAddress, tokenId, amount } = req.body;
+    const { contractId, walletAddress, tokenId } = req.body;
 
-    if (!contractId || !walletAddress) {
-      return res.status(400).json({ error: "Missing required fields." });
-    }
-    if (!tokenId) {
-      return res.status(400).json({ error: "Token ID is required" });
-    }
-    if (typeof amount !== "number" || amount <= 0) {
-      return res.status(400).json({ error: "Amount must be a positive number" });
-    }
-
-    // Record transaction in database for audit trail
     const transactionId = recordTransaction(
       contractId,
       "distribute",
       walletAddress,
-      { requestedAmount: amount.toString(), tokenId },
+      { tokenId },
     );
 
     const txXdr = await retryBuildTx(walletAddress, contractId, "distribute", [
       addressToScVal(tokenId),
-      i128ToScVal(amount),
     ]);
 
-    // Log the distribution request
     addAuditLog(contractId, "distribution_initiated", walletAddress, {
       transactionId,
-      amount: amount.toString(),
       tokenId,
     });
 

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -117,7 +117,7 @@ export async function getRoyaltyRateFromContract(contractId) {
 }
 
 /**
- * Check if a contract has been initialized by simulating get_admin().
+ * Check if a contract has been initialized by simulating is_initialized().
  * Returns true if initialized, false if not.
  */
 export async function isContractInitialized(contractId) {
@@ -130,21 +130,11 @@ export async function isContractInitialized(contractId) {
     fee: BASE_FEE,
     networkPassphrase,
   })
-    .addOperation(contract.call("get_admin"))
+    .addOperation(contract.call("is_initialized"))
     .setTimeout(30)
     .build();
 
   const sim = await server.simulateTransaction(tx);
-  // If simulation succeeds, contract is initialized
-  if (SorobanRpc.Api.isSimulationError(sim)) {
-    const errorMsg = sim.error?.toString() || '';
-    // If error contains "not initialized", contract is not initialized
-    if (errorMsg.includes('not initialized')) {
-      return false;
-    }
-    // Other errors might mean contract doesn't exist or other issues
-    return false;
-  }
-  // Successfully got admin address, so contract is initialized
-  return true;
+  if (SorobanRpc.Api.isSimulationError(sim)) return false;
+  return sim.result?.retval?.bool() ?? false;
 }

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -28,7 +28,6 @@ export const distributeSchema = z.object({
   contractId: contractAddress,
   walletAddress: stellarAddress,
   tokenId: contractAddress,
-  amount: z.number().int().positive(),
 });
 
 export const setRoyaltyRateSchema = z.object({

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -90,6 +90,19 @@
   color: #e53e3e;
 }
 
+.contract-status {
+  margin: 4px 0 0 0;
+  font-size: 0.78rem;
+}
+
+.contract-status--ok {
+  color: #38a169;
+}
+
+.contract-status--warn {
+  color: #d69e2e;
+}
+
 .quick-actions {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
     () => localStorage.getItem("lastContractId") ?? ""
   );
   const [contractIdError, setContractIdError] = useState<string | null>(null);
+  const [contractInitialized, setContractInitialized] = useState<boolean | null>(null);
   const [royaltyRate, setRoyaltyRate] = useState(500); // Default 5%
   const [currentPage, setCurrentPage] = useState("dashboard");
 
@@ -70,6 +71,17 @@ export default function App() {
       }
     }
     fetchRate();
+  }, [contractId, contractIdValid]);
+
+  // Fetch contract initialized status when contractId changes (#101)
+  useEffect(() => {
+    if (!contractIdValid) {
+      setContractInitialized(null);
+      return;
+    }
+    api.getContractStatus(contractId)
+      .then(({ initialized }) => setContractInitialized(initialized))
+      .catch(() => setContractInitialized(null));
   }, [contractId, contractIdValid]);
 
   function handleContractChange(value: string) {
@@ -200,7 +212,10 @@ export default function App() {
         <div className="app-sidebar">
           <div className="sidebar-card">
             <h3>🔗 Wallet Connection</h3>
-            <WalletConnect onConnect={setWalletAddress} />
+            <WalletConnect
+              onConnect={setWalletAddress}
+              onDisconnect={() => setWalletAddress(null)}
+            />
           </div>
 
           <div className="sidebar-card">
@@ -213,6 +228,11 @@ export default function App() {
             />
             {contractIdError && (
               <p className="contract-input-error">{contractIdError}</p>
+            )}
+            {contractIdValid && contractInitialized !== null && (
+              <p className={`contract-status ${contractInitialized ? "contract-status--ok" : "contract-status--warn"}`}>
+                {contractInitialized ? "✅ Initialized" : "⚠️ Not initialized"}
+              </p>
             )}
           </div>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -89,13 +89,15 @@ export const api = {
     contractId: string;
     walletAddress: string;
     tokenId: string;
-    amount: number;
   }) => post<{ xdr: string; transactionId: number }>("/distribute", body),
 
   getCollaborators: (contractId: string) =>
     get<{ address: string; basisPoints: number }[]>(
       `/collaborators/${contractId}`,
     ),
+
+  getContractStatus: (contractId: string) =>
+    get<{ initialized: boolean }>(`/contract/status/${contractId}`),
 
   // Transaction History & Audit Log APIs
   getTransactionHistory: (contractId: string, limit = 50, offset = 0) =>

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { api } from "../api";
-import { useSettings } from "../context/SettingsContext";
 import { signAndSubmitTransaction } from "../stellar";
 
 
@@ -15,9 +14,7 @@ export default function DistributeForm({
   walletAddress,
   onSuccess,
 }: Props) {
-  const { settings } = useSettings();
   const [tokenId, setTokenId] = useState("");
-  const [amount, setAmount] = useState("");
   const [status, setStatus] = useState<{
     type: "ok" | "error" | "info";
     msg: string;
@@ -27,24 +24,14 @@ export default function DistributeForm({
   async function submit() {
     if (!contractId)
       return setStatus({ type: "error", msg: "Enter a contract ID first." });
-    if (!tokenId || !amount)
-      return setStatus({ type: "error", msg: "Fill in token and amount." });
-
-    const numeric = parseFloat(amount);
-    if (numeric < settings.minPayoutAmount) {
-      return setStatus({ type: "error", msg: `Amount is below minimum payout (${settings.minPayoutAmount}).` });
-    }
+    if (!tokenId)
+      return setStatus({ type: "error", msg: "Enter a token address." });
 
     setLoading(true);
     setStatus({ type: "info", msg: "Building transaction…" });
 
     try {
-      const res = await api.distribute({
-        contractId,
-        walletAddress,
-        tokenId,
-        amount: parseInt(amount),
-      });
+      const res = await api.distribute({ contractId, walletAddress, tokenId });
 
       setStatus({ type: "info", msg: "Signing transaction with Freighter..." });
       const hash = await signAndSubmitTransaction(res.xdr);
@@ -57,9 +44,8 @@ export default function DistributeForm({
 
       setStatus({ type: "ok", msg: `Distributed. Tx: ${hash}` });
       onSuccess();
-
-    } catch (e: any) {
-      setStatus({ type: "error", msg: e.message });
+    } catch (e: unknown) {
+      setStatus({ type: "error", msg: e instanceof Error ? e.message : "Unknown error" });
     } finally {
       setLoading(false);
     }
@@ -74,13 +60,7 @@ export default function DistributeForm({
         value={tokenId}
         onChange={(e) => setTokenId(e.target.value)}
       />
-      <label>Amount (stroops)</label>
-      <input
-        placeholder="e.g. 10000000"
-        type="number"
-        value={amount}
-        onChange={(e) => setAmount(e.target.value)}
-      />
+      <p className="description">Distributes the full contract balance to all collaborators.</p>
       <button className="btn-primary" onClick={submit} disabled={loading}>
         {loading ? "Submitting…" : "Distribute funds"}
       </button>

--- a/frontend/src/components/RecordSecondarySale.tsx
+++ b/frontend/src/components/RecordSecondarySale.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { api } from "../api";
 import { signAndSubmitTransaction } from "../stellar";
 
+const G_ADDR = /^G[A-Z2-7]{55}$/;
+const C_ADDR = /^C[A-Z2-7]{55}$/;
 
 interface Props {
   contractId: string;
@@ -24,19 +26,18 @@ export default function RecordSecondarySale({
     saleToken: "",
   });
 
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [status, setStatus] = useState<{
     type: "ok" | "error" | "info";
     msg: string;
   } | null>(null);
   const [loading, setLoading] = useState(false);
-  const [calculatedRoyalty, setCalculatedRoyalty] = useState<number | null>(null);
+  const [calculatedRoyalty, setCalculatedRoyalty] = useState<bigint | null>(null);
 
-  // Update calculated royalty if royaltyRate or salePrice changes
   useEffect(() => {
-    const price = parseInt(formData.salePrice);
-    if (!isNaN(price) && price > 0) {
-      const royalty = Math.floor((price * royaltyRate) / 10000);
-      setCalculatedRoyalty(royalty);
+    const price = BigInt(parseInt(formData.salePrice) || 0);
+    if (price > 0n) {
+      setCalculatedRoyalty((price * BigInt(royaltyRate)) / 10000n);
     } else {
       setCalculatedRoyalty(null);
     }
@@ -44,20 +45,35 @@ export default function RecordSecondarySale({
 
   function updateField(field: string, value: string) {
     setFormData((prev) => ({ ...prev, [field]: value }));
+    // Clear error on change
+    if (fieldErrors[field]) {
+      setFieldErrors((prev) => ({ ...prev, [field]: "" }));
+    }
   }
+
+  function validateField(field: string, value: string) {
+    let err = "";
+    if (field === "previousOwner" || field === "newOwner") {
+      if (value && !G_ADDR.test(value)) err = "Must be a valid Stellar G-address (56 chars)";
+    } else if (field === "saleToken") {
+      if (value && !C_ADDR.test(value)) err = "Must be a valid Stellar C-address (56 chars)";
+    }
+    setFieldErrors((prev) => ({ ...prev, [field]: err }));
+  }
+
+  const isFormValid =
+    formData.nftId.trim() !== "" &&
+    G_ADDR.test(formData.previousOwner) &&
+    G_ADDR.test(formData.newOwner) &&
+    C_ADDR.test(formData.saleToken) &&
+    parseInt(formData.salePrice) > 0;
 
   async function submit() {
     if (!contractId) {
       return setStatus({ type: "error", msg: "Enter a contract ID first." });
     }
-
-    if (!formData.nftId || !formData.previousOwner || !formData.newOwner || !formData.salePrice || !formData.saleToken) {
-      return setStatus({ type: "error", msg: "Please fill in all fields." });
-    }
-
-    const salePrice = parseInt(formData.salePrice);
-    if (isNaN(salePrice) || salePrice <= 0) {
-      return setStatus({ type: "error", msg: "Sale price must be a positive number." });
+    if (!isFormValid) {
+      return setStatus({ type: "error", msg: "Please fix all field errors before submitting." });
     }
 
     setLoading(true);
@@ -70,14 +86,12 @@ export default function RecordSecondarySale({
         nftId: formData.nftId,
         previousOwner: formData.previousOwner,
         newOwner: formData.newOwner,
-        salePrice,
+        salePrice: parseInt(formData.salePrice),
         saleToken: formData.saleToken,
         royaltyRate,
       });
 
       setStatus({ type: "info", msg: "Please sign the transaction..." });
-
-      // Sign and submit transaction
       const result = await signAndSubmitTransaction(xdr);
 
       setStatus({ type: "info", msg: "Waiting for confirmation..." });
@@ -91,14 +105,7 @@ export default function RecordSecondarySale({
         msg: `Secondary sale recorded! Royalty: ${royaltyAmount} tokens. TX: ${result}`,
       });
 
-
-      setFormData({
-        nftId: "",
-        previousOwner: "",
-        newOwner: "",
-        salePrice: "",
-        saleToken: "",
-      });
+      setFormData({ nftId: "", previousOwner: "", newOwner: "", salePrice: "", saleToken: "" });
       setCalculatedRoyalty(null);
       onSuccess();
     } catch (err) {
@@ -137,8 +144,13 @@ export default function RecordSecondarySale({
             placeholder="G..."
             value={formData.previousOwner}
             onChange={(e) => updateField("previousOwner", e.target.value)}
+            onBlur={(e) => validateField("previousOwner", e.target.value)}
             disabled={loading}
+            className={fieldErrors.previousOwner ? "input-error" : ""}
           />
+          {fieldErrors.previousOwner && (
+            <span className="field-error">{fieldErrors.previousOwner}</span>
+          )}
         </div>
 
         <div className="form-group">
@@ -148,8 +160,13 @@ export default function RecordSecondarySale({
             placeholder="G..."
             value={formData.newOwner}
             onChange={(e) => updateField("newOwner", e.target.value)}
+            onBlur={(e) => validateField("newOwner", e.target.value)}
             disabled={loading}
+            className={fieldErrors.newOwner ? "input-error" : ""}
           />
+          {fieldErrors.newOwner && (
+            <span className="field-error">{fieldErrors.newOwner}</span>
+          )}
         </div>
 
         <div className="form-group">
@@ -165,7 +182,7 @@ export default function RecordSecondarySale({
               step="1"
             />
             {calculatedRoyalty !== null && (
-              <span className="calc-result">Royalty: {calculatedRoyalty}</span>
+              <span className="calc-result">Royalty: {calculatedRoyalty.toString()}</span>
             )}
           </div>
         </div>
@@ -177,8 +194,13 @@ export default function RecordSecondarySale({
             placeholder="C..."
             value={formData.saleToken}
             onChange={(e) => updateField("saleToken", e.target.value)}
+            onBlur={(e) => validateField("saleToken", e.target.value)}
             disabled={loading}
+            className={fieldErrors.saleToken ? "input-error" : ""}
           />
+          {fieldErrors.saleToken && (
+            <span className="field-error">{fieldErrors.saleToken}</span>
+          )}
         </div>
       </div>
 
@@ -188,7 +210,7 @@ export default function RecordSecondarySale({
         </div>
       )}
 
-      <button onClick={submit} disabled={loading} className="btn-primary">
+      <button onClick={submit} disabled={loading || !isFormValid} className="btn-primary">
         {loading ? "Processing..." : "Record Sale"}
       </button>
     </div>

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface Props {
-  onConnect: (address: string | null) => void;
+  onConnect: (address: string) => void;
+  onDisconnect?: () => void;
 }
 
 // Freighter injects window.freighter at runtime — no official type package available,
@@ -11,20 +12,30 @@ declare global {
     freighter?: {
       requestAccess: () => Promise<{ address: string }>;
       getAddress: () => Promise<{ address: string }>;
+      on?: (event: string, handler: (data: { address: string }) => void) => void;
     };
   }
 }
 
-export default function WalletConnect({ onConnect }: Props) {
+export default function WalletConnect({ onConnect, onDisconnect }: Props) {
   const [address, setAddress] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [freighterMissing, setFreighterMissing] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Listen for Freighter account changes
+  useEffect(() => {
+    if (!window.freighter?.on) return;
+    window.freighter.on("accountChanged", ({ address: newAddr }) => {
+      setAddress(newAddr);
+      onConnect(newAddr);
+    });
+  }, [onConnect]);
 
   async function connect() {
     setError("");
     setFreighterMissing(false);
 
-    // Check at call-time, not render-time, so the extension has time to inject
     if (!window.freighter) {
       setFreighterMissing(true);
       return;
@@ -43,8 +54,16 @@ export default function WalletConnect({ onConnect }: Props) {
     setAddress(null);
     setFreighterMissing(false);
     setError("");
-    onConnect(null);
+    setCopied(false);
     localStorage.removeItem("lastWalletAddress");
+    onDisconnect?.();
+  }
+
+  async function copyAddress() {
+    if (!address) return;
+    await navigator.clipboard.writeText(address);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   return (
@@ -53,9 +72,14 @@ export default function WalletConnect({ onConnect }: Props) {
         <span className="badge">Wallet</span>
         {address ? (
           <>
-            <span className="wallet-addr">
+            <button
+              className="wallet-addr"
+              onClick={copyAddress}
+              title="Copy address"
+            >
               {address.slice(0, 6)}...{address.slice(-4)}
-            </span>
+              <span className="copy-hint">{copied ? " ✓" : " 📋"}</span>
+            </button>
             <button className="btn-secondary" onClick={disconnect}>
               Disconnect
             </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -191,6 +191,10 @@ td:last-child {
   margin-bottom: 0.5rem;
 }
 
+.input-error {
+  border-color: var(--error-color) !important;
+}
+
 .share-bar {
   height: 6px;
   border-radius: 3px;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,18 @@ impl RoyaltySplitter {
         env.storage().instance().set(&DataKey::ShareMap, &share_map);
     }
 
-    /// Distribute `amount` of `token` from the contract balance to all collaborators.
-    pub fn distribute(env: Env, token: Address, amount: i128) {
+    /// Returns true if the contract has been initialized.
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Admin)
+    }
+
+    /// Returns the contract's current balance of `token`.
+    pub fn get_balance(env: Env, token: Address) -> i128 {
+        token::Client::new(&env, &token).balance(&env.current_contract_address())
+    }
+
+    /// Distribute the full contract balance of `token` to all collaborators.
+    pub fn distribute(env: Env, token: Address) {
         let admin: Address = env
             .storage()
             .instance()
@@ -61,11 +71,9 @@ impl RoyaltySplitter {
         admin.require_auth();
 
         let token_client = token::Client::new(&env, &token);
-
-        // Assert full balance is available before any transfers begin.
-        let balance = token_client.balance(&env.current_contract_address());
-        if amount > balance {
-            panic!("amount exceeds contract balance");
+        let amount = token_client.balance(&env.current_contract_address());
+        if amount == 0 {
+            panic!("no balance to distribute");
         }
 
         let collaborators: Vec<Address> = env
@@ -275,7 +283,7 @@ mod tests {
 
         client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
         mint(&env, &token, &contract_id, 1000);
-        client.distribute(&token, &1000_i128);
+        client.distribute(&token);
 
         assert_eq!(TokenClient::new(&env, &token).balance(&admin), 500);
         assert_eq!(TokenClient::new(&env, &token).balance(&b), 500);
@@ -292,11 +300,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "amount exceeds contract balance")]
-    fn test_distribute_panics_when_amount_exceeds_balance() {
+    #[should_panic(expected = "no balance to distribute")]
+    fn test_distribute_panics_when_balance_is_zero() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, client) = setup(&env);
+        let (_, client) = setup(&env);
 
         let admin = Address::generate(&env);
         let b = Address::generate(&env);
@@ -304,16 +312,12 @@ mod tests {
         let token = make_token(&env, &token_admin);
 
         client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
-        mint(&env, &token, &contract_id, 500);
-        client.distribute(&token, &1000_i128);
+        // No mint — balance is zero
+        client.distribute(&token);
     }
 
-    /// Issue #92 — balance validated before loop; no partial distribution possible.
-    /// With 3 collaborators, if the contract only holds enough for the first payout,
-    /// the balance check must fire before any transfer occurs.
     #[test]
-    #[should_panic(expected = "amount exceeds contract balance")]
-    fn test_no_partial_distribution_on_insufficient_balance() {
+    fn test_distribute_uses_actual_balance() {
         let env = Env::default();
         env.mock_all_auths();
         let (contract_id, client) = setup(&env);
@@ -324,23 +328,18 @@ mod tests {
         let token_admin = Address::generate(&env);
         let token = make_token(&env, &token_admin);
 
-        // 3-way split: 50 / 30 / 20
         client.initialize(
             &vec![&env, admin.clone(), b.clone(), c.clone()],
             &vec![&env, 5000_u32, 3000_u32, 2000_u32],
         );
 
-        // Fund only 300 but request distribution of 1000.
-        // Without the pre-loop balance check, the first transfer (500) would succeed,
-        // the second (300) would succeed, and the third (200) would fail — leaving a
-        // partial state. The guard must reject the whole call upfront.
+        // Fund 300 — distribute uses actual balance, not a caller-supplied amount.
         mint(&env, &token, &contract_id, 300);
-        client.distribute(&token, &1000_i128);
+        client.distribute(&token);
 
-        // Verify no collaborator received anything (guard fired before any transfer).
-        assert_eq!(TokenClient::new(&env, &token).balance(&admin), 0);
-        assert_eq!(TokenClient::new(&env, &token).balance(&b), 0);
-        assert_eq!(TokenClient::new(&env, &token).balance(&c), 0);
+        assert_eq!(TokenClient::new(&env, &token).balance(&admin), 150);
+        assert_eq!(TokenClient::new(&env, &token).balance(&b), 90);
+        assert_eq!(TokenClient::new(&env, &token).balance(&c), 60);
     }
 
     #[test]
@@ -388,7 +387,7 @@ mod tests {
         // then drain balance via primary distribute — pool > balance.
         mint(&env, &token, &contract_id, 100);
         client.record_secondary_royalty(&token, &contract_id, &100_i128);
-        client.distribute(&token, &100_i128); // balance → 0, pool still = 100
+        client.distribute(&token); // balance → 0, pool still = 100
         client.distribute_secondary_royalties(); // should panic
     }
 }


### PR DESCRIPTION
## Summary

---

### #101 — Add `is_initialized` view and contract status endpoint

- Added `pub fn is_initialized(env: Env) -> bool` to `src/lib.rs` — checks `DataKey::Admin` presence without panicking.
- Added `GET /api/contract/status/:contractId` backend route (`backend/src/routes/contract.js`) that simulates `is_initialized` and returns `{ initialized: bool }`.
- Updated `backend/src/stellar.js` — `isContractInitialized` now calls the real `is_initialized` view instead of inferring from `get_admin` errors.
- `App.tsx` fetches contract status on contract ID change and shows ✅ Initialized / ⚠️ Not initialized next to the contract ID input.

closes #101 

### #102 — Distribute actual contract balance and add `get_balance` view

- `distribute` no longer accepts a caller-supplied `amount`. It reads the actual token balance via `token_client.balance()` and distributes that, preventing stranded tokens.
- Added `pub fn get_balance(env: Env, token: Address) -> i128` view function.
- Backend `POST /api/distribute` and `distributeSchema` updated to drop the `amount` field.
- `DistributeForm.tsx` removes the amount input; description clarifies the full balance is distributed.
- Tests updated: replaced the two stale `amount exceeds contract balance` tests with `no balance to distribute` and `distribute_uses_actual_balance`.

closes #102 

### #103 — Wallet disconnect and Freighter account change handling

- `WalletConnect.tsx` gains an `onDisconnect?: () => void` prop called on disconnect.
- Registers a `window.freighter.on('accountChanged', ...)" listener that updates the address state automatically when the user switches accounts in the extension.
- Connected address is now a copyable button with a clipboard indicator.
- `App.tsx` passes `onDisconnect={() => setWalletAddress(null)}`.

closes #103 

### #104 — Field validation and BigInt royalty preview in `RecordSecondarySale`

- `previousOwner` / `newOwner` validated against `/^G[A-Z2-7]{55}$/` on blur.
- `saleToken` validated against `/^C[A-Z2-7]{55}$/` on blur.
- Royalty preview uses `BigInt` arithmetic (`(price * rate) / 10000n`) to match contract precision.
- Submit button disabled while any field is invalid; inline field errors shown below each input.

closes #104 
---

### Testing

- Rust unit tests updated and passing (contract compile verified locally).
- Frontend and backend changes are type-safe; no new dependencies introduced.