### PR TITLE
perf(backend): add CORS preflight caching (24h)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,9 @@ SERVER_SECRET_KEY=S...
 # CORS — restrict to your frontend origin
 FRONTEND_ORIGIN=http://localhost:5173
 
+# CORS_PREFLIGHT_MAX_AGE — Access-Control-Max-Age for preflight responses in seconds (default: 24 hours)
+CORS_PREFLIGHT_MAX_AGE=86400
+
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX=100

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -38,11 +38,17 @@ app.use((req, res, next) => {
 // Security headers
 app.use(helmet());
 
+const corsPreflightMaxAge = parseInt(
+  process.env.CORS_PREFLIGHT_MAX_AGE ?? "86400",
+  10,
+);
+
 // CORS restricted to configured frontend origin
 app.use(
   cors({
     origin: process.env.FRONTEND_ORIGIN ?? "http://localhost:5173",
     methods: ["GET", "POST"],
+    maxAge: Number.isNaN(corsPreflightMaxAge) ? 86400 : corsPreflightMaxAge,
   }),
 );
 


### PR DESCRIPTION
Set CORS preflight max-age to 86400 seconds to reduce repeated OPTIONS requests and latency on cross-origin POSTs. Add env-backed configuration via CORS_PREFLIGHT_MAX_AGE with a default of 86400. Document the setting in backend/.env.example.

Closes #149