### PR TITLE
feat: add graceful shutdown handler for SIGTERM

### DIFF
--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -24,7 +24,7 @@ export function countWrite() {
 // Final checkpoint on clean shutdown.
 process.on("exit", () => db.pragma("wal_checkpoint(TRUNCATE)"));
 process.on("SIGINT", () => process.exit(0));
-process.on("SIGTERM", () => process.exit(0));
+// SIGTERM is handled in index.js for graceful HTTP + DB shutdown.
 
 // Initialize database schema
 export function initializeDatabase() {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,6 +14,7 @@ import historyRouter from "./routes/history.js";
 import { analyticsRouter } from "./routes/analytics.js";
 import { contractRouter } from "./routes/contract.js";
 import { initializeDatabase, getMigrationVersion } from "./database.js";
+import db from "./database.js";
 
 // Initialize database on startup
 initializeDatabase();
@@ -133,3 +134,36 @@ const server = app.listen(PORT, () =>
 // Prevent hung connections from exhausting the connection pool
 server.keepAliveTimeout = parseInt(process.env.KEEP_ALIVE_TIMEOUT_MS ?? "35000");
 server.headersTimeout = parseInt(process.env.HEADERS_TIMEOUT_MS ?? "40000");
+
+// Graceful shutdown on SIGTERM (e.g. during deployment / container stop)
+const SHUTDOWN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_TIMEOUT_MS ?? "10000");
+
+process.on("SIGTERM", () => {
+  logger.info("SIGTERM received — starting graceful shutdown");
+
+  // Stop accepting new connections; wait for in-flight requests to finish.
+  server.close((err) => {
+    if (err) {
+      logger.error("Error while closing HTTP server", err);
+    } else {
+      logger.info("HTTP server closed");
+    }
+
+    // Close the SQLite connection (better-sqlite3 is synchronous).
+    try {
+      db.close();
+      logger.info("Database connection closed");
+    } catch (dbErr) {
+      logger.error("Error while closing database", dbErr);
+    }
+
+    logger.info("Graceful shutdown complete");
+    process.exit(err ? 1 : 0);
+  });
+
+  // Force-exit if in-flight requests don't drain in time.
+  setTimeout(() => {
+    logger.error(`Shutdown timeout (${SHUTDOWN_TIMEOUT_MS}ms) exceeded — forcing exit`);
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS).unref();
+});


### PR DESCRIPTION
- Add process.on('SIGTERM') handler in index.js that calls server.close() to stop accepting new connections while allowing in-flight requests to drain
- Close the SQLite database connection after the HTTP server closes
- Log each step of the shutdown sequence (received, server closed, db closed, complete)
- Force-exit after configurable SHUTDOWN_TIMEOUT_MS (default 10s) to prevent hanging indefinitely if requests don't drain in time; uses .unref() so the timer doesn't keep the process alive on its own
- Remove the bare process.on('SIGTERM') from database.js that previously called process.exit(0) immediately with no cleanup, which would have raced with the new handler

Closes #158