### PR TITLE
fix: add global request timeout to prevent API hang under RPC stalls

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,15 @@ RATE_LIMIT_MAX=100
 # RATE_LIMIT_WRITE_MAX — max requests per window for write/mutation endpoints
 RATE_LIMIT_WRITE_MAX=10
 
+# REQUEST_TIMEOUT_MS — per-request timeout in milliseconds; returns 503 if exceeded (default: 30s)
+REQUEST_TIMEOUT_MS=30000
+
+# KEEP_ALIVE_TIMEOUT_MS — HTTP keep-alive timeout on the server socket (default: 35s)
+KEEP_ALIVE_TIMEOUT_MS=35000
+
+# HEADERS_TIMEOUT_MS — max time to receive full request headers (default: 40s)
+HEADERS_TIMEOUT_MS=40000
+
 export type Transaction = {
   // ...existing transaction fields...
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -76,6 +76,19 @@ app.use((req, res, next) => {
   next();
 });
 
+// Per-request timeout middleware
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS ?? "30000");
+app.use((req, res, next) => {
+  const timer = setTimeout(() => {
+    if (!res.headersSent) {
+      res.status(503).json({ error: "Request timed out. Please try again later." });
+    }
+  }, REQUEST_TIMEOUT_MS);
+  res.on("finish", () => clearTimeout(timer));
+  res.on("close", () => clearTimeout(timer));
+  next();
+});
+
 // Apply write limiter to mutating endpoints
 app.use("/api/v1/initialize", writeLimiter);
 app.use("/api/v1/distribute", writeLimiter);
@@ -105,6 +118,10 @@ app.use((err, _req, res, _next) => {
 });
 
 const PORT = process.env.PORT ?? 3001;
-app.listen(PORT, () =>
+const server = app.listen(PORT, () =>
   logger.info(`API listening on http://localhost:${PORT}`),
 );
+
+// Prevent hung connections from exhausting the connection pool
+server.keepAliveTimeout = parseInt(process.env.KEEP_ALIVE_TIMEOUT_MS ?? "35000");
+server.headersTimeout = parseInt(process.env.HEADERS_TIMEOUT_MS ?? "40000");


### PR DESCRIPTION
closes #96 

1. Per-request timeout middleware — fires a setTimeout for REQUEST_TIMEOUT_MS (default 30s). If the response hasn't been sent by then, it returns 503 Service Unavailable. 
The timer is cleared on finish/close so normal requests have zero overhead.

2. Server-level timeouts — after app.listen() the server instance gets:
   - keepAliveTimeout (35s) — closes idle keep-alive connections before they pile up
   - headersTimeout (40s) — drops connections that never finish sending headers

The values are intentionally staggered (request < keepAlive < headers) so the per-request 503 fires first, then the socket-level guards clean up anything that slips through.

