### PR TITLE
feat: add get_token_balance view function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,13 @@ impl RoyaltySplitter {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
     }
+    /// Returns the contract's balance of a specific token.
+    /// This is a view function that can be called without auth.
+    pub fn get_token_balance(env: Env, token: Address) -> i128 {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        token::Client::new(&env, &token).balance(&env.current_contract_address())
+    }
+
 
     /// Distribute the full contract balance of `token` to all collaborators.
     pub fn distribute(env: Env, token: Address) {


### PR DESCRIPTION
Closes #154

- Added get_token_balance view function to query contract token balance
- Frontend can now display 'Available to distribute: X tokens'
- No auth required for read-only balance queries
- Closes #152