### PR TITLE
fix: make secondary sale DB write atomic with XDR build

### DIFF
--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -16,6 +16,7 @@ import {
   getRoyaltyStatistics,
   addAuditLog,
 } from "../database.js";
+import db from "../database.js";
 import { validate, recordSecondarySaleSchema, setRoyaltyRateSchema, validateContractId, parsePagination } from "../validation.js";
 
 export const secondaryRoyaltyRouter = Router();
@@ -71,37 +72,41 @@ secondaryRoyaltyRouter.post("/", validate(recordSecondarySaleSchema), async (req
       return res.status(400).json({ error: "Calculated royalty amount is zero." });
     }
 
-    // Record transaction in database
-    const transactionId = recordTransaction(
-      contractId,
-      "secondary_royalty",
-      walletAddress,
-      { salePrice: salePrice.toString(), nftId, saleToken, royaltyRate: onChainRate }
-    );
+    // Build XDR first — if this throws (e.g. RPC timeout) no DB record is written
+    const txXdr = await buildTx(walletAddress, contractId, "record_secondary_royalty", [
+      i128ToScVal(salePrice),
+    ]);
 
-    // Record the secondary sale (unique constraint prevents duplicates)
+    // XDR is ready — now atomically write both DB records so neither is
+    // orphaned if the other fails (unique-constraint violation rolls back both)
+    let transactionId;
     try {
-      recordSecondarySale(
-        contractId,
-        nftId,
-        previousOwner,
-        newOwner,
-        salePrice,
-        saleToken,
-        royaltyAmount,
-        onChainRate
-      );
+      const writeAtomic = db.transaction(() => {
+        const txId = recordTransaction(
+          contractId,
+          "secondary_royalty",
+          walletAddress,
+          { salePrice: salePrice.toString(), nftId, saleToken, royaltyRate: onChainRate }
+        );
+        recordSecondarySale(
+          contractId,
+          nftId,
+          previousOwner,
+          newOwner,
+          salePrice,
+          saleToken,
+          royaltyAmount,
+          onChainRate
+        );
+        return txId;
+      });
+      transactionId = writeAtomic();
     } catch (err) {
       if (err.code === "SQLITE_CONSTRAINT_UNIQUE") {
         return res.status(409).json({ error: "This sale has already been recorded." });
       }
       throw err;
     }
-
-    // Build transaction to record royalty in contract
-    const txXdr = await buildTx(walletAddress, contractId, "record_secondary_royalty", [
-      i128ToScVal(salePrice),
-    ]);
 
     // Log the secondary sale
     addAuditLog(contractId, "secondary_sale_recorded", walletAddress, {


### PR DESCRIPTION
This closes #113 
## Problem

`POST /api/secondary-royalty` was writing to the DB (both `transactions`
and `secondary_sales`) before calling `buildTx`. If `buildTx` threw — e.g.
an RPC timeout — the sale was permanently orphaned in the DB with no XDR
returned to the client. The user had no way to retry and the on-chain
royalty pool was never updated.

## Fix

- `buildTx` is now called first; no DB writes happen if it throws
- Both `recordTransaction` and `recordSecondarySale` are wrapped in a
  single `db.transaction(...)` so they commit together or not at all
- The unique-constraint 409 guard is preserved inside the transaction

## Definition of Done
- [x] DB write only happens after XDR is successfully built
- [x] Failed XDR builds do not leave orphaned DB records
- [x] SQLite transaction wraps both writes atomically

Closes #
