### PR TITLE
refactor(frontend): extract shared form status component and hook

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,9 @@ SERVER_SECRET_KEY=S...
 # CORS — restrict to your frontend origin
 FRONTEND_ORIGIN=http://localhost:5173
 
+# CORS_PREFLIGHT_MAX_AGE — Access-Control-Max-Age for preflight responses in seconds (default: 24 hours)
+CORS_PREFLIGHT_MAX_AGE=86400
+
 # Rate limiting
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX=100

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -38,11 +38,17 @@ app.use((req, res, next) => {
 // Security headers
 app.use(helmet());
 
+const corsPreflightMaxAge = parseInt(
+  process.env.CORS_PREFLIGHT_MAX_AGE ?? "86400",
+  10,
+);
+
 // CORS restricted to configured frontend origin
 app.use(
   cors({
     origin: process.env.FRONTEND_ORIGIN ?? "http://localhost:5173",
     methods: ["GET", "POST"],
+    maxAge: Number.isNaN(corsPreflightMaxAge) ? 86400 : corsPreflightMaxAge,
   }),
 );
 

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { api } from "../api";
 import { signAndSubmitTransaction } from "../stellar";
+import FormStatus from "./FormStatus";
+import { useFormStatus } from "../hooks/useFormStatus";
 
 interface Props {
   contractId: string;
@@ -17,10 +19,7 @@ export default function DistributeForm({
   const [amount, setAmount] = useState("");
   const [contractBalance, setContractBalance] = useState<string | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
-  const [status, setStatus] = useState<{
-    type: "ok" | "error" | "info";
-    msg: string;
-  } | null>(null);
+  const { status, setStatus } = useFormStatus();
   const [loading, setLoading] = useState(false);
 
   // Fetch contract balance whenever tokenId changes (debounced)
@@ -50,33 +49,33 @@ export default function DistributeForm({
 
   async function submit() {
     if (!contractId)
-      return setStatus({ type: "error", msg: "Enter a contract ID first." });
+      return setStatus("error", "Enter a contract ID first.");
     if (!tokenId)
-      return setStatus({ type: "error", msg: "Enter a token address." });
+      return setStatus("error", "Enter a token address.");
     if (!amount || isNaN(parsedAmount) || parsedAmount <= 0)
-      return setStatus({ type: "error", msg: "Enter a valid amount." });
+      return setStatus("error", "Enter a valid amount.");
     if (exceedsBalance)
-      return setStatus({ type: "error", msg: "Amount exceeds contract balance." });
+      return setStatus("error", "Amount exceeds contract balance.");
 
     setLoading(true);
-    setStatus({ type: "info", msg: "Building transaction…" });
+    setStatus("info", "Building transaction…");
 
     try {
       const res = await api.distribute({ contractId, walletAddress, tokenId });
 
-      setStatus({ type: "info", msg: "Signing transaction with Freighter..." });
+      setStatus("info", "Signing transaction with Freighter...");
       const hash = await signAndSubmitTransaction(res.xdr);
 
-      setStatus({ type: "info", msg: "Waiting for confirmation..." });
+      setStatus("info", "Waiting for confirmation...");
       await api.confirmTransaction(hash, {
         status: "confirmed",
         blockTime: new Date().toISOString(),
       });
 
-      setStatus({ type: "ok", msg: `Distributed. Tx: ${hash}` });
+      setStatus("ok", `Distributed. Tx: ${hash}`);
       onSuccess();
     } catch (e: unknown) {
-      setStatus({ type: "error", msg: e instanceof Error ? e.message : "Unknown error" });
+      setStatus("error", e instanceof Error ? e.message : "Unknown error");
     } finally {
       setLoading(false);
     }
@@ -123,7 +122,7 @@ export default function DistributeForm({
       >
         {loading ? "Submitting…" : "Distribute funds"}
       </button>
-      {status && <div className={`status ${status.type}`}>{status.msg}</div>}
+      {status && <FormStatus type={status.type} message={status.message} />}
     </div>
   );
 }

--- a/frontend/src/components/FormStatus.tsx
+++ b/frontend/src/components/FormStatus.tsx
@@ -1,0 +1,10 @@
+export type FormStatusType = "ok" | "error" | "info";
+
+interface FormStatusProps {
+  type: FormStatusType;
+  message: string;
+}
+
+export default function FormStatus({ type, message }: FormStatusProps) {
+  return <div className={`form-status form-status--${type}`}>{message}</div>;
+}

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { api } from "../api";
 import { signAndSubmitTransaction } from "../stellar";
+import FormStatus from "./FormStatus";
+import { useFormStatus } from "../hooks/useFormStatus";
 
 
 interface Collaborator {
@@ -27,10 +29,7 @@ export default function InitializeForm({
   const [errors, setErrors] = useState<
     Record<number, { address?: string; basisPoints?: string }>
   >({});
-  const [status, setStatus] = useState<{
-    type: "ok" | "error" | "info";
-    msg: string;
-  } | null>(null);
+  const { status, setStatus } = useFormStatus();
   const [loading, setLoading] = useState(false);
 
   function update(i: number, field: keyof Collaborator, value: string) {
@@ -90,24 +89,18 @@ export default function InitializeForm({
 
   async function submit() {
     if (!contractId)
-      return setStatus({ type: "error", msg: "Enter a contract ID first." });
+      return setStatus("error", "Enter a contract ID first.");
     if (total !== 10_000)
-      return setStatus({
-        type: "error",
-        msg: `Shares must sum to 10,000 bp (currently ${total}).`,
-      });
+      return setStatus("error", `Shares must sum to 10,000 bp (currently ${total}).`);
 
     const addresses = collaborators.map((c: Collaborator) => c.address);
     const hasDuplicates = new Set(addresses).size !== addresses.length;
     if (hasDuplicates) {
-      return setStatus({
-        type: "error",
-        msg: "Duplicate addresses are not allowed.",
-      });
+      return setStatus("error", "Duplicate addresses are not allowed.");
     }
 
     setLoading(true);
-    setStatus({ type: "info", msg: "Building transaction…" });
+    setStatus("info", "Building transaction…");
 
     try {
       const res = await api.initialize({
@@ -117,28 +110,25 @@ export default function InitializeForm({
         shares: collaborators.map((c: Collaborator) => parseInt(c.basisPoints)),
       });
 
-      setStatus({ type: "info", msg: "Signing transaction with Freighter..." });
+      setStatus("info", "Signing transaction with Freighter...");
       const hash = await signAndSubmitTransaction(res.xdr);
 
-      setStatus({ type: "info", msg: "Waiting for confirmation..." });
+      setStatus("info", "Waiting for confirmation...");
       await api.confirmTransaction(hash, {
         status: "confirmed",
         blockTime: new Date().toISOString(),
       });
 
-      setStatus({ type: "ok", msg: `Initialized. Tx: ${hash}` });
+      setStatus("ok", `Initialized. Tx: ${hash}`);
       onSuccess();
 
     } catch (e: unknown) {
       // Handle 409 Conflict error specifically
       const errorMessage = e instanceof Error ? e.message : "Unknown error";
       if (errorMessage.includes('409') || errorMessage.includes('already initialized')) {
-        setStatus({ 
-          type: "error", 
-          msg: "⚠️ This contract is already initialized. You cannot re-initialize an existing contract." 
-        });
+        setStatus("error", "⚠️ This contract is already initialized. You cannot re-initialize an existing contract.");
       } else {
-        setStatus({ type: "error", msg: errorMessage });
+        setStatus("error", errorMessage);
       }
     } finally {
       setLoading(false);
@@ -200,7 +190,7 @@ export default function InitializeForm({
         </button>
       </div>
 
-      {status && <div className={`status ${status.type}`}>{status.msg}</div>}
+      {status && <FormStatus type={status.type} message={status.message} />}
     </div>
   );
 }

--- a/frontend/src/components/RecordSecondarySale.tsx
+++ b/frontend/src/components/RecordSecondarySale.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { api } from "../api";
 import { signAndSubmitTransaction } from "../stellar";
+import FormStatus from "./FormStatus";
+import { useFormStatus } from "../hooks/useFormStatus";
 
 const G_ADDR = /^G[A-Z2-7]{55}$/;
 const C_ADDR = /^C[A-Z2-7]{55}$/;
@@ -27,10 +29,7 @@ export default function RecordSecondarySale({
   });
 
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  const [status, setStatus] = useState<{
-    type: "ok" | "error" | "info";
-    msg: string;
-  } | null>(null);
+  const { status, setStatus } = useFormStatus();
   const [loading, setLoading] = useState(false);
   const [calculatedRoyalty, setCalculatedRoyalty] = useState<bigint | null>(null);
 
@@ -70,14 +69,14 @@ export default function RecordSecondarySale({
 
   async function submit() {
     if (!contractId) {
-      return setStatus({ type: "error", msg: "Enter a contract ID first." });
+      return setStatus("error", "Enter a contract ID first.");
     }
     if (!isFormValid) {
-      return setStatus({ type: "error", msg: "Please fix all field errors before submitting." });
+      return setStatus("error", "Please fix all field errors before submitting.");
     }
 
     setLoading(true);
-    setStatus({ type: "info", msg: "Recording secondary sale..." });
+    setStatus("info", "Recording secondary sale...");
 
     try {
       const { xdr, royaltyAmount } = await api.recordSecondarySale({
@@ -91,28 +90,22 @@ export default function RecordSecondarySale({
         royaltyRate,
       });
 
-      setStatus({ type: "info", msg: "Please sign the transaction..." });
+      setStatus("info", "Please sign the transaction...");
       const result = await signAndSubmitTransaction(xdr);
 
-      setStatus({ type: "info", msg: "Waiting for confirmation..." });
+      setStatus("info", "Waiting for confirmation...");
       await api.confirmTransaction(result, {
         status: "confirmed",
         blockTime: new Date().toISOString(),
       });
 
-      setStatus({
-        type: "ok",
-        msg: `Secondary sale recorded! Royalty: ${royaltyAmount} tokens. TX: ${result}`,
-      });
+      setStatus("ok", `Secondary sale recorded! Royalty: ${royaltyAmount} tokens. TX: ${result}`);
 
       setFormData({ nftId: "", previousOwner: "", newOwner: "", salePrice: "", saleToken: "" });
       setCalculatedRoyalty(null);
       onSuccess();
     } catch (err) {
-      setStatus({
-        type: "error",
-        msg: `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-      });
+      setStatus("error", `Error: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
       setLoading(false);
     }
@@ -204,11 +197,7 @@ export default function RecordSecondarySale({
         </div>
       </div>
 
-      {status && (
-        <div className={`message ${status.type}`}>
-          {status.msg}
-        </div>
-      )}
+      {status && <FormStatus type={status.type} message={status.message} />}
 
       <button onClick={submit} disabled={loading || !isFormValid} className="btn-primary">
         {loading ? "Processing..." : "Record Sale"}

--- a/frontend/src/hooks/useFormStatus.ts
+++ b/frontend/src/hooks/useFormStatus.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from "react";
+import type { FormStatusType } from "../components/FormStatus";
+
+interface FormStatusState {
+  type: FormStatusType;
+  message: string;
+}
+
+export function useFormStatus(clearAfterMs = 5000) {
+  const [status, setStatusState] = useState<FormStatusState | null>(null);
+
+  useEffect(() => {
+    if (!status) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setStatusState(null);
+    }, clearAfterMs);
+
+    return () => window.clearTimeout(timer);
+  }, [status, clearAfterMs]);
+
+  const setStatus = useCallback((type: FormStatusType, message: string) => {
+    setStatusState({ type, message });
+  }, []);
+
+  const clearStatus = useCallback(() => {
+    setStatusState(null);
+  }, []);
+
+  return { status, setStatus, clearStatus };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -352,6 +352,31 @@ td:last-child {
   border: 1px solid var(--info);
 }
 
+.form-status {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.form-status--ok {
+  background: #14532d;
+  color: #86efac;
+  border: 1px solid var(--success);
+}
+
+.form-status--error {
+  background: var(--error-light);
+  color: var(--error-dark);
+  border: 1px solid var(--error-color);
+}
+
+.form-status--info {
+  background: var(--accent-primary-light);
+  color: var(--info);
+  border: 1px solid var(--info);
+}
+
 small {
   display: block;
   font-size: 0.75rem;


### PR DESCRIPTION



Add reusable FormStatus component with type/message API.
Add useFormStatus hook to manage form status and auto-clear after 5 seconds.
Refactor Initialize, Distribute, and Record Secondary Sale forms to use shared status logic and UI.
Unify form status styling for consistent feedback across forms.

Closes #150