### PR TITLE
fix: block zero royalty rate, add min distribution amount, validate admin on init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@ impl RoyaltySplitter {
 
         let admin = collaborators.get(0).unwrap();
 
+        // Explicitly validate the admin address by requiring its auth signature.
+        // This ensures the stored admin is a real, signable account and prevents
+        // an invalid or uncontrolled address from taking admin control (#264).
+        admin.require_auth();
+
         env.storage().instance().set(&StorageKey::Admin, &admin);
         env.storage().instance().set(&StorageKey::Collaborators, &collaborators);
         env.storage().instance().set(&StorageKey::ShareMap, &share_map);
@@ -157,6 +162,10 @@ impl RoyaltySplitter {
             .expect("contract not initialized");
 
         auth::require_admin(&env, &admin, auth::msg::SET_ROYALTY_RATE_ADMIN);
+
+        if new_rate == 0 {
+            panic!("royalty rate cannot be zero: use a value between 1 and 10000 basis points");
+        }
 
         if new_rate > 10_000 {
             panic!("royalty rate cannot exceed 10000 basis points");
@@ -454,6 +463,11 @@ impl RoyaltySplitter {
         }
 
         let n = recipients_to_use.len();
+
+        // Guard: each recipient must receive at least 1 stroop to avoid silent dust no-ops (#263).
+        if amount < n as i128 {
+            panic!("amount too small: each recipient must receive at least 1 stroop");
+        }
         let mut payouts: Vec<(Address, i128)> = Vec::new(&env);
         let mut total_calculated: i128 = 0;
 


### PR DESCRIPTION
Closes #263
Closes #264
Closes #265
Closes #269

- **#265** (`set_royalty_rate`): Adds `if new_rate == 0 { panic!(...) }` before the existing `> 10_000` check. Calling `set_royalty_rate(0)` now returns a clear error instead of silently storing a rate that makes `distribute` a no-op.

- **#263** (`distribute_with_override`): After the zero-balance check, verifies `amount >= n as i128` (each of the *n* recipients must receive at least 1 stroop). Panics with a descriptive message if the amount is below the dust threshold to prevent integer-truncation silent failures.

- **#264** (`initialize`): Adds an explicit `admin.require_auth()` call immediately before writing the admin to storage. Soroban's `Address` type already enforces format correctness at the type level, and the existing `auth::require_admin` check on `collaborators[0]` also validates the key — the explicit call makes the intent unambiguous and prevents a front-runner from substituting an address they don't control.

- **#269**: The pause/unpause mechanism (`pause`, `unpause`, `is_paused`) is already fully implemented in the contract — no code change needed.