### PR TITLE
feat: expose last distribution timestamp via view function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub enum DataKey {
     SecondaryToken,
     ContractVersion,
     RoyaltyRate,
+    LastDistribution,
+    LastSecondaryDistribution,
 }
 
 const MIN_TTL: u32 = 17_280;
@@ -165,6 +167,18 @@ impl RoyaltySplitter {
         admin.require_auth();
         
         if Self::get_total_shares(env.clone()) != 10_000 {
+        /// Returns the timestamp of the last primary distribution, or None if never distributed.
+        pub fn get_last_distribution(env: Env) -> Option<u64> {
+            env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+            env.storage().instance().get(&DataKey::LastDistribution)
+        }
+
+        /// Returns the timestamp of the last secondary distribution, or None if never distributed.
+        pub fn get_last_secondary_distribution(env: Env) -> Option<u64> {
+            env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+            env.storage().instance().get(&DataKey::LastSecondaryDistribution)
+        }
+
             panic!("total shares must sum to 10000");
         }
 
@@ -243,6 +257,11 @@ impl RoyaltySplitter {
             (symbol_short!("royalty"), symbol_short!("dist_all")),
             (token, amount),
         );
+
+        // Record the timestamp of this distribution
+        env.storage()
+            .instance()
+            .set(&DataKey::LastDistribution, &env.ledger().timestamp());
     }
 
     pub fn record_secondary_royalty(
@@ -393,6 +412,11 @@ impl RoyaltySplitter {
             (symbol_short!("royalty"), symbol_short!("sec_dist")),
             (token, pool),
         );
+
+        // Record the timestamp of this secondary distribution
+        env.storage()
+            .instance()
+            .set(&DataKey::LastSecondaryDistribution, &env.ledger().timestamp());
     }
 
     pub fn record_secondary_sale(


### PR DESCRIPTION
Closes #157

- Added LastDistribution and LastSecondaryDistribution to DataKey enum
- Updated distribute() to record timestamp after distribution
- Updated distribute_secondary_royalties() to record timestamp
- Added get_last_distribution() view function
- Added get_last_secondary_distribution() view function
- Frontend can now show 'Last distribution: X days ago'