### PR TITLE
perf: add get_all_shares to eliminate N+1 RPC calls in collaborators endpoint

### DIFF
--- a/backend/src/routes/collaborators.js
+++ b/backend/src/routes/collaborators.js
@@ -7,7 +7,7 @@ import {
   BASE_FEE,
   Account,
 } from "@stellar/stellar-sdk";
-import { server, networkPassphrase, addressToScVal } from "../stellar.js";
+import { server, networkPassphrase } from "../stellar.js";
 import logger from "../logger.js";
 
 export const collaboratorsRouter = Router();
@@ -16,23 +16,25 @@ export const collaboratorsRouter = Router();
  * GET /api/collaborators/:contractId
  * Returns: [{ address, basisPoints }]
  *
- * Uses a read-only simulation (no signing required).
+ * Uses a single read-only simulation of get_all_shares (Map<Address, u32>)
+ * instead of N+1 individual get_share calls.
  */
 collaboratorsRouter.get("/:contractId", async (req, res, next) => {
   try {
     const { contractId } = req.params;
     const contract = new Contract(contractId);
 
-    // Simulate get_collaborators
     const dummyAccount = new Account(
       "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
       "0",
     );
+
+    // Single simulation — replaces N+1 individual get_share calls
     const tx = new TransactionBuilder(dummyAccount, {
       fee: BASE_FEE,
       networkPassphrase,
     })
-      .addOperation(contract.call("get_collaborators"))
+      .addOperation(contract.call("get_all_shares"))
       .setTimeout(30)
       .build();
 
@@ -41,56 +43,17 @@ collaboratorsRouter.get("/:contractId", async (req, res, next) => {
       return res.status(400).json({ error: sim.error });
     }
 
-    // Parse the returned Vec<Address>
     const resultVal = sim.result?.retval;
     if (!resultVal) return res.json([]);
 
-    const addresses =
-      resultVal.vec()?.map((scv) => Address.fromScVal(scv).toString()) ?? [];
+    // retval is a Map<Address, u32> — iterate its entries
+    const mapEntries = resultVal.map()?.entries ?? [];
+    const results = mapEntries.map((entry) => ({
+      address: Address.fromScVal(entry.key()).toString(),
+      basisPoints: entry.val().u32(),
+    }));
 
-    // Fetch share for each address — use allSettled so a single RPC failure
-    // doesn't abort the entire request (#130)
-    const settled = await Promise.allSettled(
-      addresses.map(async (addr) => {
-        // #132: validate address is a known collaborator before calling get_share
-        const isCollabTx = new TransactionBuilder(dummyAccount, {
-          fee: BASE_FEE,
-          networkPassphrase,
-        })
-          .addOperation(contract.call("is_collaborator", addressToScVal(addr)))
-          .setTimeout(30)
-          .build();
-
-        const isCollabSim = await server.simulateTransaction(isCollabTx);
-        const isCollab = !SorobanRpc.Api.isSimulationError(isCollabSim) &&
-          (isCollabSim.result?.retval?.bool() ?? false);
-
-        if (!isCollab) {
-          throw new Error(`${addr} is not a registered collaborator`);
-        }
-
-        const shareTx = new TransactionBuilder(dummyAccount, {
-          fee: BASE_FEE,
-          networkPassphrase,
-        })
-          .addOperation(contract.call("get_share", addressToScVal(addr)))
-          .setTimeout(30)
-          .build();
-
-        const shareSim = await server.simulateTransaction(shareTx);
-        if (SorobanRpc.Api.isSimulationError(shareSim)) {
-          throw new Error(shareSim.error);
-        }
-        return { address: addr, basisPoints: shareSim.result?.retval?.u32() ?? 0, status: "success" };
-      }),
-    );
-
-    const results = settled.map((result, i) => {
-      if (result.status === "fulfilled") return result.value;
-      logger.warn(`Failed to fetch share for ${addresses[i]}: ${result.reason?.message ?? result.reason}`);
-      return { address: addresses[i], basisPoints: 0, status: "failed" };
-    });
-
+    logger.info(`get_all_shares returned ${results.length} collaborators for ${contractId}`);
     res.json(results);
   } catch (err) {
     next(err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,6 +447,15 @@ impl RoyaltySplitter {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Returns the full share map (Address → basis points) in a single call,
+    /// eliminating the need for N individual get_share simulations.
+    pub fn get_all_shares(env: Env) -> Map<Address, u32> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ShareMap)
+            .unwrap_or(Map::new(&env))
+    }
+
     pub fn get_secondary_pool(
         env: Env,
     ) -> i128 {


### PR DESCRIPTION
This fixes #108 
## Summary

The collaborators endpoint was making 2 RPC simulations per collaborator
(is_collaborator + get_share), causing N+1 network calls on every page load.

### Changes

- `src/lib.rs`: Added `get_all_shares(env: Env) -> Map<Address, u32>` — a single
  view function that returns the full share map in one call
- `backend/src/routes/collaborators.js`: Replaced the N+1 Promise.allSettled loop
  with a single simulation of `get_all_shares`, parsing the returned Map entries directly

### Definition of Done
- [x] `get_all_shares` view function exists on the contract
- [x] Collaborators endpoint uses a single simulation call
- [x] N+1 RPC calls are eliminated

Closes #
