### PR TITLE
Fix issues #236, #242, #250, and #253

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,39 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "start": "node src/index.js",
     "lint": "eslint src/**/*.js",
     "format": "prettier --write src/**/*.js",
-    "test": "echo \"No tests yet — see open issues\" && exit 0",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --testPathPatterns=tests/",
     "test:backend": "node --experimental-vm-modules node_modules/.bin/jest --testPathPatterns=tests/"
   },
   "jest": {

--- a/backend/tests/collaborators.test.js
+++ b/backend/tests/collaborators.test.js
@@ -36,7 +36,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   vecToScVal: jest.fn((v) => v),
 }));
 
-await jest.unstable_mockModule("../src/database.js", () => ({
+await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction: jest.fn(() => "tx-789"),
   addAuditLog: jest.fn(),
   initializeDatabase: jest.fn(),
@@ -54,18 +54,28 @@ describe("GET /api/v1/collaborators/:contractId", () => {
   });
 
   test("happy path — returns collaborators with basisPoints", async () => {
-    mockSimulate
-      .mockResolvedValueOnce({ result: { retval: { vec: () => [COLLAB1, COLLAB2] } } })
-      .mockResolvedValueOnce({ result: { retval: { bool: () => true } } })
-      .mockResolvedValueOnce({ result: { retval: { u32: () => 5000 } } })
-      .mockResolvedValueOnce({ result: { retval: { bool: () => true } } })
-      .mockResolvedValueOnce({ result: { retval: { u32: () => 5000 } } });
+    const makeEntry = (address, share) => ({
+      key: () => address,
+      val: () => ({ u32: () => share }),
+    });
+
+    mockSimulate.mockResolvedValueOnce({
+      result: {
+        retval: {
+          map: () => ({
+            entries: [makeEntry(COLLAB1, 5000), makeEntry(COLLAB2, 5000)],
+          }),
+        },
+      },
+    });
 
     const res = await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
 
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBe(2);
+    expect(res.body[0]).toMatchObject({ address: COLLAB1, basisPoints: 5000 });
+    expect(res.body[1]).toMatchObject({ address: COLLAB2, basisPoints: 5000 });
   });
 
   test("returns empty array when contract has no collaborators", async () => {

--- a/backend/tests/distribute.integration.test.js
+++ b/backend/tests/distribute.integration.test.js
@@ -18,7 +18,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 const recordTransaction = jest.fn(() => "tx-integration-001");
 const addAuditLog = jest.fn();
 
-await jest.unstable_mockModule("../src/database.js", () => ({
+await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog,
   initializeDatabase: jest.fn(),

--- a/backend/tests/distribute.test.js
+++ b/backend/tests/distribute.test.js
@@ -15,7 +15,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 
 const recordTransaction = jest.fn(() => "tx-456");
 
-await jest.unstable_mockModule("../src/database.js", () => ({
+await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog: jest.fn(),
   initializeDatabase: jest.fn(),

--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -18,7 +18,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 const recordTransaction = jest.fn(() => "tx-123");
 const addAuditLog = jest.fn();
 
-await jest.unstable_mockModule("../src/database.js", () => ({
+await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog,
   initializeDatabase: jest.fn(),

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -61,6 +61,17 @@
   background-clip: text;
 }
 
+.contract-input-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.contract-input-row .contract-input {
+  flex: 1;
+  min-width: 0;
+}
+
 .contract-input {
   width: 100%;
   padding: var(--spacing-sm);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import RecordSecondarySale from "./components/RecordSecondarySale";
 import DistributeSecondaryRoyalties from "./components/DistributeSecondaryRoyalties";
 import ResaleHistory from "./components/ResaleHistory";
 import { Skeleton } from "./components/Skeleton";
+import { CopyButton } from "./components/CopyButton";
 import { api } from "./api";
 
 
@@ -277,13 +278,18 @@ export default function App() {
 
           <div className="sidebar-card">
             <h3>📋 Contract ID</h3>
-            <input
-              ref={contractInputRef}
-              className={`contract-input${contractIdError ? " contract-input--error" : ""}`}
-              placeholder="C..."
-              value={contractId}
-              onChange={(e) => handleContractChange(e.target.value)}
-            />
+            <div className="contract-input-row">
+              <input
+                ref={contractInputRef}
+                className={`contract-input${contractIdError ? " contract-input--error" : ""}`}
+                placeholder="C..."
+                value={contractId}
+                onChange={(e) => handleContractChange(e.target.value)}
+              />
+              {contractIdValid && (
+                <CopyButton value={contractId} label="contract ID" size="sm" />
+              )}
+            </div>
             {contractIdError && (
               <p className="contract-input-error">{contractIdError}</p>
             )}

--- a/frontend/src/components/AdminDashboard.css
+++ b/frontend/src/components/AdminDashboard.css
@@ -360,6 +360,11 @@
   color: var(--error-dark);
 }
 
+.detail-row.tx-hash-row {
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .detail-row .tx-hash {
   cursor: pointer;
   color: var(--accent-primary);

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { api, TransactionRecord } from "../api";
 import { QRCodeSVG } from "qrcode.react";
+import { CopyButton } from "./CopyButton";
 import "./AdminDashboard.css";
 
 interface AdminDashboardProps {
@@ -12,7 +13,6 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
 }) => {
   const [showModal, setShowModal] = useState(false);
   const [showQRModal, setShowQRModal] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [shareLinkCopied, setShareLinkCopied] = useState(false);
   const [initHistory, setInitHistory] = useState<TransactionRecord[]>([]);
   const [loading, setLoading] = useState(false);
@@ -56,12 +56,6 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
         setContractVersion("unknown");
       }
     }
-  };
-
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(contractId);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
 
   const exportContractInfo = () => {
@@ -127,13 +121,7 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
           <div className="contract-id-label">Contract ID</div>
           <div className="contract-id-value">
             <code>{contractId}</code>
-            <button
-              className={`copy-btn ${copied ? "copied" : ""}`}
-              onClick={copyToClipboard}
-              title="Copy to clipboard"
-            >
-              {copied ? "✓ Copied" : "📋 Copy"}
-            </button>
+            <CopyButton value={contractId} label="contract ID" />
           </div>
         </div>
 
@@ -209,11 +197,16 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
                     </span>
                   </div>
                   {record.txHash && (
-                    <div className="detail-row">
+                    <div className="detail-row tx-hash-row">
                       <span className="label">TX Hash:</span>
                       <code className="value tx-hash">
                         {record.txHash.slice(0, 16)}...
                       </code>
+                      <CopyButton
+                        value={record.txHash}
+                        label="transaction hash"
+                        size="sm"
+                      />
                     </div>
                   )}
                 </div>
@@ -244,9 +237,7 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
                 <h3>Contract ID</h3>
                 <div className="contract-info-block">
                   <code>{contractId}</code>
-                  <button onClick={copyToClipboard} className="copy-modal-btn">
-                    📋 Copy
-                  </button>
+                  <CopyButton value={contractId} label="contract ID" size="sm" />
                 </div>
               </div>
 

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,46 @@
+import { useState, useCallback } from "react";
+
+interface CopyButtonProps {
+  value: string;
+  label?: string;
+  className?: string;
+  size?: "sm" | "md";
+}
+
+export function CopyButton({
+  value,
+  label = "Copy",
+  className = "",
+  size = "md",
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!value) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        setCopied(false);
+      }
+    },
+    [value],
+  );
+
+  const sizeClass = size === "sm" ? "copy-btn-sm" : "copy-btn";
+
+  return (
+    <button
+      type="button"
+      className={`${sizeClass} ${copied ? "copied" : ""} ${className}`.trim()}
+      onClick={handleCopy}
+      aria-label={copied ? "Copied to clipboard" : `Copy ${label}`}
+      title={copied ? "Copied" : `Copy ${label}`}
+    >
+      {copied ? "✓ Copied" : "📋 Copy"}
+    </button>
+  );
+}

--- a/frontend/src/components/Settings.css
+++ b/frontend/src/components/Settings.css
@@ -21,6 +21,13 @@
   font-size: 0.95rem;
 }
 
+.settings-contract-id {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .save-status {
   background: #c6f6d5;
   border: 1px solid #9ae6b4;

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTheme } from "../context/ThemeContext";
 import { useSettings, SettingsType } from "../context/SettingsContext";
 
+import { CopyButton } from "./CopyButton";
 import "./Settings.css";
 
 interface SettingsProps {
@@ -61,8 +62,11 @@ export const Settings: React.FC<SettingsProps> = ({ contractId, onClearContract 
     <div className="settings">
       <div className="settings-header">
         <h1>⚙️ Settings</h1>
-        <p className="settings-subtitle">
-          Contract ID: {contractId || "Not connected"}
+        <p className="settings-subtitle settings-contract-id">
+          <span>Contract ID: {contractId || "Not connected"}</span>
+          {contractId && (
+            <CopyButton value={contractId} label="contract ID" size="sm" />
+          )}
         </p>
       </div>
 

--- a/frontend/src/components/TransactionHistory.css
+++ b/frontend/src/components/TransactionHistory.css
@@ -117,15 +117,15 @@
 }
 
 .tx-hash-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-family: "Monaco", "Courier New", monospace;
   font-size: 12px;
-  cursor: pointer;
-  color: #3b82f6;
-  text-decoration: underline;
 }
 
-.tx-hash-cell:hover {
-  color: #2563eb;
+.tx-hash-text {
+  color: #3b82f6;
 }
 
 .status-badge {

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { api, TransactionRecord, TransactionDetails } from "../api";
 import "./TransactionHistory.css";
 import { formatNumber } from "../utils/format";
+import { CopyButton } from "./CopyButton";
 
 interface TransactionHistoryProps {
   contractId: string;
@@ -17,7 +18,6 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const [total, setTotal] = useState(0);
   const [selected, setSelected] = useState<TransactionDetails | null>(null);
   const [modalLoading, setModalLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
   const LIMIT = 10;
 
   const fetchHistory = async () => {
@@ -55,13 +55,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
     }
   };
 
-  const closeModal = () => { setSelected(null); setCopied(false); };
-
-  const copyHash = async (hash: string) => {
-    await navigator.clipboard.writeText(hash);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const closeModal = () => { setSelected(null); };
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -122,7 +116,19 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                     <td><span className="tx-type">{tx.type}</span></td>
                     <td title={tx.initiatorAddress}>{truncateAddress(tx.initiatorAddress)}</td>
                     <td>{tx.requestedAmount ? formatNumber(tx.requestedAmount) : "—"}</td>
-                    <td className="tx-hash-cell">{truncateHash(tx.txHash)}</td>
+                    <td
+                      className="tx-hash-cell"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <span className="tx-hash-text">{truncateHash(tx.txHash)}</span>
+                      {tx.txHash && (
+                        <CopyButton
+                          value={tx.txHash}
+                          label="transaction hash"
+                          size="sm"
+                        />
+                      )}
+                    </td>
                     <td>
                       <span
                         className="status-badge"
@@ -193,13 +199,11 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                 <span className="tx-detail-hash">
                   <span className="tx-detail-mono">{selected.txHash ?? "Pending"}</span>
                   {selected.txHash && (
-                    <button
-                      className="tx-copy-btn"
-                      onClick={() => copyHash(selected.txHash!)}
-                      aria-label="Copy transaction hash"
-                    >
-                      {copied ? "✓ Copied" : "Copy"}
-                    </button>
+                    <CopyButton
+                      value={selected.txHash}
+                      label="transaction hash"
+                      size="sm"
+                    />
                   )}
                 </span>
               </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -221,6 +221,12 @@ td:last-child {
   color: var(--accent-primary);
 }
 
+.copy-btn.copied,
+.copy-btn-sm.copied {
+  border-color: var(--success-color, #22c55e);
+  color: var(--success-color, #22c55e);
+}
+
 .wallet-row {
   display: flex;
   justify-content: space-between;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,36 @@ impl RoyaltySplitter {
         env.storage().instance().set(&DataKey::Paused, &true);
     }
 
+    /// Transfer admin rights to a new address.
+    ///
+    /// # Arguments
+    /// * `new_admin` - Address that will become the contract admin.
+    ///
+    /// # Authorization
+    /// Requires signature from the current admin.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    pub fn admin_transfer(env: Env, new_admin: Address) {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+
+        admin.require_auth();
+
+        let previous_admin = admin.clone();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        env.events().publish(
+            (symbol_short!("royalty"), symbol_short!("admin_xfr")),
+            (previous_admin, new_admin),
+        );
+    }
+
     /// Unpause the contract — re-enables `distribute` and `distribute_secondary_royalties`.
     ///
     /// # Authorization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,9 @@ impl RoyaltySplitter {
     ///
     /// # Authorization
     /// Requires admin signature
+    ///
+    /// # Panics
+    /// * `"recipients list cannot be empty"` — no collaborators are configured
     pub fn distribute(env: Env, token: Address) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -259,6 +262,16 @@ impl RoyaltySplitter {
             panic!("contract is paused");
         }
 
+        let collaborators: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Collaborators)
+            .expect("no collaborators");
+
+        if collaborators.is_empty() {
+            panic!("recipients list cannot be empty");
+        }
+
         if Self::get_total_shares(env.clone()) != 10_000 {
             panic!("total shares must sum to 10000");
         }
@@ -268,12 +281,6 @@ impl RoyaltySplitter {
         if amount == 0 {
             panic!("no balance to distribute");
         }
-
-        let collaborators: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::Collaborators)
-            .expect("no collaborators");
 
         let share_map: Map<Address, u32> = env
             .storage()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     token::{Client as TokenClient, StellarAssetClient},
     vec, Address, Env, IntoVal, Vec as SorobanVec,
 };
-use stellar_royalty_splitter::RoyaltySplitterClient;
+use stellar_royalty_splitter::{DataKey, RoyaltySplitterClient};
 
 fn setup(env: &Env) -> (Address, RoyaltySplitterClient) {
     let contract_id = env.register_contract(None, stellar_royalty_splitter::RoyaltySplitter);
@@ -659,4 +659,35 @@ fn test_distribute_secondary_fuzz_style() {
         );
         assert_eq!(client.get_secondary_pool(), 0, "Secondary pool must be zero after distribution");
     }
+}
+
+// ── Issue #236: empty recipients guard on distribute ─────────────────────────
+
+/// Calling distribute with an empty collaborators list must panic before transfers.
+#[test]
+#[should_panic(expected = "recipients list cannot be empty")]
+fn test_distribute_empty_recipients_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    mint(&env, &token, &contract_id, 1000);
+
+    let empty_collaborators: SorobanVec<Address> = vec![&env];
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::Collaborators, &empty_collaborators);
+    });
+
+    client.distribute(&token);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -661,6 +661,96 @@ fn test_distribute_secondary_fuzz_style() {
     }
 }
 
+// ── Issue #242: admin_transfer ───────────────────────────────────────────────
+
+fn read_admin(env: &Env, contract_id: &Address) -> Address {
+    env.as_contract(contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("admin not set")
+    })
+}
+
+#[test]
+fn test_admin_transfer_updates_admin() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "admin_transfer",
+            args: (&new_admin,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.admin_transfer(&new_admin);
+
+    assert_eq!(read_admin(&env, &contract_id), new_admin);
+}
+
+#[test]
+fn test_admin_transfer_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    client.admin_transfer(&new_admin);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("admin_xfr").into_val(&env),
+                ]
+            && data == (admin, new_admin).into_val(&env)
+    });
+    assert!(found, "admin_xfr event not emitted");
+}
+
+#[test]
+#[should_panic]
+fn test_admin_transfer_requires_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(
+        &vec![&env, admin, b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // No mock auths for admin_transfer — must panic on require_auth
+    client.admin_transfer(&new_admin);
+}
+
 // ── Issue #236: empty recipients guard on distribute ─────────────────────────
 
 /// Calling distribute with an empty collaborators list must panic before transfers.


### PR DESCRIPTION
## Summary

- **#236**: Reject `distribute` when the stored collaborators list is empty, before balance reads or token transfers.
- **#242**: Add `admin_transfer` so the current admin can hand off ownership in one authorized call, with an on-chain event.
- **#250**: Add reusable copy-to-clipboard controls for contract IDs and transaction hashes with success feedback.
- **#253**: Add backend GitHub Actions CI on PRs to `main` running `npm test` (Node 20.x / 22.x) and wire the default test script to the Jest suite.

## Verification

- Backend: `cd backend && npm ci && npm test` (28 tests passing).
- Contract changes include integration tests for empty-recipient guard and `admin_transfer` (auth, storage, events).
- Frontend copy buttons use shared `CopyButton` with ARIA labels; contract ID copy in sidebar, settings, and admin views; transaction hash copy in history table and detail modal.

Closes #236
Closes #242
Closes #250
Closes #253

Made with [Cursor](https://cursor.com)