### PR TITLE
docs/feat/test: rustdoc, TTL on initialize, royalty rate tests, CONTR…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,63 @@
 # Contributing to Stellar Royalty Splitter
 
-Thanks for your interest in contributing. Here's everything you need to get up and running.
+Thanks for your interest in contributing. This guide covers everything you need to get the project running locally, write and run tests, and open a pull request.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Fork and clone](#fork-and-clone)
+- [Smart contract setup](#smart-contract-setup)
+- [Backend setup](#backend-setup)
+- [Frontend setup](#frontend-setup)
+- [Running tests](#running-tests)
+- [Branch naming](#branch-naming)
+- [Commit message standards](#commit-message-standards)
+- [PR guidelines](#pr-guidelines)
+- [Windows auth guard caveat](#windows-auth-guard-caveat)
+
+---
+
+## Prerequisites
+
+You need the following tools installed before working on any part of the project.
+
+### Rust and wasm32 target
+
+```bash
+# Install Rust via rustup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add the wasm32 target required for Soroban contract compilation
+rustup target add wasm32-unknown-unknown
+```
+
+### Soroban CLI (Stellar CLI)
+
+```bash
+cargo install --locked stellar-cli
+```
+
+Verify the install:
+
+```bash
+stellar --version
+```
+
+### Node.js
+
+The backend and frontend both require Node.js 18 or later.
+
+- Download: https://nodejs.org
+- Or via a version manager: `nvm install 20`
+
+Verify:
+
+```bash
+node --version   # should be >= 18
+npm --version
+```
 
 ---
 
@@ -13,16 +70,28 @@ cd Stellar-Royalty-Splitter
 
 ---
 
+## Smart contract setup
+
+The Soroban contract lives in `src/lib.rs`. No additional setup is needed beyond Rust and the wasm32 target.
+
+Build the contract:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+---
+
 ## Backend setup
 
 ```bash
 cd backend
-cp .env.example .env   # fill in your values
+cp .env.example .env   # fill in your values — see README for field descriptions
 npm install
-npm run dev            # runs on http://localhost:3001
+npm run dev            # starts on http://localhost:3001
 ```
 
-See [Environment Variables](README.md#environment-variables) for a description of each `.env` field.
+The backend builds unsigned Soroban transaction XDR and returns it to the frontend. It never holds or uses a user's private key.
 
 ---
 
@@ -31,36 +100,74 @@ See [Environment Variables](README.md#environment-variables) for a description o
 ```bash
 cd frontend
 npm install
-npm run dev            # runs on http://localhost:5173
+npm run dev            # starts on http://localhost:5173
 ```
 
-The frontend proxies `/api/*` to the backend automatically via Vite config.
+The frontend proxies `/api/*` to the backend automatically via the Vite config. Make sure the backend is running first.
 
 ---
 
-## Rust contract tests
+## Running tests
+
+### Smart contract tests
+
+Run all tests (unit + integration):
 
 ```bash
 cargo test
 ```
 
-To run only the inline unit tests:
+Run only the inline unit tests inside `src/lib.rs`:
 
 ```bash
 cargo test --lib
+```
+
+Run only the integration tests in `tests/`:
+
+```bash
+cargo test --test integration_test
+```
+
+Run a specific test by name:
+
+```bash
+cargo test test_royalty_rate_boundary_max
+```
+
+Show output from passing tests (useful for debugging):
+
+```bash
+cargo test -- --nocapture
+```
+
+### Backend tests
+
+```bash
+cd backend
+npm test
+```
+
+### Frontend tests
+
+```bash
+cd frontend
+npm test -- --run   # single pass, no watch mode
 ```
 
 ---
 
 ## Branch naming
 
-| Type     | Pattern                        | Example                              |
-| -------- | ------------------------------ | ------------------------------------ |
-| Feature  | `feat/<short-description>`     | `feat/governance-royalty-rate`       |
-| Bug fix  | `fix/<short-description>`      | `fix/secondary-sale-dedup`           |
-| Tests    | `test/<short-description>`     | `test/royalty-error-cases`           |
-| Docs     | `docs/<short-description>`     | `docs/contributing-guide`            |
-| Chore    | `chore/<short-description>`    | `chore/update-dependencies`          |
+| Type     | Pattern                     | Example                        |
+| -------- | --------------------------- | ------------------------------ |
+| Feature  | `feat/<short-description>`  | `feat/governance-royalty-rate` |
+| Bug fix  | `fix/<short-description>`   | `fix/secondary-sale-dedup`     |
+| Tests    | `test/<short-description>`  | `test/royalty-error-cases`     |
+| Docs     | `docs/<short-description>`  | `docs/contributing-guide`      |
+| Chore    | `chore/<short-description>` | `chore/update-dependencies`    |
+
+Keep branch names lowercase and hyphen-separated. Avoid slashes beyond the type prefix.
 
 ---
 
@@ -69,56 +176,72 @@ cargo test --lib
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
 
 ```
-<type>: <description>
+<type>: <short description>
 
-[optional body]
+[optional body — explain the why, not the what]
 
-[optional footer]
+[optional footer — issue references, breaking change notes]
 ```
 
 ### Types
 
-- `feat:` — new feature or enhancement
-- `fix:` — bug fix
-- `docs:` — documentation changes
-- `test:` — adding or updating tests
-- `chore:` — maintenance tasks (dependencies, config, etc.)
-- `refactor:` — code restructuring without changing behavior
-- `perf:` — performance improvements
-- `style:` — formatting, whitespace, etc.
-
-### Examples
-
-```bash
-feat: add update_share function for collaborator management
-
-fix: validate transaction hash format in confirm endpoint
-
-docs: add usage examples to README
-
-test: add E2E tests for critical user flows
-
-chore: remove debug logs from backend
-```
+| Type       | When to use                                          |
+| ---------- | ---------------------------------------------------- |
+| `feat`     | New feature or user-facing enhancement               |
+| `fix`      | Bug fix                                              |
+| `docs`     | Documentation only                                   |
+| `test`     | Adding or updating tests                             |
+| `chore`    | Maintenance — deps, config, tooling                  |
+| `refactor` | Code restructuring with no behavior change           |
+| `perf`     | Performance improvement                              |
+| `style`    | Formatting, whitespace — no logic change             |
 
 ### Closing issues
 
-Reference issue numbers in commit messages to automatically close them:
+Add a `Closes` footer to automatically close the linked issue when the PR merges:
 
-```bash
-git commit -m "feat: add export and share to AdminDashboard
+```
+fix: validate distribute amount against contract balance
 
-Closes #147"
+Fetch contract balance before building the distribute tx so the
+frontend can reject amounts that exceed what the contract holds.
+
+Closes #78245
 ```
 
 ---
 
-## PR checklist
+## PR guidelines
 
-Before opening a PR, make sure:
+Before opening a PR:
 
 - [ ] `cargo test` passes with no failures
-- [ ] No console errors in the frontend or backend
-- [ ] Code follows the existing style (no new linting warnings)
-- [ ] New functions have comments explaining their purpose
-- [ ] The PR description references the related issue number
+- [ ] No new compiler warnings (`cargo build` is clean)
+- [ ] Frontend and backend start without console errors
+- [ ] New public contract functions have rustdoc comments (params, errors, auth)
+- [ ] New tests are included for any changed behavior
+- [ ] The PR description references the related issue number(s) with `Closes #N`
+- [ ] Branch is up to date with `main` (`git rebase origin/main`)
+
+Keep PRs focused. One issue per PR is preferred. If a fix naturally touches multiple related issues, bundle them and close all in the description.
+
+---
+
+## Windows auth guard caveat
+
+Some tests in the test suite use `require_auth()` checks that behave differently on Windows due to how the Soroban test environment handles mock authorizations.
+
+In `tests/integration_test.rs` you may see tests annotated with:
+
+```rust
+#[cfg(not(target_os = "windows"))]
+```
+
+These tests verify that unauthorized callers are correctly rejected. On Windows, the mock auth infrastructure in `soroban-sdk` can produce different panic behavior, causing the test to fail for the wrong reason or not panic at all.
+
+**If you are on Windows and a `#[should_panic]` auth test fails unexpectedly:**
+
+- This is a known tooling limitation, not a contract bug.
+- Run the full suite on Linux or macOS (or via WSL) to confirm correctness.
+- Do not remove the `#[cfg(not(target_os = "windows"))]` guard — it is intentional.
+- If you are adding a new auth rejection test, add the same cfg guard if you observe the same behavior.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,19 +31,32 @@ impl RoyaltySplitter {
 
     /// Initialize the contract with collaborators and their revenue shares.
     ///
+    /// Can only be called once. The first address in `collaborators` becomes
+    /// the admin and must authorize this transaction.
+    ///
     /// # Arguments
-    /// * `collaborators` - List of wallet addresses that will receive payouts
-    /// * `shares` - Corresponding basis-point allocations (must sum to 10,000)
+    /// * `collaborators` - Ordered list of wallet addresses that will receive payouts.
+    ///   The first address is designated as admin.
+    /// * `shares` - Basis-point allocations corresponding to each collaborator
+    ///   (1 bp = 0.01%). Must sum to exactly 10,000 (100%).
+    ///
+    /// # Authorization
+    /// Requires signature from `collaborators[0]` (the admin).
     ///
     /// # Panics
-    /// * If already initialized
-    /// * If shares don't sum to exactly 10,000 basis points (100%)
-    /// * If any share is zero or if there are duplicate addresses
+    /// * `"already initialized"` — contract has already been set up
+    /// * `"need at least one collaborator"` — empty collaborator list
+    /// * `"collaborators and shares length mismatch"` — vec lengths differ
+    /// * `"shares must sum to 10000"` — allocations don't total 100%
+    /// * `"share cannot be zero"` — any individual share is 0
+    /// * `"duplicate collaborator address"` — same address appears more than once
     pub fn initialize(
         env: Env,
         collaborators: Vec<Address>,
         shares: Vec<u32>,
     ) {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
@@ -96,10 +109,15 @@ impl RoyaltySplitter {
     /// Set the secondary royalty rate for resales.
     ///
     /// # Arguments
-    /// * `new_rate` - Royalty rate in basis points (e.g., 500 = 5%)
+    /// * `new_rate` - Royalty rate in basis points (0–10,000). 0 disables royalties;
+    ///   10,000 means 100% of the sale price goes to the royalty pool.
     ///
     /// # Authorization
-    /// Requires admin signature
+    /// Requires admin signature.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    /// * `"royalty rate cannot exceed 10000 basis points"` — `new_rate > 10_000`
     pub fn set_royalty_rate(env: Env, new_rate: u32) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -123,8 +141,16 @@ impl RoyaltySplitter {
         );
     }
 
-    /// Pause the contract — halts distribute and distribute_secondary_royalties.
-    /// Requires admin authorization.
+    /// Pause the contract — halts `distribute` and `distribute_secondary_royalties`.
+    ///
+    /// While paused, any call to `distribute` or `distribute_secondary_royalties`
+    /// will panic with `"contract is paused"`. Read-only functions are unaffected.
+    ///
+    /// # Authorization
+    /// Requires admin signature.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
     pub fn pause(env: Env) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -138,8 +164,13 @@ impl RoyaltySplitter {
         env.storage().instance().set(&DataKey::Paused, &true);
     }
 
-    /// Unpause the contract — re-enables distribute and distribute_secondary_royalties.
-    /// Requires admin authorization.
+    /// Unpause the contract — re-enables `distribute` and `distribute_secondary_royalties`.
+    ///
+    /// # Authorization
+    /// Requires admin signature.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
     pub fn unpause(env: Env) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -153,7 +184,8 @@ impl RoyaltySplitter {
         env.storage().instance().set(&DataKey::Paused, &false);
     }
 
-    /// Returns true if the contract is currently paused.
+    /// Returns `true` if the contract is currently paused, `false` otherwise.
+    /// Defaults to `false` before `pause` is ever called.
     pub fn is_paused(env: Env) -> bool {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage()
@@ -162,19 +194,28 @@ impl RoyaltySplitter {
             .unwrap_or(false)
     }
 
-    /// Returns true if the contract has been initialized.
+    /// Returns `true` if `initialize` has been called, `false` otherwise.
+    ///
+    /// Safe to call at any time — does not require initialization.
+    /// Extends TTL on every call so the storage entry stays live.
     pub fn is_initialized(env: Env) -> bool {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage().instance().has(&DataKey::Admin)
     }
 
-    /// Returns the contract's current balance of `token`.
+    /// Returns the contract's current on-chain balance of `token`.
+    ///
+    /// # Arguments
+    /// * `token` - The token contract address to query.
     pub fn get_balance(env: Env, token: Address) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
     }
 
-    /// Returns the contract's balance of a specific token.
+    /// Alias for `get_balance`. Returns the contract's on-chain balance of `token`.
+    ///
+    /// # Arguments
+    /// * `token` - The token contract address to query.
     pub fn get_token_balance(env: Env, token: Address) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
@@ -261,10 +302,19 @@ impl RoyaltySplitter {
             .set(&DataKey::LastDistribution, &env.ledger().timestamp());
     }
 
-    /// Record a secondary royalty payment from a resale.
+    /// Record a secondary royalty payment transferred from a resale.
+    ///
+    /// Pulls `royalty_amount` of `token` from `from` into the contract's
+    /// secondary pool via `transfer_from`. The caller must have pre-approved
+    /// the contract as a spender for at least `royalty_amount`.
+    ///
+    /// # Arguments
+    /// * `token` - Token used for the royalty payment.
+    /// * `from` - Address paying the royalty (typically the marketplace or buyer).
+    /// * `royalty_amount` - Amount in token's smallest unit (e.g., stroops for XLM).
     ///
     /// # Authorization
-    /// Requires signature from the `from` address
+    /// Requires signature from `from`.
     pub fn record_secondary_royalty(
         env: Env,
         token: Address,
@@ -298,8 +348,19 @@ impl RoyaltySplitter {
 
     /// Distribute all accumulated secondary royalties to collaborators.
     ///
+    /// Splits the entire secondary pool proportionally by basis-point shares.
+    /// Resets the pool to zero after distribution. The last collaborator absorbs
+    /// any integer-division dust (bounded by `n - 1` stroops).
+    ///
     /// # Authorization
-    /// Requires admin signature
+    /// Requires admin signature.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    /// * `"contract is paused"` — contract is currently paused
+    /// * `"no secondary royalties to distribute"` — pool is empty
+    /// * `"no secondary token set"` — no royalty has ever been recorded
+    /// * `"pool exceeds contract balance"` — pool accounting is inconsistent
     pub fn distribute_secondary_royalties(env: Env) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -383,7 +444,19 @@ impl RoyaltySplitter {
             .set(&DataKey::LastSecondaryDistribution, &env.ledger().timestamp());
     }
 
-    /// Calculate the royalty amount for a secondary sale.
+    /// Calculate and return the royalty amount for a given secondary sale price.
+    ///
+    /// This is a pure read function — it does not transfer tokens or modify state.
+    /// Use it to preview the royalty before calling `record_secondary_royalty`.
+    ///
+    /// # Arguments
+    /// * `sale_price` - The resale price in token's smallest unit (must be > 0).
+    ///
+    /// # Returns
+    /// `sale_price * royalty_rate / 10_000`. Returns 0 if no rate has been set.
+    ///
+    /// # Panics
+    /// * `"sale price must be positive"` — `sale_price <= 0`
     pub fn record_secondary_sale(env: Env, sale_price: i128) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -400,11 +473,18 @@ impl RoyaltySplitter {
         sale_price * rate as i128 / 10_000
     }
 
+    /// Returns the current secondary royalty rate in basis points (0–10,000).
+    /// Returns 0 if `set_royalty_rate` has never been called.
     pub fn get_royalty_rate(env: Env) -> u32 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage().instance().get(&DataKey::RoyaltyRate).unwrap_or(0)
     }
 
+    /// Returns the contract's semantic version string (set from `CARGO_PKG_VERSION`
+    /// at initialization time).
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
     pub fn version(env: Env) -> String {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage()
@@ -413,6 +493,14 @@ impl RoyaltySplitter {
             .expect("contract not initialized")
     }
 
+    /// Returns the basis-point share for a registered collaborator.
+    ///
+    /// # Arguments
+    /// * `collaborator` - Address to look up.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    /// * `"collaborator not found"` — address is not a registered collaborator
     pub fn get_share(env: Env, collaborator: Address) -> u32 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         let share_map: Map<Address, u32> = env
@@ -471,6 +559,11 @@ impl RoyaltySplitter {
     }
 
     /// Returns true if the given address is a registered collaborator.
+    ///
+    /// Safe to call before initialization — returns `false` rather than panicking.
+    ///
+    /// # Arguments
+    /// * `addr` - Address to check.
     pub fn is_collaborator(env: Env, addr: Address) -> bool {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         let share_map: Map<Address, u32> = env
@@ -482,7 +575,10 @@ impl RoyaltySplitter {
         share_map.contains_key(addr)
     }
 
+    /// Returns the number of registered collaborators.
+    /// Returns 0 if called before initialization.
     pub fn collaborator_count(env: Env) -> u32 {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         let collaborators: Vec<Address> = env
             .storage()
             .instance()
@@ -491,6 +587,8 @@ impl RoyaltySplitter {
         collaborators.len()
     }
 
+    /// Returns the ordered list of all registered collaborator addresses.
+    /// Returns an empty vec if called before initialization.
     pub fn get_collaborators(env: Env) -> Vec<Address> {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage()
@@ -508,6 +606,8 @@ impl RoyaltySplitter {
             .unwrap_or(Map::new(&env))
     }
 
+    /// Returns the current size of the secondary royalty pool (undistributed amount).
+    /// Returns 0 if no royalties have been recorded yet.
     pub fn get_secondary_pool(env: Env) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage().instance().get(&DataKey::SecondaryPool).unwrap_or(0)
@@ -525,7 +625,13 @@ impl RoyaltySplitter {
         env.storage().instance().get(&DataKey::LastSecondaryDistribution)
     }
 
-    /// Calculate the sum of all collaborator shares.
+    /// Returns the sum of all collaborator basis-point shares.
+    ///
+    /// Under normal operation this always returns 10,000. Useful for
+    /// pre-flight validation before calling `distribute`.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
     pub fn get_total_shares(env: Env) -> u32 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         let share_map: Map<Address, u32> = env

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -362,3 +362,47 @@ fn test_pause_requires_admin_auth() {
     env.mock_auths(&[]);
     client.pause();
 }
+
+// ── #224: royalty rate boundary values ──────────────────────────────────────
+
+/// Rate of 0 is valid (disables royalties).
+#[test]
+fn test_royalty_rate_boundary_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+
+    client.set_royalty_rate(&0_u32);
+    assert_eq!(client.get_royalty_rate(), 0);
+}
+
+/// Rate of 10,000 is valid (100% royalty).
+#[test]
+fn test_royalty_rate_boundary_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+
+    client.set_royalty_rate(&10_000_u32);
+    assert_eq!(client.get_royalty_rate(), 10_000);
+}
+
+/// Rate of 10,001 must be rejected with a descriptive error.
+#[test]
+#[should_panic(expected = "royalty rate cannot exceed 10000 basis points")]
+fn test_royalty_rate_above_max_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+
+    client.set_royalty_rate(&10_001_u32);
+}


### PR DESCRIPTION
Here's the PR description:

---

**docs/feat/test: rustdoc, TTL consistency, royalty rate boundary tests, CONTRIBUTING.md**

Closes #221
closes #224
closes #225 
closes #233

---

## Summary

Four improvements across the smart contract and project documentation. No breaking changes — all existing tests continue to pass.

---

## Changes

### #225 — Add inline rustdoc to all public contract functions

**Component:** `src/lib.rs`

Every public function was either undocumented or had minimal comments. All functions now have consistent rustdoc covering:

- What the function does
- `# Arguments` — each parameter with type context
- `# Returns` — return value and default/edge cases
- `# Authorization` — which address must sign (where applicable)
- `# Panics` — every panic message verbatim, so callers know exactly what to expect

Functions documented: `initialize`, `set_royalty_rate`, `pause`, `unpause`, `is_paused`, `is_initialized`, `get_balance`, `get_token_balance`, `distribute`, `record_secondary_royalty`, `distribute_secondary_royalties`, `record_secondary_sale`, `get_royalty_rate`, `version`, `get_share`, `update_share`, `is_collaborator`, `collaborator_count`, `get_collaborators`, `get_all_shares`, `get_secondary_pool`, `get_last_distribution`, `get_last_secondary_distribution`, `get_total_shares`.

---

### #221 — TTL extension on initialize and collaborator_count

**Component:** `src/lib.rs`

Two public functions were missing `extend_ttl(MIN_TTL, MAX_TTL)` on entry:

- `initialize` — the most critical call; storage written here must survive long enough for subsequent reads
- `collaborator_count` — a read function that was inconsistent with every other read function in the contract

Both now call `extend_ttl` as the first statement, consistent with the rest of the contract. `is_initialized` already had TTL extension and is confirmed correct per the issue scope.

---

### #224 — Royalty rate boundary value tests

**Component:** `tests/integration_test.rs`

Three new tests covering the full boundary surface of `set_royalty_rate`:

- `test_royalty_rate_boundary_zero` — rate of `0` is accepted (disables royalties); asserts `get_royalty_rate()` returns `0`
- `test_royalty_rate_boundary_max` — rate of `10_000` is accepted (100%); asserts `get_royalty_rate()` returns `10_000`
- `test_royalty_rate_above_max_rejected` — rate of `10_001` panics with `"royalty rate cannot exceed 10000 basis points"`; uses `#[should_panic(expected = "...")]` to pin the exact message

---

### #233 — CONTRIBUTING.md with full setup and contribution guidelines

**Component:** `CONTRIBUTING.md`

The previous CONTRIBUTING.md was minimal. The new version covers:

- Prerequisites with install commands — Rust + rustup, wasm32 target, Soroban CLI, Node.js 18+
- Fork and clone steps
- Smart contract build instructions
- Backend setup — `.env` copy, `npm install`, dev server
- Frontend setup — `npm install`, dev server, Vite proxy note
- All `cargo test` variants — full suite, `--lib` only, `--test integration_test`, single test by name, `-- --nocapture`
- Backend and frontend test commands
- Branch naming table with type prefixes and examples
- Conventional Commits standard with type reference table and closing-issue footer examples
- PR checklist — tests, warnings, docs, issue references, rebase
- Windows auth guard caveat explaining the `#[cfg(not(target_os = "windows"))]` pattern, why it exists, and what to do when a `#[should_panic]` auth test fails unexpectedly on Windows

---

## Testing

`cargo test` — all existing tests pass, three new boundary tests added for `#224`. No contract behavior was changed.