### PR TITLE
fix: dynamic network detection, distribute integration tests, unautho…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,11 +4,22 @@ PORT=3001
 # DATABASE_PATH — path to the SQLite database file (default: ../audit.db relative to src/)
 DATABASE_PATH=./audit.db
 
-# STELLAR_NETWORK — testnet or mainnet
+# STELLAR_NETWORK — target network for the deploy script and backend RPC client
+# Accepted values: testnet | mainnet
+# Testnet (default):
 STELLAR_NETWORK=testnet
+# Mainnet:
+# STELLAR_NETWORK=mainnet
+
+# STELLAR_IDENTITY — Stellar CLI key identity used by deploy.sh to sign the deploy tx
+# Create with: stellar keys generate --global <name> --network <network>
+STELLAR_IDENTITY=deployer
 
 # SOROBAN_RPC_URL — Soroban RPC endpoint for smart contract interactions
+# Testnet (default):
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# Mainnet:
+# SOROBAN_RPC_URL=https://soroban-mainnet.stellar.org
 # Server-side signing key (only used for read-only simulation; real txs are signed client-side)
 SERVER_SECRET_KEY=S...
 
@@ -23,7 +34,10 @@ RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX=100
 
 # HORIZON_URL — Horizon REST API endpoint for account and transaction queries
+# Testnet (default):
 HORIZON_URL=https://horizon-testnet.stellar.org
+# Mainnet:
+# HORIZON_URL=https://horizon.stellar.org
 
 # FRONTEND_ORIGIN — allowed CORS origin (your frontend URL)
 FRONTEND_ORIGIN=http://localhost:5173

--- a/backend/tests/distribute.integration.test.js
+++ b/backend/tests/distribute.integration.test.js
@@ -1,0 +1,217 @@
+﻿import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import request from "supertest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const retryBuildTx = jest.fn();
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  retryBuildTx,
+  isContractInitialized: jest.fn(),
+  addressToScVal: jest.fn((a) => a),
+  u32ToScVal: jest.fn((n) => n),
+  vecToScVal: jest.fn((v) => v),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+const recordTransaction = jest.fn(() => "tx-integration-001");
+const addAuditLog = jest.fn();
+
+await jest.unstable_mockModule("../src/database.js", () => ({
+  recordTransaction,
+  addAuditLog,
+  initializeDatabase: jest.fn(),
+  getMigrationVersion: jest.fn(() => 1),
+}));
+
+const { default: app } = await import("./app.js");
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN    = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+const validBody = { contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN };
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+
+describe("POST /api/v1/distribute — integration", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  test("happy path — returns xdr and transactionId", async () => {
+    retryBuildTx.mockResolvedValue("signed-xdr-payload");
+    recordTransaction.mockReturnValue("tx-integration-001");
+
+    const res = await request(app).post("/api/v1/distribute").send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      xdr: "signed-xdr-payload",
+      transactionId: "tx-integration-001",
+    });
+    expect(retryBuildTx).toHaveBeenCalledTimes(1);
+    expect(recordTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Insufficient funds (RPC simulation failure) ─────────────────────────────
+
+  test("503 when Stellar RPC reports insufficient funds / unavailable", async () => {
+    retryBuildTx.mockRejectedValue({
+      status: 503,
+      message: "Stellar RPC is currently unavailable. Please try again later.",
+    });
+
+    const res = await request(app).post("/api/v1/distribute").send(validBody);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/unavailable/i);
+  });
+
+  // ── Invalid admin auth ──────────────────────────────────────────────────────
+  // The backend builds unsigned XDR; admin auth is enforced by the smart contract
+  // on submission. A missing or malformed walletAddress is the server-side
+  // equivalent of an invalid caller identity.
+
+  test("400 when walletAddress is missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ contractId: CONTRACT, tokenId: TOKEN });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/validation/i);
+  });
+
+  test("400 when walletAddress is not a valid Stellar address", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ ...validBody, walletAddress: "NOT-A-VALID-ADDRESS" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "walletAddress" }),
+      ])
+    );
+  });
+
+  test("400 when walletAddress is a contract address (starts with C, not G)", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ ...validBody, walletAddress: CONTRACT });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "walletAddress" }),
+      ])
+    );
+  });
+
+  // ── Malformed recipient list / body ─────────────────────────────────────────
+
+  test("400 when contractId is missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ walletAddress: WALLET, tokenId: TOKEN });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "contractId" }),
+      ])
+    );
+  });
+
+  test("400 when tokenId is missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ contractId: CONTRACT, walletAddress: WALLET });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "tokenId" }),
+      ])
+    );
+  });
+
+  test("400 when tokenId is not a valid contract address", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ ...validBody, tokenId: "not-a-contract-id" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "tokenId" }),
+      ])
+    );
+  });
+
+  test("400 when tokenId is an account address (starts with G, not C)", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ ...validBody, tokenId: WALLET });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "tokenId" }),
+      ])
+    );
+  });
+
+  test("400 when contractId is malformed", async () => {
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send({ ...validBody, contractId: "INVALID" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "contractId" }),
+      ])
+    );
+  });
+
+  test("400 when body is completely empty", async () => {
+    const res = await request(app).post("/api/v1/distribute").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.details.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Audit trail ─────────────────────────────────────────────────────────────
+
+  test("records transaction and audit log on success", async () => {
+    retryBuildTx.mockResolvedValue("xdr-payload");
+    recordTransaction.mockReturnValue("tx-audit-check");
+
+    await request(app).post("/api/v1/distribute").send(validBody);
+
+    expect(recordTransaction).toHaveBeenCalledWith(
+      CONTRACT,
+      "distribute",
+      WALLET,
+      expect.objectContaining({ tokenId: TOKEN })
+    );
+    expect(addAuditLog).toHaveBeenCalledWith(
+      CONTRACT,
+      "distribution_initiated",
+      WALLET,
+      expect.objectContaining({ transactionId: "tx-audit-check" })
+    );
+  });
+
+  test("does not call retryBuildTx when validation fails", async () => {
+    await request(app)
+      .post("/api/v1/distribute")
+      .send({ contractId: "BAD", walletAddress: WALLET, tokenId: TOKEN });
+
+    expect(retryBuildTx).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,6 @@
 # VITE_STELLAR_NETWORK — default network shown on first load (testnet | mainnet)
 # Users can toggle the network in the UI; this only sets the initial value.
+# Testnet (default):
 VITE_STELLAR_NETWORK=testnet
+# Mainnet:
+# VITE_STELLAR_NETWORK=mainnet

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,20 +1,41 @@
 #!/usr/bin/env bash
-# deploy.sh — Build and deploy the Stellar Royalty Splitter to Stellar Testnet
+# deploy.sh — Build and deploy the Stellar Royalty Splitter to a Stellar network
 #
 # Prerequisites:
 #   - Rust + wasm32-unknown-unknown target  (rustup target add wasm32-unknown-unknown)
 #   - Stellar CLI                           (cargo install --locked stellar-cli)
-#   - A funded testnet identity             (stellar keys generate --global deployer)
+#   - A funded identity                     (stellar keys generate --global deployer)
+#
+# Environment variables (override defaults via shell or .env):
+#   STELLAR_NETWORK   — target network: "testnet" (default) or "mainnet"
+#   STELLAR_IDENTITY  — signing identity name (default: "deployer")
 #
 # Usage:
 #   chmod +x scripts/deploy.sh
 #   ./scripts/deploy.sh
+#
+# Testnet example:
+#   STELLAR_NETWORK=testnet STELLAR_IDENTITY=deployer ./scripts/deploy.sh
+#
+# Mainnet example:
+#   STELLAR_NETWORK=mainnet STELLAR_IDENTITY=my-mainnet-key ./scripts/deploy.sh
 
 set -euo pipefail
 
-NETWORK="testnet"
-IDENTITY="deployer"
+# ── Network configuration ────────────────────────────────────────────────────
+# Load from environment; fall back to safe testnet defaults.
+NETWORK="${STELLAR_NETWORK:-testnet}"
+IDENTITY="${STELLAR_IDENTITY:-deployer}"
 CONTRACT_NAME="stellar_royalty_splitter"
+
+# Validate network value
+if [[ "$NETWORK" != "testnet" && "$NETWORK" != "mainnet" ]]; then
+  echo "❌ STELLAR_NETWORK must be 'testnet' or 'mainnet' (got: '$NETWORK')"
+  exit 1
+fi
+
+echo "▶ Target network : $NETWORK"
+echo "▶ Signing identity: $IDENTITY"
 
 # ── Preflight checks ────────────────────────────────────────────────────────
 
@@ -31,7 +52,11 @@ command -v stellar >/dev/null 2>&1 || {
 if ! stellar keys show "$IDENTITY" >/dev/null 2>&1; then
   echo "⚠️  Identity '$IDENTITY' not found."
   echo "   Run: stellar keys generate --global $IDENTITY --network $NETWORK"
-  echo "   Then fund it: https://friendbot.stellar.org/?addr=\$(stellar keys address $IDENTITY)"
+  if [[ "$NETWORK" == "testnet" ]]; then
+    echo "   Then fund it: https://friendbot.stellar.org/?addr=\$(stellar keys address $IDENTITY)"
+  else
+    echo "   Fund the mainnet address before deploying."
+  fi
   exit 1
 fi
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -406,3 +406,63 @@ fn test_royalty_rate_above_max_rejected() {
 
     client.set_royalty_rate(&10_001_u32);
 }
+
+// ── Issue #219: unauthorized caller for set_royalty_rate ─────────────────────
+
+/// A non-admin address calling set_royalty_rate must panic.
+/// Does NOT use mock_all_auths() — simulates a real unauthorized caller.
+/// Pattern mirrors test_pause_requires_admin_auth.
+#[test]
+#[should_panic]
+fn test_set_royalty_rate_unauthorized_caller() {
+    let env = Env::default();
+
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    // Initialize with mock_all_auths so setup succeeds
+    env.mock_all_auths();
+    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+
+    // Clear all auths — the next call has no authorization at all,
+    // simulating a non-admin (or any unauthorized) caller.
+    env.mock_auths(&[]);
+
+    // Must panic: require_auth() on admin will fail
+    client.set_royalty_rate(&500_u32);
+}
+
+// ── Issue #220: unauthorized caller for distribute ───────────────────────────
+
+/// Calling distribute without admin auth must be rejected atomically.
+/// No token transfers should occur and the contract balance must remain unchanged.
+/// Does NOT use mock_all_auths() for the distribute call.
+#[test]
+#[should_panic]
+fn test_distribute_unauthorized_caller() {
+    let env = Env::default();
+
+    let (contract_id, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    // Initialize and fund the contract
+    env.mock_all_auths();
+    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+
+    let amount: i128 = 1_000;
+    mint(&env, &token, &contract_id, amount);
+
+    // Verify the contract has the expected balance before the unauthorized call
+    assert_eq!(TokenClient::new(&env, &token).balance(&contract_id), amount);
+
+    // Clear all auths — simulate a non-admin caller with no authorization
+    env.mock_auths(&[]);
+
+    // Must panic: require_auth() on admin will reject this call before any
+    // token transfers occur, leaving the contract balance unchanged.
+    client.distribute(&token);
+}


### PR DESCRIPTION


Closes #219
closes #220 
closes  #222 
closes #229 

 #222 - Replace hardcoded network passphrase with live network detection
- scripts/deploy.sh: read STELLAR_NETWORK and STELLAR_IDENTITY from env
  with safe testnet/deployer defaults; add validation guard for unknown
  network values; make friendbot hint conditional on testnet only
- backend/.env.example: document STELLAR_IDENTITY, add mainnet variants
  for STELLAR_NETWORK, SOROBAN_RPC_URL, and HORIZON_URL
- frontend/.env.example: add mainnet comment variant for VITE_STELLAR_NETWORK

## #229 - Add integration tests for distribute endpoint
- backend/tests/distribute.integration.test.js: 12 integration tests
  covering happy path, 503 on RPC/insufficient-funds failure, 400 for
  missing/invalid walletAddress (invalid admin auth), 400 for all
  malformed body scenarios, and audit trail verification

## #220 - Add unauthorized caller test for distribute
- tests/integration_test.rs: test_distribute_unauthorized_caller()
  initializes and funds the contract, clears mock_auths, then calls
  distribute — must panic before any token transfers occur

## #219 - Add unauthorized caller test for set_royalty_rate
- tests/integration_test.rs: test_set_royalty_rate_unauthorized_caller()
  initializes contract, clears mock_auths, then calls set_royalty_rate
  with no authorization — must panic; does not rely on mock_all_auths()"