### PR TITLE
fix: improve CollaboratorTable address display and empty state

### DIFF
--- a/frontend/src/components/CollaboratorTable.tsx
+++ b/frontend/src/components/CollaboratorTable.tsx
@@ -31,7 +31,15 @@ export default function CollaboratorTable({ contractId, refreshKey }: Props) {
   if (loading)
     return <div className="card status info">Loading collaborators…</div>;
   if (error) return <div className="card status error">{error}</div>;
-  if (!collaborators.length) return null;
+  if (!collaborators.length)
+    return (
+      <div className="card">
+        <span className="badge">Collaborators</span>
+        <p style={{ color: "var(--text-secondary)", fontSize: "0.85rem" }}>
+          No collaborators found. Initialize the contract to add collaborators.
+        </p>
+      </div>
+    );
 
   return (
     <div className="card">
@@ -46,9 +54,20 @@ export default function CollaboratorTable({ contractId, refreshKey }: Props) {
         <tbody>
           {collaborators.map((c) => (
             <tr key={c.address}>
-              <td>{c.address}</td>
               <td>
-                {(c.basisPoints / 100).toFixed(2)}%
+                <span title={c.address}>
+                  {c.address.slice(0, 8)}...{c.address.slice(-6)}
+                </span>
+                <button
+                  className="copy-btn-sm"
+                  onClick={() => navigator.clipboard.writeText(c.address)}
+                  title="Copy address"
+                >
+                  ⧉
+                </button>
+              </td>
+              <td style={{ textAlign: "right" }}>
+                <span>{(c.basisPoints / 100).toFixed(2)}%</span>
                 <div
                   className="share-bar"
                   style={{ width: `${c.basisPoints / 100}%` }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -202,6 +202,25 @@ td:last-child {
   margin-top: 4px;
 }
 
+.copy-btn-sm {
+  margin-left: 6px;
+  padding: 2px 6px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: all var(--transition-base);
+  vertical-align: middle;
+}
+
+.copy-btn-sm:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
 .wallet-row {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
This closes #39 

## Summary

Fixes UX issues in the `CollaboratorTable` component.

### Changes
- **Address truncation**: Full wallet addresses truncated (`first8...last6`) with full address in tooltip
- **Copy button**: Each row has a `.copy-btn-sm` button to copy the full address to clipboard
- **Share bar label**: Percentage label rendered alongside the share bar
- **Empty state**: Replaced silent `return null` with a helpful card message

### Definition of Done
- [x] Addresses are truncated with a full-address tooltip
- [x] Each row has a copy-to-clipboard button
- [x] Share bar has a visible percentage label
- [x] Empty state shows a helpful message instead of rendering nothing

Closes #
