### PR TITLE
fix(backend,ci): RPC timeout, dynamic fee, sequence refresh, contract CI

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -1,0 +1,62 @@
+name: Contract CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "test_snapshots/**"
+      - ".github/workflows/contract-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "test_snapshots/**"
+      - ".github/workflows/contract-ci.yml"
+
+jobs:
+  test:
+    name: cargo test (wasm32-unknown-unknown)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Add wasm32 target (idempotent)
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: cargo build (wasm32-unknown-unknown)
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: cargo test (host)
+        # Soroban unit tests run against the host target, not wasm32; the
+        # wasm build above ensures the contract compiles for deployment.
+        run: cargo test --workspace --locked
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check

--- a/backend/API.md
+++ b/backend/API.md
@@ -122,3 +122,22 @@ See route module `src/routes/secondary-royalty.js` for pool, sales, and distribu
 
 - `GET /api/v1/history/:contractId`
 - `GET /api/v1/analytics/:contractId`
+
+## Operational configuration
+
+The Soroban RPC and Horizon clients are configurable via the following
+environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint |
+| `HORIZON_URL` | `https://horizon-testnet.stellar.org` | Horizon endpoint (used for fee stats and connectivity probes) |
+| `STELLAR_NETWORK` | `testnet` | `testnet` or `mainnet` |
+| `SOROBAN_RPC_TIMEOUT_MS` | `10000` | Per-call timeout for Soroban RPC (#273). On timeout the route returns HTTP 504 with `Soroban RPC timed out after Nms`. |
+| `HORIZON_TIMEOUT_MS` | `10000` | Per-call timeout for Horizon (fee fetch + health probe). |
+| `HORIZON_FEE_CACHE_MS` | `30000` | How long the recommended fee (#274) is cached before re-fetching. |
+| `HEALTH_CHECK_TIMEOUT_MS` | `5000` | Timeout for the `/health` Horizon connectivity probe. |
+
+When the fee fetch fails the backend falls back to `BASE_FEE` (`100` stroops) so transaction submission keeps working.
+
+Transactions built via `retryBuildTx` refresh the account sequence (#275) on every attempt; retries never reuse a stale sequence.

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -1,7 +1,17 @@
-﻿/**
+/**
  * Shared Soroban RPC client and helpers.
  * Real transactions are assembled here and returned as XDR so the
  * frontend can sign them with Freighter before submission.
+ *
+ * Operational hardening (#273, #274, #275):
+ *   - Every RPC call goes through `withTimeout()` so the backend never
+ *     hangs on a slow upstream. Configurable via SOROBAN_RPC_TIMEOUT_MS
+ *     (default 10s) and HORIZON_TIMEOUT_MS (default 10s).
+ *   - The transaction fee is fetched from Horizon's /fee_stats endpoint
+ *     and cached for 30 seconds (configurable via HORIZON_FEE_CACHE_MS).
+ *     Falls back to BASE_FEE on fetch failure.
+ *   - `retryBuildTx` calls `getFreshAccount()` on every attempt, so each
+ *     rebuilt transaction carries a freshly refetched sequence number.
  */
 import StellarSdk from "@stellar/stellar-sdk";
 import logger from "./logger.js";
@@ -24,6 +34,24 @@ const HORIZON_URL =
   process.env.HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const NETWORK = process.env.STELLAR_NETWORK ?? "testnet";
 
+function parsePositiveInt(value, fallback) {
+  const n = parseInt(value ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+const SOROBAN_RPC_TIMEOUT_MS = parsePositiveInt(
+  process.env.SOROBAN_RPC_TIMEOUT_MS,
+  10_000,
+);
+const HORIZON_TIMEOUT_MS = parsePositiveInt(
+  process.env.HORIZON_TIMEOUT_MS,
+  10_000,
+);
+const HORIZON_FEE_CACHE_MS = parsePositiveInt(
+  process.env.HORIZON_FEE_CACHE_MS,
+  30_000,
+);
+
 export const server = new SorobanRpc.Server(RPC_URL, { allowHttp: false });
 export const networkPassphrase =
   NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
@@ -36,12 +64,36 @@ export function getConfiguredContractId() {
   return process.env.ROYALTY_CONTRACT_ID ?? process.env.CONTRACT_ID ?? null;
 }
 
+// ── RPC timeout wrapper (#273) ─────────────────────────────────────────────
+
+/**
+ * Reject `promise` after `ms` milliseconds with a `{ status: 504, message }`
+ * shape so the route layer can pass the error straight through.
+ */
+export function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      reject({
+        status: 504,
+        message: `${label} did not respond within ${ms}ms`,
+      });
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 /**
  * Probe Horizon with a lightweight ledgers request.
  */
 export async function checkHorizonConnectivity() {
   const url = `${HORIZON_URL.replace(/\/$/, "")}/ledgers?order=desc&limit=1`;
-  const timeoutMs = parseInt(process.env.HEALTH_CHECK_TIMEOUT_MS ?? "5000", 10);
+  const timeoutMs = parsePositiveInt(
+    process.env.HEALTH_CHECK_TIMEOUT_MS,
+    5_000,
+  );
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -92,7 +144,11 @@ export async function checkContractDeploymentStatus(contractId) {
       .setTimeout(30)
       .build();
 
-    const sim = await server.simulateTransaction(tx);
+    const sim = await withTimeout(
+      server.simulateTransaction(tx),
+      SOROBAN_RPC_TIMEOUT_MS,
+      "Soroban simulateTransaction",
+    );
     if (SorobanRpc.Api.isSimulationError(sim)) {
       return {
         configured: true,
@@ -122,23 +178,96 @@ export async function checkContractDeploymentStatus(contractId) {
   }
 }
 
+// ── Dynamic fee (#274) ─────────────────────────────────────────────────────
+
+let feeCache = null; // { fee: string, fetchedAt: number }
+
+/**
+ * Reset the cached fee. Exposed for tests; production code shouldn't call this.
+ */
+export function _resetFeeCache() {
+  feeCache = null;
+}
+
+/**
+ * Fetch the recommended transaction fee from Horizon's `/fee_stats` endpoint,
+ * cached for HORIZON_FEE_CACHE_MS (default 30s). Falls back to `BASE_FEE` on
+ * any error so transaction submission keeps working even when fee stats are
+ * unavailable.
+ */
+export async function getRecommendedFee() {
+  const now = Date.now();
+  if (feeCache && now - feeCache.fetchedAt < HORIZON_FEE_CACHE_MS) {
+    return feeCache.fee;
+  }
+
+  const url = `${HORIZON_URL.replace(/\/$/, "")}/fee_stats`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HORIZON_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    // Prefer `p50_accepted_fee` (median accepted), fall back to
+    // `last_ledger_base_fee`, then BASE_FEE.
+    const candidate =
+      data?.fee_charged?.p50 ??
+      data?.last_ledger_base_fee ??
+      BASE_FEE;
+    const fee = String(candidate);
+    feeCache = { fee, fetchedAt: now };
+    return fee;
+  } catch (error) {
+    logger.warn?.("Horizon fee fetch failed; falling back to BASE_FEE", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return BASE_FEE;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Build path (#273, #274, #275) ──────────────────────────────────────────
+
+/**
+ * Fetch a fresh account record (including the current sequence number) for
+ * `callerAddress`. Each `retryBuildTx` attempt funnels through here, which
+ * is what guarantees retries don't reuse a stale sequence (#275).
+ */
+export async function getFreshAccount(callerAddress) {
+  return withTimeout(
+    server.getAccount(callerAddress),
+    SOROBAN_RPC_TIMEOUT_MS,
+    "Soroban getAccount",
+  );
+}
+
 /**
  * Build an unsigned Soroban transaction XDR for a contract invocation.
  * The frontend signs and submits it.
  */
 export async function buildTx(callerAddress, contractId, method, args = []) {
-  const account = await server.getAccount(callerAddress);
+  const account = await getFreshAccount(callerAddress);
+  const fee = await getRecommendedFee();
   const contract = new Contract(contractId);
 
   const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
+    fee,
     networkPassphrase,
   })
     .addOperation(contract.call(method, ...args))
     .setTimeout(30)
     .build();
 
-  const prepared = await server.prepareTransaction(tx);
+  const prepared = await withTimeout(
+    server.prepareTransaction(tx),
+    SOROBAN_RPC_TIMEOUT_MS,
+    "Soroban prepareTransaction",
+  );
   return prepared.toXDR();
 }
 
@@ -147,13 +276,26 @@ function isRateLimitError(error) {
     error?.response?.status === 429 ||
     error?.status === 429 ||
     error?.message?.includes("429") ||
-    error?.message?.toLowerCase().includes("too many requests") ||
-    error?.message?.toLowerCase().includes("rate limit")
+    error?.message?.toLowerCase?.().includes("too many requests") ||
+    error?.message?.toLowerCase?.().includes("rate limit")
   );
+}
+
+function isTimeoutError(error) {
+  return error?.status === 504;
 }
 
 /**
  * Retry wrapper for buildTx with exponential backoff.
+ *
+ * Sequence-number freshness (#275): every attempt re-enters `buildTx`,
+ * which always calls `getFreshAccount` — the retry therefore carries the
+ * latest sequence number from Horizon, not the one captured by the first
+ * attempt.
+ *
+ * Timeouts (#273) surface as `{ status: 504 }` and are retried like other
+ * network errors up to `maxRetries`.
+ *
  * Handles HTTP 429 rate-limit responses from Horizon explicitly.
  */
 export async function retryBuildTx(callerAddress, contractId, method, args = []) {
@@ -165,29 +307,74 @@ export async function retryBuildTx(callerAddress, contractId, method, args = [])
       return await buildTx(callerAddress, contractId, method, args);
     } catch (error) {
       const isLastAttempt = attempt === maxRetries;
-      const isNetworkError = error.message?.includes("network") || error.message?.includes("timeout") || error.code === "ENOTFOUND";
+      const isNetworkError =
+        error.message?.includes("network") ||
+        error.message?.includes("timeout") ||
+        error.code === "ENOTFOUND";
       const isAccountNotFound = error.message?.includes("account not found");
-      const isSimulationError = error.message?.includes("simulation") || error.message?.includes("prepare");
+      const isSimulationError =
+        error.message?.includes("simulation") ||
+        error.message?.includes("prepare");
       const isRateLimit = isRateLimitError(error);
+      const isTimeout = isTimeoutError(error);
 
       if (isAccountNotFound) {
-        throw { status: 400, message: "Caller account not found on Stellar network" };
+        throw {
+          status: 400,
+          message: "Caller account not found on Stellar network",
+        };
       }
 
       if (isRateLimit) {
         if (isLastAttempt) {
-          logger.warn("Horizon rate limit exceeded after max retries", { method, contractId, attempt });
-          throw { status: 429, message: "Stellar Horizon rate limit exceeded. Please try again later." };
+          logger.warn("Horizon rate limit exceeded after max retries", {
+            method,
+            contractId,
+            attempt,
+          });
+          throw {
+            status: 429,
+            message:
+              "Stellar Horizon rate limit exceeded. Please try again later.",
+          };
         }
         const delay = baseBackoffMs * Math.pow(2, attempt - 1);
-        logger.warn(`Horizon rate limit hit, retrying with backoff`, { method, contractId, attempt, maxRetries, delayMs: delay });
+        logger.warn(`Horizon rate limit hit, retrying with backoff`, {
+          method,
+          contractId,
+          attempt,
+          maxRetries,
+          delayMs: delay,
+        });
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      if (isTimeout) {
+        if (isLastAttempt) {
+          logger.warn("Soroban RPC timed out after max retries", {
+            method,
+            contractId,
+            attempt,
+            timeoutMs: SOROBAN_RPC_TIMEOUT_MS,
+          });
+          throw {
+            status: 504,
+            message: `Soroban RPC timed out after ${SOROBAN_RPC_TIMEOUT_MS}ms`,
+          };
+        }
+        const delay = baseBackoffMs * Math.pow(2, attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;
       }
 
       if (isNetworkError || isSimulationError) {
         if (isLastAttempt) {
-          throw { status: 503, message: "Stellar RPC is currently unavailable. Please try again later." };
+          throw {
+            status: 503,
+            message:
+              "Stellar RPC is currently unavailable. Please try again later.",
+          };
         }
         const delay = baseBackoffMs * Math.pow(2, attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, delay));
@@ -235,7 +422,11 @@ export async function getRoyaltyRateFromContract(contractId) {
     .setTimeout(30)
     .build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withTimeout(
+    server.simulateTransaction(tx),
+    SOROBAN_RPC_TIMEOUT_MS,
+    "Soroban simulateTransaction",
+  );
   if (SorobanRpc.Api.isSimulationError(sim)) return 0;
   return sim.result?.retval?.u32() ?? 0;
 }
@@ -258,7 +449,20 @@ export async function isContractInitialized(contractId) {
     .setTimeout(30)
     .build();
 
-  const sim = await server.simulateTransaction(tx);
+  const sim = await withTimeout(
+    server.simulateTransaction(tx),
+    SOROBAN_RPC_TIMEOUT_MS,
+    "Soroban simulateTransaction",
+  );
   if (SorobanRpc.Api.isSimulationError(sim)) return false;
   return sim.result?.retval?.bool() ?? false;
 }
+
+// ── Test exports ───────────────────────────────────────────────────────────
+// Internal config snapshot for the test layer.
+export const _config = {
+  SOROBAN_RPC_TIMEOUT_MS,
+  HORIZON_TIMEOUT_MS,
+  HORIZON_FEE_CACHE_MS,
+  HORIZON_URL,
+};

--- a/backend/tests/stellar.test.js
+++ b/backend/tests/stellar.test.js
@@ -1,0 +1,246 @@
+/**
+ * Tests for the operational hardening added to `src/stellar.js`:
+ *   #273 — RPC timeout
+ *   #274 — Dynamic fee from Horizon /fee_stats with 30s cache + fallback
+ *   #275 — Sequence number refreshed on every retry
+ */
+import {
+  jest,
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+
+beforeEach(() => {
+  // Test isolation — clear caches and module mocks between cases.
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ── #273 — RPC timeout ─────────────────────────────────────────────────────
+
+describe("withTimeout (#273)", () => {
+  test("rejects with a 504-shaped error when the inner promise never settles", async () => {
+    const { withTimeout } = await import("../src/stellar.js");
+    const slow = new Promise(() => {});
+    await expect(withTimeout(slow, 10, "test-op")).rejects.toMatchObject({
+      status: 504,
+      message: expect.stringContaining("test-op"),
+    });
+  });
+
+  test("forwards the inner value when it settles before the deadline", async () => {
+    const { withTimeout } = await import("../src/stellar.js");
+    const fast = Promise.resolve("ok");
+    await expect(withTimeout(fast, 100, "test-op")).resolves.toBe("ok");
+  });
+
+  test("forwards the inner rejection unchanged when it loses to the timer", async () => {
+    const { withTimeout } = await import("../src/stellar.js");
+    const boom = Promise.reject(new Error("upstream boom"));
+    await expect(
+      withTimeout(boom, 100, "test-op"),
+    ).rejects.toThrow(/upstream boom/);
+  });
+});
+
+// ── #274 — Dynamic fee with cache + fallback ───────────────────────────────
+
+describe("getRecommendedFee (#274)", () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test("returns the median accepted fee from Horizon and caches it", async () => {
+    let calls = 0;
+    global.fetch = jest.fn(async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          fee_charged: { p50: "250" },
+          last_ledger_base_fee: 100,
+        }),
+      };
+    });
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    expect(await stellar.getRecommendedFee()).toBe("250");
+    expect(await stellar.getRecommendedFee()).toBe("250");
+    expect(calls).toBe(1); // second call served from cache
+  });
+
+  test("falls back to last_ledger_base_fee when p50 is missing", async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ last_ledger_base_fee: 150 }),
+    }));
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    expect(await stellar.getRecommendedFee()).toBe("150");
+  });
+
+  test("falls back to BASE_FEE when Horizon responds with a non-2xx", async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, status: 500 }));
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    const fee = await stellar.getRecommendedFee();
+    // BASE_FEE in the @stellar/stellar-sdk is "100" (stroops).
+    expect(fee).toBe("100");
+  });
+
+  test("falls back to BASE_FEE when fetch throws", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("ENOTFOUND");
+    });
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    const fee = await stellar.getRecommendedFee();
+    expect(fee).toBe("100");
+  });
+
+  test("cache expires after HORIZON_FEE_CACHE_MS", async () => {
+    let calls = 0;
+    const responses = ["100", "250"];
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        fee_charged: { p50: responses[Math.min(calls++, responses.length - 1)] },
+      }),
+    }));
+
+    jest.useFakeTimers();
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    expect(await stellar.getRecommendedFee()).toBe("100");
+
+    // Advance past the default 30s cache window.
+    jest.setSystemTime(Date.now() + 31_000);
+    expect(await stellar.getRecommendedFee()).toBe("250");
+  });
+});
+
+// ── #275 — Sequence refresh on every retry ────────────────────────────────
+
+describe("retryBuildTx sequence-refresh contract (#275)", () => {
+  test("calls server.getAccount on every retry attempt", async () => {
+    // We mock the entire stellar module's `server` so we can count
+    // getAccount invocations across retries.
+    const getAccount = jest.fn(async () => ({
+      accountId: () => "GTEST",
+      sequenceNumber: () => "1",
+    }));
+    const prepareTransaction = jest.fn();
+
+    // First two prepareTransaction calls fail with a network error so the
+    // retry loop runs through three attempts total.
+    prepareTransaction
+      .mockRejectedValueOnce(Object.assign(new Error("network glitch"), {}))
+      .mockRejectedValueOnce(Object.assign(new Error("network glitch"), {}))
+      .mockResolvedValueOnce({ toXDR: () => "MOCK_XDR" });
+
+    jest.unstable_mockModule("@stellar/stellar-sdk", () => {
+      class Account {
+        constructor(id, seq) {
+          this.id = id;
+          this.seq = seq;
+        }
+        accountId() {
+          return this.id;
+        }
+        sequenceNumber() {
+          return this.seq;
+        }
+        incrementSequenceNumber() {
+          this.seq = String(BigInt(this.seq) + 1n);
+        }
+      }
+      const mock = {
+        Contract: class {
+          constructor(id) {
+            this.id = id;
+          }
+          call(method, ...args) {
+            return { kind: "op", method, args };
+          }
+        },
+        Networks: {
+          PUBLIC: "Public",
+          TESTNET: "Test SDF Network ; September 2015",
+        },
+        SorobanRpc: {
+          Server: class {
+            constructor() {}
+            getAccount = getAccount;
+            prepareTransaction = prepareTransaction;
+            simulateTransaction = jest.fn();
+          },
+          Api: { isSimulationError: () => false },
+        },
+        TransactionBuilder: class {
+          constructor() {
+            this.ops = [];
+          }
+          addOperation(op) {
+            this.ops.push(op);
+            return this;
+          }
+          setTimeout() {
+            return this;
+          }
+          build() {
+            return {};
+          }
+        },
+        BASE_FEE: "100",
+        nativeToScVal: () => ({}),
+        Address: class {
+          constructor(a) {
+            this.a = a;
+          }
+          toScVal() {
+            return { addr: this.a };
+          }
+        },
+        Account,
+        xdr: { ScVal: { scvU32: () => ({}), scvVec: () => ({}) } },
+      };
+      return { default: mock, ...mock };
+    });
+
+    // Patch fetch so getRecommendedFee resolves quickly to BASE_FEE.
+    global.fetch = jest.fn(async () => ({ ok: false, status: 500 }));
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+
+    const xdr = await stellar.retryBuildTx(
+      "GCALLER",
+      "CCONTRACT",
+      "noop",
+      [],
+    );
+    expect(xdr).toBe("MOCK_XDR");
+    expect(getAccount).toHaveBeenCalledTimes(3);
+    // Each call uses the same caller — but a *separate* fetch — which is
+    // exactly the freshness guarantee.
+    for (const call of getAccount.mock.calls) {
+      expect(call[0]).toBe("GCALLER");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Four assigned issues, one PR per repo per persona.

- closes #273 — every Soroban RPC call goes through a new `withTimeout()` helper, configurable via `SOROBAN_RPC_TIMEOUT_MS` (default 10s). On timeout the helper rejects with `{ status: 504, message }`; `retryBuildTx` recognises the 504 and retries with exponential backoff up to `maxRetries`. The error message includes the operation label and timeout for clean client-side surfacing.
- closes #274 — `buildTx` no longer uses a hardcoded fee. New `getRecommendedFee()` fetches Horizon's `/fee_stats`, prefers `fee_charged.p50`, falls back to `last_ledger_base_fee`, then to `BASE_FEE`. Result is cached for `HORIZON_FEE_CACHE_MS` (default 30s); the fetch is bounded by `HORIZON_TIMEOUT_MS` (default 10s). A failed fetch falls back silently so submissions keep working under fee-stats degradation.
- closes #275 — `retryBuildTx` re-enters `buildTx` which now explicitly calls a new `getFreshAccount()` for every attempt. The contract that "retries never reuse a stale sequence" is now explicit and covered by a regression test that mocks `server.getAccount` and asserts it's invoked once per attempt across a 3-attempt cycle.
- closes #282 — new `.github/workflows/contract-ci.yml` running on every PR + push touching `src/`, `tests/`, `Cargo.toml`, `Cargo.lock`, or `test_snapshots/`. Installs the `wasm32-unknown-unknown` target, caches `~/.cargo/registry`, `~/.cargo/git`, and `target/`, builds the WASM release artifact, runs `cargo test --workspace --locked` on the host target, and checks `cargo fmt`.

## Notes

- I could not run `npm test` / `cargo` locally in the build sandbox; CI is the source of truth. The new backend tests follow the same `jest.unstable_mockModule` pattern as `tests/health.test.js`.
- `API.md` gained an **Operational configuration** section listing every env var the backend reads, their defaults, and the failure semantics.
- The retry path is backward-compatible — existing 429 and network-error handling is preserved; the new 504 timeout branch slots in alongside them with the same exponential-backoff schedule.

## Test plan

- [ ] CI: backend `npm test` — new `tests/stellar.test.js` passes (8 tests) and existing suites still green
- [ ] CI: contract `cargo build --target wasm32-unknown-unknown --release` + `cargo test --workspace --locked` succeed
- [ ] Manual: set `SOROBAN_RPC_TIMEOUT_MS=1` and hit any `/api/v1/*` route — should return 504
- [ ] Manual: hit `/api/v1/distribute` with no `HORIZON_URL` reachable — should still respond using `BASE_FEE` fallback