### PR TITLE
fix: validate share totals at distribute and add operator health endp…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,13 @@ PORT=3001
 # DATABASE_PATH — path to the SQLite database file (default: ../audit.db relative to src/)
 DATABASE_PATH=./audit.db
 
+# ROYALTY_CONTRACT_ID — default Soroban contract ID for /health and operator tooling
+# (also accepts CONTRACT_ID). Set after deploy.sh writes .contract-id.
+# ROYALTY_CONTRACT_ID=C...
+
+# HEALTH_CACHE_TTL_MS — cache duration for /api/v1/health responses (default: 30000)
+# HEALTH_CHECK_TIMEOUT_MS — Horizon probe timeout in ms (default: 5000)
+
 # STELLAR_NETWORK — target network for the deploy script and backend RPC client
 # Accepted values: testnet | mainnet
 # Testnet (default):

--- a/backend/API.md
+++ b/backend/API.md
@@ -1,0 +1,98 @@
+# Stellar Royalty Splitter — HTTP API
+
+Base URL: `http://localhost:3001` (default)
+
+All JSON POST bodies must use `Content-Type: application/json`.
+
+## Health
+
+### `GET /api/v1/health`
+
+Operator health check for the backend and Stellar connectivity.
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "dbVersion": 2,
+  "network": "Testnet",
+  "horizon": {
+    "connected": true,
+    "url": "https://horizon-testnet.stellar.org"
+  },
+  "contract": {
+    "configured": true,
+    "contractId": "C...",
+    "deployed": true,
+    "initialized": true,
+    "status": "initialized"
+  }
+}
+```
+
+| Field | Description |
+| ----- | ----------- |
+| `ok` | `true` when Horizon is reachable and any configured contract is healthy |
+| `dbVersion` | SQLite schema migration version |
+| `network` | `Testnet` or `Mainnet` (from `STELLAR_NETWORK`) |
+| `horizon.connected` | Whether Horizon responded successfully |
+| `horizon.url` | Configured `HORIZON_URL` |
+| `contract.status` | `not_configured`, `deployed`, `initialized`, `unreachable`, or `error` |
+
+Configure the default contract with `ROYALTY_CONTRACT_ID` or `CONTRACT_ID`. Responses are cached for `HEALTH_CACHE_TTL_MS` (default 30s).
+
+Legacy `/api/*` paths redirect to `/api/v1/*`.
+
+## Initialize
+
+### `POST /api/v1/initialize`
+
+Build an unsigned `initialize` transaction XDR.
+
+**Body:** `{ contractId, walletAddress, collaborators, shares }`
+
+**Response:** `{ xdr, transactionId }`
+
+## Distribute
+
+### `POST /api/v1/distribute`
+
+Build an unsigned `distribute` transaction XDR.
+
+**Body:** `{ contractId, walletAddress, tokenId }`
+
+**Response:** `{ xdr, transactionId }`
+
+## Collaborators
+
+### `GET /api/v1/collaborators/:contractId`
+
+Returns on-chain collaborator addresses and shares.
+
+## Contract
+
+### `GET /api/v1/contract/status/:contractId`
+
+**Response:** `{ initialized: boolean }`
+
+### `GET /api/v1/contract/balance/:contractId?tokenId=...`
+
+**Response:** `{ balance: string }`
+
+### `GET /api/v1/contract/collaborator-count/:contractId`
+
+**Response:** `{ contractId, count }`
+
+### `GET /api/v1/contract/shares-total/:contractId`
+
+**Response:** `{ contractId, totalShares }`
+
+## Secondary royalty
+
+See route module `src/routes/secondary-royalty.js` for pool, sales, and distribution endpoints.
+
+## History & analytics
+
+- `GET /api/v1/history/:contractId`
+- `GET /api/v1/analytics/:contractId`

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,7 +13,8 @@ import { secondaryRoyaltyRouter } from "./routes/secondary-royalty.js";
 import historyRouter from "./routes/history.js";
 import { analyticsRouter } from "./routes/analytics.js";
 import { contractRouter } from "./routes/contract.js";
-import { initializeDatabase, getMigrationVersion } from "./database/index.js";
+import { healthRouter } from "./routes/health.js";
+import { initializeDatabase } from "./database/index.js";
 import db from "./database/index.js";
 
 // Initialize database on startup
@@ -57,7 +58,7 @@ const generalLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, please try again later." },
-  skip: (req) => req.path === "/api/health",
+  skip: (req) => req.path === "/api/v1/health" || req.path === "/api/health",
 });
 
 // Write limiter: 10 req / 1 min per IP
@@ -105,9 +106,7 @@ app.use("/api/v1/secondary-royalty", secondaryRoyaltyRouter);
 app.use("/api/v1", historyRouter);
 app.use("/api/v1", analyticsRouter);
 app.use("/api/v1/contract", contractRouter);
-
-// Health check
-app.get("/api/v1/health", (_req, res) => res.json({ ok: true, dbVersion: getMigrationVersion() }));
+app.use("/api/v1/health", healthRouter);
 
 // Legacy /api/* redirect to /api/v1/*
 app.use("/api", (req, res) => {

--- a/backend/src/routes/health.js
+++ b/backend/src/routes/health.js
@@ -1,0 +1,56 @@
+import { Router } from "express";
+import { getMigrationVersion } from "../database/index.js";
+import {
+  getConfiguredContractId,
+  getNetworkLabel,
+  checkHorizonConnectivity,
+  checkContractDeploymentStatus,
+} from "../stellar.js";
+
+export const healthRouter = Router();
+
+const CACHE_TTL_MS = parseInt(process.env.HEALTH_CACHE_TTL_MS ?? "30000", 10);
+let cachedHealth = null;
+let cacheExpiresAt = 0;
+
+/**
+ * GET /api/v1/health
+ * Operator health: DB migration version, network, Horizon, and optional contract status.
+ */
+healthRouter.get("/", async (_req, res, next) => {
+  try {
+    const now = Date.now();
+    if (cachedHealth && now < cacheExpiresAt) {
+      return res.json(cachedHealth);
+    }
+
+    const contractId = getConfiguredContractId();
+    const [horizon, contract] = await Promise.all([
+      checkHorizonConnectivity(),
+      checkContractDeploymentStatus(contractId),
+    ]);
+
+    const contractHealthy =
+      !contract.configured || (contract.deployed && contract.status !== "error");
+
+    const body = {
+      ok: horizon.connected && contractHealthy,
+      dbVersion: getMigrationVersion(),
+      network: getNetworkLabel(),
+      horizon,
+      contract,
+    };
+
+    cachedHealth = body;
+    cacheExpiresAt = now + (Number.isNaN(CACHE_TTL_MS) ? 30_000 : CACHE_TTL_MS);
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** Reset cached health (for tests). */
+export function clearHealthCache() {
+  cachedHealth = null;
+  cacheExpiresAt = 0;
+}

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -18,11 +18,107 @@ import logger from "./logger.js";
 
 const RPC_URL =
   process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
+const HORIZON_URL =
+  process.env.HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const NETWORK = process.env.STELLAR_NETWORK ?? "testnet";
 
 export const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
 export const networkPassphrase =
   NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+export function getNetworkLabel() {
+  return NETWORK === "mainnet" ? "Mainnet" : "Testnet";
+}
+
+export function getConfiguredContractId() {
+  return process.env.ROYALTY_CONTRACT_ID ?? process.env.CONTRACT_ID ?? null;
+}
+
+/**
+ * Probe Horizon with a lightweight ledgers request.
+ */
+export async function checkHorizonConnectivity() {
+  const url = `${HORIZON_URL.replace(/\/$/, "")}/ledgers?order=desc&limit=1`;
+  const timeoutMs = parseInt(process.env.HEALTH_CHECK_TIMEOUT_MS ?? "5000", 10);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    return {
+      connected: response.ok,
+      url: HORIZON_URL,
+    };
+  } catch {
+    return {
+      connected: false,
+      url: HORIZON_URL,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Report whether a default contract ID is configured and reachable on Soroban RPC.
+ */
+export async function checkContractDeploymentStatus(contractId) {
+  if (!contractId) {
+    return {
+      configured: false,
+      contractId: null,
+      deployed: false,
+      initialized: false,
+      status: "not_configured",
+    };
+  }
+
+  try {
+    const contract = new Contract(contractId);
+    const dummyAccount = new Account(
+      "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      "0",
+    );
+    const tx = new TransactionBuilder(dummyAccount, {
+      fee: BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(contract.call("is_initialized"))
+      .setTimeout(30)
+      .build();
+
+    const sim = await server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      return {
+        configured: true,
+        contractId,
+        deployed: false,
+        initialized: false,
+        status: "unreachable",
+      };
+    }
+
+    const initialized = sim.result?.retval?.bool() ?? false;
+    return {
+      configured: true,
+      contractId,
+      deployed: true,
+      initialized,
+      status: initialized ? "initialized" : "deployed",
+    };
+  } catch {
+    return {
+      configured: true,
+      contractId,
+      deployed: false,
+      initialized: false,
+      status: "error",
+    };
+  }
+}
 
 /**
  * Build an unsigned Soroban transaction XDR for a contract invocation.

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,104 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import request from "supertest";
+
+const checkHorizonConnectivity = jest.fn();
+const checkContractDeploymentStatus = jest.fn();
+const getConfiguredContractId = jest.fn();
+const getNetworkLabel = jest.fn(() => "Testnet");
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  checkHorizonConnectivity,
+  checkContractDeploymentStatus,
+  getConfiguredContractId,
+  getNetworkLabel,
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  initializeDatabase: jest.fn(),
+  getMigrationVersion: jest.fn(() => 2),
+}));
+
+const { clearHealthCache } = await import("../src/routes/health.js");
+
+const express = (await import("express")).default;
+const { healthRouter } = await import("../src/routes/health.js");
+
+const app = express();
+app.use("/api/v1/health", healthRouter);
+
+describe("GET /api/v1/health", () => {
+  beforeEach(() => {
+    clearHealthCache();
+    getConfiguredContractId.mockReturnValue("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    checkHorizonConnectivity.mockResolvedValue({
+      connected: true,
+      url: "https://horizon-testnet.stellar.org",
+    });
+    checkContractDeploymentStatus.mockResolvedValue({
+      configured: true,
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      deployed: true,
+      initialized: true,
+      status: "initialized",
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns network, horizon, contract, and db version", async () => {
+    const res = await request(app).get("/api/v1/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      dbVersion: 2,
+      network: "Testnet",
+      horizon: { connected: true, url: expect.any(String) },
+      contract: {
+        configured: true,
+        deployed: true,
+        initialized: true,
+        status: "initialized",
+      },
+    });
+  });
+
+  test("ok is false when Horizon is unreachable", async () => {
+    checkHorizonConnectivity.mockResolvedValue({
+      connected: false,
+      url: "https://horizon-testnet.stellar.org",
+    });
+
+    const res = await request(app).get("/api/v1/health");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.horizon.connected).toBe(false);
+  });
+
+  test("reports not_configured when no contract ID is set", async () => {
+    getConfiguredContractId.mockReturnValue(null);
+    checkContractDeploymentStatus.mockResolvedValue({
+      configured: false,
+      contractId: null,
+      deployed: false,
+      initialized: false,
+      status: "not_configured",
+    });
+
+    const res = await request(app).get("/api/v1/health");
+    expect(res.body.contract.status).toBe("not_configured");
+    expect(res.body.ok).toBe(true);
+  });
+
+  test("caches responses within TTL", async () => {
+    await request(app).get("/api/v1/health");
+    await request(app).get("/api/v1/health");
+
+    expect(checkHorizonConnectivity).toHaveBeenCalledTimes(1);
+    expect(checkContractDeploymentStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,12 @@ impl RoyaltySplitter {
     ///
     /// # Authorization
     /// Requires admin signature
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    /// * `"contract is paused"` — contract is currently paused
+    /// * `"total shares must sum to 10000"` — share map does not total 100%
+    /// * `"no balance to distribute"` — contract holds zero tokens
     pub fn distribute(env: Env, token: Address) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -372,6 +378,7 @@ impl RoyaltySplitter {
     /// * `"contract is paused"` — contract is currently paused
     /// * `"no secondary royalties to distribute"` — pool is empty
     /// * `"no secondary token set"` — no royalty has ever been recorded
+    /// * `"total shares must sum to 10000"` — share map does not total 100%
     /// * `"pool exceeds contract balance"` — pool accounting is inconsistent
     pub fn distribute_secondary_royalties(env: Env) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
@@ -386,6 +393,10 @@ impl RoyaltySplitter {
 
         if env.storage().instance().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false) {
             panic!("contract is paused");
+        }
+
+        if Self::get_total_shares(env.clone()) != 10_000 {
+            panic!("total shares must sum to 10000");
         }
 
         let pool: i128 = env

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,9 +3,9 @@ use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
     token::{Client as TokenClient, StellarAssetClient},
-    vec, Address, Env, IntoVal, Vec as SorobanVec,
+    vec, Address, Env, IntoVal, Map, Vec as SorobanVec,
 };
-use stellar_royalty_splitter::RoyaltySplitterClient;
+use stellar_royalty_splitter::{DataKey, RoyaltySplitterClient};
 
 fn setup(env: &Env) -> (Address, RoyaltySplitterClient) {
     let contract_id = env.register_contract(None, stellar_royalty_splitter::RoyaltySplitter);
@@ -29,6 +29,35 @@ fn test_distribute_before_initialize_panics() {
     let (_, client) = setup(&env);
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
+    client.distribute(&token);
+}
+
+/// Issue #237 — distribute must reject when stored shares do not sum to 10,000.
+#[test]
+#[should_panic(expected = "total shares must sum to 10000")]
+fn test_distribute_rejects_invalid_share_total() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    mint(&env, &token, &contract_id, 1000);
+
+    // Corrupt share map so totals are 60% instead of 100% (defense-in-depth path).
+    let mut bad_map: Map<Address, u32> = Map::new(&env);
+    bad_map.set(admin.clone(), 3000);
+    bad_map.set(b.clone(), 3000);
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::ShareMap, &bad_map);
+    });
+
     client.distribute(&token);
 }
 


### PR DESCRIPTION
## Summary

- **#237**: Hardens percentage allocation validation at distribution time — `distribute` already checked share totals; this adds the same defense-in-depth check to `distribute_secondary_royalties`, documents panic conditions, and adds an integration test that corrupts the share map and confirms distribute panics with a clear error.
- **#246**: Expands `GET /api/v1/health` to report network (Testnet/Mainnet), Horizon connectivity, and contract deployment status (configured, deployed, initialized). Responses are cached for 30s. Adds `backend/API.md`, env docs, and health route tests.

Closes #237
Closes #246

## Test plan

- [ ] `cargo test test_distribute_rejects_invalid_share_total` — distribute panics when shares do not sum to 10,000
- [ ] `cargo test` — existing distribution tests still pass
- [ ] `cd backend && npm run test:backend -- tests/health.test.js` — health endpoint tests pass
- [ ] `curl http://localhost:3001/api/v1/health` — returns `network`, `horizon`, and `contract` fields
- [ ] Set `ROYALTY_CONTRACT_ID` in backend `.env` and verify contract status reflects on-chain state