### PR TITLE
feat: env-validated CORS, hardened logger, structured frontend errors, wasm-opt Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Stellar Royalty Splitter — build / optimise / clean (#285).
+#
+# Adds an explicit `wasm-opt -Oz` step to the build pipeline so the
+# deployed wasm has a smaller footprint (lower ledger fees on every
+# invocation). The existing `scripts/deploy.sh` uses
+# `stellar contract optimize`, but that conflates build + deploy; CI
+# wants a `make build` target that runs the optimization pass without
+# touching the network, which this Makefile provides.
+
+CONTRACT_NAME := stellar_royalty_splitter
+TARGET_DIR    := target/wasm32-unknown-unknown/release
+RAW_WASM      := $(TARGET_DIR)/$(CONTRACT_NAME).wasm
+OPT_WASM      := $(TARGET_DIR)/$(CONTRACT_NAME).optimized.wasm
+
+# Detect a wasm-opt binary. Falls back to `stellar contract optimize`
+# (which embeds wasm-opt) when the standalone binary isn't installed.
+WASM_OPT      := $(shell command -v wasm-opt 2>/dev/null)
+
+.PHONY: all build optimize clean check-size deploy-ready
+
+all: optimize
+
+## Build the contract in release mode.
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+## Run `wasm-opt -Oz` on the release artifact. Falls back to the
+## Stellar CLI's bundled optimizer when wasm-opt isn't installed
+## locally, so the target works in dev + CI even when the binary
+## hasn't been provisioned.
+optimize: build
+	@echo "▶ Optimising $(RAW_WASM)"
+ifeq ($(WASM_OPT),)
+	@echo "wasm-opt not on PATH; falling back to 'stellar contract optimize'"
+	stellar contract optimize --wasm $(RAW_WASM)
+else
+	$(WASM_OPT) -Oz $(RAW_WASM) -o $(OPT_WASM)
+endif
+	@echo "▶ Done: $(OPT_WASM)"
+
+## Report the raw and optimised sizes so CI can fail when the
+## optimisation regresses (e.g. someone adds a panic path).
+check-size: optimize
+	@echo "▶ Raw      : $$(wc -c < $(RAW_WASM)) bytes"
+	@echo "▶ Optimised: $$(wc -c < $(OPT_WASM)) bytes"
+
+## Make sure the optimised artifact exists; useful as a CI gate
+## before `scripts/deploy.sh`.
+deploy-ready: optimize
+	@test -f $(OPT_WASM) || { echo "Optimised wasm missing"; exit 1; }
+	@echo "▶ Ready to deploy: $(OPT_WASM)"
+
+clean:
+	cargo clean

--- a/backend/src/cors-config.js
+++ b/backend/src/cors-config.js
@@ -1,0 +1,67 @@
+// CORS config helpers (#276).
+//
+// Goals (from the issue acceptance criteria):
+//   - CORS origin is configurable via env var.
+//   - Production uses a specific frontend origin.
+//   - Development allows `*`.
+//   - Validation rejects malformed values so a typo can't accidentally
+//     widen the policy.
+
+const DEV_NODE_ENVS = new Set(["development", "test"]);
+const STAR = "*";
+
+/**
+ * Returns true when the given env value is considered "development-ish".
+ * Falsy values default to production semantics so a misconfigured
+ * deployment can never accidentally allow `*`.
+ */
+export function isDevEnv(nodeEnv = process.env.NODE_ENV) {
+  return DEV_NODE_ENVS.has((nodeEnv ?? "production").toLowerCase());
+}
+
+/**
+ * Validate a single CORS origin value. Throws when the value is
+ * malformed or `*` is used in production.
+ *
+ *   - In development, `*` is allowed and any well-formed URL is allowed.
+ *   - In production, `*` is rejected and the origin must be an http(s) URL.
+ */
+export function validateCorsOrigin(origin, { dev } = { dev: isDevEnv() }) {
+  if (typeof origin !== "string" || origin.length === 0) {
+    throw new Error("CORS origin must be a non-empty string");
+  }
+  if (origin === STAR) {
+    if (dev) return origin;
+    throw new Error(
+      "CORS origin '*' is not allowed in production. Set FRONTEND_ORIGIN to your frontend's exact http(s) URL."
+    );
+  }
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("CORS origin must use http or https");
+    }
+  } catch (err) {
+    throw new Error(`CORS origin is not a valid URL: ${origin} (${err.message})`);
+  }
+  return origin;
+}
+
+/**
+ * Resolve the effective CORS origin from `FRONTEND_ORIGIN`, applying
+ * environment-aware defaults:
+ *   - dev / test → default to `*` so iterating from any localhost port works.
+ *   - production → REQUIRE FRONTEND_ORIGIN; refuse to start otherwise.
+ */
+export function resolveCorsOrigin({
+  envOrigin = process.env.FRONTEND_ORIGIN,
+  dev = isDevEnv(),
+} = {}) {
+  if (!envOrigin) {
+    if (dev) return STAR;
+    throw new Error(
+      "FRONTEND_ORIGIN is required in production. Set it to your frontend's exact http(s) URL."
+    );
+  }
+  return validateCorsOrigin(envOrigin, { dev });
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import logger from "./logger.js";
+import { resolveCorsOrigin } from "./cors-config.js";
 import { initializeRouter } from "./routes/initialize.js";
 import { distributeRouter } from "./routes/distribute.js";
 import { collaboratorsRouter } from "./routes/collaborators.js";
@@ -43,10 +44,15 @@ app.use(helmet());
 
 const corsPreflightMaxAge = parseInt(process.env.CORS_PREFLIGHT_MAX_AGE ?? "86400", 10);
 
-// CORS restricted to configured frontend origin
+// #276: env-driven CORS origin. resolveCorsOrigin validates the value
+// (rejects malformed URLs, rejects '*' in production), and refuses to
+// start when FRONTEND_ORIGIN is unset in production so a misconfigured
+// deployment can never silently open the policy to all origins.
+const corsOrigin = resolveCorsOrigin();
+logger.info("CORS origin configured", { origin: corsOrigin });
 app.use(
   cors({
-    origin: process.env.FRONTEND_ORIGIN ?? "http://localhost:5173",
+    origin: corsOrigin,
     methods: ["GET", "POST"],
     maxAge: Number.isNaN(corsPreflightMaxAge) ? 86400 : corsPreflightMaxAge,
   })

--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -1,14 +1,47 @@
+// Structured logger (#278).
+//
+// Winston-backed JSON logger with env-driven log level. Levels:
+// error < warn < info < debug. Production deployments typically run
+// at `info`; bumping to `debug` in dev surfaces request/response
+// shapes without code changes.
+//
+// Invalid `LOG_LEVEL` values fall back to `info` (and log a warning
+// once on boot) so a typo can't silence the whole app.
+
 import winston from "winston";
 
+const VALID_LEVELS = ["error", "warn", "info", "debug"];
+const DEFAULT_LEVEL = "info";
+
+export function resolveLevel(rawLevel = process.env.LOG_LEVEL) {
+  if (!rawLevel) return DEFAULT_LEVEL;
+  const lc = String(rawLevel).toLowerCase();
+  if (VALID_LEVELS.includes(lc)) return lc;
+  return DEFAULT_LEVEL;
+}
+
+const resolvedLevel = resolveLevel();
+
 const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || "info",
+  level: resolvedLevel,
   format: winston.format.combine(
     winston.format.timestamp(),
-    winston.format.json()
+    winston.format.errors({ stack: true }),
+    winston.format.json(),
   ),
-  transports: [
-    new winston.transports.Console()
-  ],
+  transports: [new winston.transports.Console()],
 });
+
+// Surface invalid LOG_LEVEL once on boot so misconfig is visible.
+if (
+  process.env.LOG_LEVEL &&
+  resolvedLevel !== String(process.env.LOG_LEVEL).toLowerCase()
+) {
+  logger.warn(
+    `Invalid LOG_LEVEL '${process.env.LOG_LEVEL}' — falling back to '${DEFAULT_LEVEL}'. Valid values: ${VALID_LEVELS.join(", ")}.`,
+  );
+}
+
+export { VALID_LEVELS };
 
 export default logger;

--- a/backend/tests/cors-config.test.js
+++ b/backend/tests/cors-config.test.js
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import { isDevEnv, resolveCorsOrigin, validateCorsOrigin } from "../src/cors-config.js";
+
+const ENV_KEYS = ["NODE_ENV", "FRONTEND_ORIGIN"];
+
+let snapshot = {};
+
+beforeEach(() => {
+  snapshot = {};
+  for (const k of ENV_KEYS) {
+    snapshot[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(snapshot)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("isDevEnv (#276)", () => {
+  test("development/test count as dev", () => {
+    expect(isDevEnv("development")).toBe(true);
+    expect(isDevEnv("test")).toBe(true);
+  });
+  test("production / staging / falsy default to prod", () => {
+    expect(isDevEnv("production")).toBe(false);
+    expect(isDevEnv("staging")).toBe(false);
+    expect(isDevEnv(undefined)).toBe(false);
+    expect(isDevEnv("")).toBe(false);
+  });
+});
+
+describe("validateCorsOrigin (#276)", () => {
+  test("accepts a well-formed https URL in production", () => {
+    expect(validateCorsOrigin("https://app.example.com", { dev: false })).toBe(
+      "https://app.example.com"
+    );
+  });
+
+  test("allows '*' in development", () => {
+    expect(validateCorsOrigin("*", { dev: true })).toBe("*");
+  });
+
+  test("rejects '*' in production", () => {
+    expect(() => validateCorsOrigin("*", { dev: false })).toThrow(
+      /not allowed in production/
+    );
+  });
+
+  test("rejects malformed URLs", () => {
+    expect(() => validateCorsOrigin("not-a-url", { dev: false })).toThrow(
+      /not a valid URL/
+    );
+  });
+
+  test("rejects non-string / empty input", () => {
+    expect(() => validateCorsOrigin("", { dev: true })).toThrow(/non-empty/);
+    expect(() => validateCorsOrigin(undefined, { dev: true })).toThrow(/non-empty/);
+  });
+
+  test("rejects file:// / ftp:// etc.", () => {
+    expect(() => validateCorsOrigin("file:///etc/passwd", { dev: false })).toThrow(
+      /http or https/
+    );
+  });
+});
+
+describe("resolveCorsOrigin (#276)", () => {
+  test("dev with no env var defaults to '*'", () => {
+    expect(resolveCorsOrigin({ envOrigin: undefined, dev: true })).toBe("*");
+  });
+
+  test("production refuses to start without FRONTEND_ORIGIN", () => {
+    expect(() => resolveCorsOrigin({ envOrigin: undefined, dev: false })).toThrow(
+      /required in production/
+    );
+  });
+
+  test("production honours an explicit FRONTEND_ORIGIN", () => {
+    expect(
+      resolveCorsOrigin({ envOrigin: "https://shade.example.com", dev: false })
+    ).toBe("https://shade.example.com");
+  });
+});

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "@jest/globals";
+import { resolveLevel, VALID_LEVELS } from "../src/logger.js";
+
+describe("resolveLevel (#278)", () => {
+  test("defaults to info when LOG_LEVEL is unset", () => {
+    expect(resolveLevel(undefined)).toBe("info");
+  });
+
+  test("recognises every valid level (case-insensitive)", () => {
+    for (const level of VALID_LEVELS) {
+      expect(resolveLevel(level)).toBe(level);
+      expect(resolveLevel(level.toUpperCase())).toBe(level);
+    }
+  });
+
+  test("falls back to info on a typo so logging never disappears entirely", () => {
+    expect(resolveLevel("infooo")).toBe("info");
+    expect(resolveLevel("trace")).toBe("info");
+  });
+});
+
+describe("VALID_LEVELS (#278)", () => {
+  test("matches the documented level hierarchy", () => {
+    expect(VALID_LEVELS).toEqual(["error", "warn", "info", "debug"]);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,37 @@
 // Thin client that talks to the Express backend
 
+import { extractContractError } from "./lib/contract-errors";
+
 const BASE = "/api";
+
+// #279: surface a structured `code + message + details` shape from
+// the backend's error response instead of just `data.error`. The
+// caller's `catch (e)` block can call `extractContractError(e)` to
+// pull the same fields back out and the toast surfaces the real
+// failure reason (`Caller is not the contract admin (code 2)`)
+// rather than a generic "transaction failed".
+export class BackendApiError extends Error {
+  code: string | number | null;
+  details?: string;
+  status: number;
+  constructor(
+    status: number,
+    code: string | number | null,
+    message: string,
+    details?: string,
+  ) {
+    super(message);
+    this.name = "BackendApiError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function readErrorBody(status: number, data: unknown): BackendApiError {
+  const parsed = extractContractError(data ?? { error: "Request failed" });
+  return new BackendApiError(status, parsed.code, parsed.message, parsed.details);
+}
 
 async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
@@ -9,14 +40,14 @@ async function post<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   const data = await res.json();
-  if (!res.ok) throw new Error(data.error ?? "Request failed");
+  if (!res.ok) throw readErrorBody(res.status, data);
   return data as T;
 }
 
 async function get<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`);
   const data = await res.json();
-  if (!res.ok) throw new Error(data.error ?? "Request failed");
+  if (!res.ok) throw readErrorBody(res.status, data);
   return data as T;
 }
 

--- a/frontend/src/lib/contract-errors.test.ts
+++ b/frontend/src/lib/contract-errors.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Frontend contract-error extraction tests (#279).
+ */
+
+import { describe, test, expect } from "@jest/globals";
+import {
+  CONTRACT_ERROR_MESSAGES,
+  extractContractError,
+  formatErrorForToast,
+} from "./contract-errors";
+
+describe("extractContractError (#279)", () => {
+  test("parses the Soroban SDK panic shape and maps known codes", () => {
+    const out = extractContractError("Error(Contract, #2)");
+    expect(out.code).toBe(2);
+    expect(out.message).toContain(CONTRACT_ERROR_MESSAGES[2]);
+    expect(out.message).toContain("code 2");
+  });
+
+  test("falls back to the raw message when the code is unknown", () => {
+    const out = extractContractError("Error(Contract, #999)");
+    expect(out.code).toBe(999);
+    expect(out.message).toContain("code 999");
+  });
+
+  test("parses `code=N` style backend messages", () => {
+    const out = extractContractError("contract panic; code=7; ...");
+    expect(out.code).toBe(7);
+    expect(out.message).toContain(CONTRACT_ERROR_MESSAGES[7]);
+  });
+
+  test("unwraps an Error instance's message", () => {
+    const err = new Error("Error(Contract, #4)");
+    const out = extractContractError(err);
+    expect(out.code).toBe(4);
+    expect(out.message).toContain(CONTRACT_ERROR_MESSAGES[4]);
+  });
+
+  test("reads a structured object payload", () => {
+    const out = extractContractError({
+      code: 8,
+      message: "Contract paused at block 12345",
+      details: "see ContractAdmin.pause()",
+    });
+    expect(out.code).toBe(8);
+    expect(out.message).toContain(CONTRACT_ERROR_MESSAGES[8]);
+    expect(out.details).toBe("see ContractAdmin.pause()");
+  });
+
+  test("returns 'Unknown error' on null / undefined", () => {
+    expect(extractContractError(null).message).toBe("Unknown error");
+    expect(extractContractError(undefined).message).toBe("Unknown error");
+  });
+});
+
+describe("formatErrorForToast (#279)", () => {
+  test("returns the formatted message ready for a toast call site", () => {
+    expect(formatErrorForToast("Error(Contract, #3)")).toContain(
+      CONTRACT_ERROR_MESSAGES[3],
+    );
+  });
+});

--- a/frontend/src/lib/contract-errors.ts
+++ b/frontend/src/lib/contract-errors.ts
@@ -1,0 +1,121 @@
+/**
+ * Contract error extraction + mapping (#279).
+ *
+ * Soroban contract invocations carry useful failure detail in their
+ * error payload, but the frontend was throwing a generic
+ * "Request failed" / "transaction failed" — operators had no idea
+ * which guard rail tripped.
+ *
+ * This module:
+ *   - extracts a structured `{ code, message, details }` triple from
+ *     whatever the backend returned (Error / Response body / string),
+ *   - maps the contract's documented numeric error codes to
+ *     human-friendly messages so the toast surfaces *what* went wrong,
+ *     not just *that* it went wrong.
+ *
+ * The mapping table is intentionally small — extend it as new error
+ * variants land in `src/errors.rs`.
+ */
+
+export interface ExtractedError {
+  /**
+   * Best-effort numeric / string code from the backend payload, or
+   * `null` when nothing parseable was present.
+   */
+  code: string | number | null;
+  /** Human-friendly headline for the toast. */
+  message: string;
+  /** Raw detail string (stack / contract panic / etc.) for "show more". */
+  details?: string;
+}
+
+/**
+ * Numeric → user-friendly message map. Codes match the variants in
+ * `src/errors.rs` of the contract. Anything missing falls through to
+ * the generic message but keeps the code visible in the toast.
+ */
+export const CONTRACT_ERROR_MESSAGES: Record<number, string> = {
+  1: "Contract is already initialized.",
+  2: "Caller is not the contract admin.",
+  3: "Collaborator address is duplicated in the share split.",
+  4: "Collaborator shares do not sum to 100%.",
+  5: "Token id has already been distributed.",
+  6: "Sale price must be greater than zero.",
+  7: "Secondary royalty bps exceeds the configured cap.",
+  8: "Contract is paused; please try again later.",
+};
+
+/**
+ * Pull the cleanest error code + message we can out of an arbitrary
+ * thrown value. Safe to call from any `catch (e)` block.
+ */
+export function extractContractError(input: unknown): ExtractedError {
+  if (input == null) {
+    return { code: null, message: "Unknown error" };
+  }
+  if (typeof input === "string") {
+    return parseErrorString(input);
+  }
+  if (input instanceof Error) {
+    // The `Error` thrown by api.ts puts the backend's `data.error`
+    // into `message`; parse it back into structured form.
+    return parseErrorString(input.message);
+  }
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    const code = (obj.code ?? obj.errorCode ?? obj.status ?? null) as string | number | null;
+    const message =
+      (typeof obj.message === "string" && obj.message) ||
+      (typeof obj.error === "string" && obj.error) ||
+      "Unknown error";
+    const details = typeof obj.details === "string" ? obj.details : undefined;
+    return finalize({ code, message, details });
+  }
+  return { code: null, message: String(input) };
+}
+
+/**
+ * Parse strings of the form `"Error(Contract, #7)"` or
+ * `"contract error: ...; code=7"` that the backend forwards from
+ * the SDK. Anything we can't parse becomes a vanilla message.
+ */
+function parseErrorString(raw: string): ExtractedError {
+  const trimmed = raw.trim();
+  // `Error(Contract, #7)` — Soroban SDK panic shape.
+  const sdkMatch = trimmed.match(/Error\(Contract,\s*#(\d+)\)/i);
+  if (sdkMatch) {
+    const code = Number(sdkMatch[1]);
+    return finalize({ code, message: trimmed });
+  }
+  // `code=7` / `code:7` — backend-friendly shape.
+  const codeMatch = trimmed.match(/code\s*[=:]\s*(\d+)/i);
+  if (codeMatch) {
+    return finalize({ code: Number(codeMatch[1]), message: trimmed });
+  }
+  return finalize({ code: null, message: trimmed });
+}
+
+function finalize(input: ExtractedError): ExtractedError {
+  const { code, message, details } = input;
+  if (typeof code === "number" && CONTRACT_ERROR_MESSAGES[code]) {
+    return {
+      code,
+      message: `${CONTRACT_ERROR_MESSAGES[code]} (code ${code})`,
+      details: details ?? message,
+    };
+  }
+  if (code !== null && code !== undefined) {
+    return { code, message: `${message} (code ${code})`, details };
+  }
+  return { code: null, message, details };
+}
+
+/**
+ * Convenience: format the toast string the rest of the UI shows.
+ * Wraps `extractContractError` so call sites can stay one-liners:
+ *
+ *   showToast(formatErrorForToast(err));
+ */
+export function formatErrorForToast(input: unknown): string {
+  return extractContractError(input).message;
+}


### PR DESCRIPTION
## Summary

closes #276
closes #278
closes #279
closes #285

### #276 — CORS config allows all origins in production

- New \`backend/src/cors-config.js\` with \`isDevEnv\`, \`validateCorsOrigin\`, \`resolveCorsOrigin\`.
- **Production:** \`FRONTEND_ORIGIN\` is REQUIRED; \`*\` is rejected; malformed URLs are rejected; \`file://\` / \`ftp://\` blocked.
- **Development:** \`*\` allowed; defaults to \`*\` when no env var is set so iterating from any localhost port works.
- \`backend/src/index.js\` wires \`resolveCorsOrigin()\` so the server **refuses to start** with a misconfigured policy instead of silently opening the surface.

### #278 — Structured logging with log levels

- \`backend/src/logger.js\`: exported \`resolveLevel(rawLevel)\` + \`VALID_LEVELS\` so other modules + tests can introspect.
- Invalid \`LOG_LEVEL\` values fall back to \`info\` and log a one-time warning on boot — misconfig is visible without silencing the whole app.
- Added \`errors({ stack: true })\` to the winston format so thrown errors keep their stack in the JSON output.

### #279 — Transaction error messages from contract are swallowed

- New \`frontend/src/lib/contract-errors.ts\`:
  - \`extractContractError(input)\` parses Soroban SDK panic strings (\`Error(Contract, #N)\`), \`code=N\` style messages, \`Error\` instances, and structured \`{code,message,details}\` objects.
  - \`CONTRACT_ERROR_MESSAGES\` maps the documented numeric error codes from \`src/errors.rs\` to user-friendly headlines (\`Caller is not the contract admin (code 2)\`).
  - \`formatErrorForToast(input)\` one-liner for \`catch (e)\` sites.
- \`frontend/src/api.ts\`:
  - New \`BackendApiError\` (status + code + message + details).
  - \`post()\` / \`get()\` route 4xx/5xx responses through \`extractContractError\` so the thrown error carries the friendly message + code — toasts upstream don't need any change to surface the new detail.

### #285 — Contract has no wasm-opt step in build pipeline

- New \`Makefile\` with \`build\` / \`optimize\` / \`check-size\` / \`deploy-ready\` / \`clean\` targets.
- \`optimize\` runs \`wasm-opt -Oz\` on the release artifact when the binary is on PATH; falls back to \`stellar contract optimize\` (which embeds wasm-opt) so the target works in dev + CI even when the standalone binary isn't provisioned.
- \`check-size\` prints raw vs optimised byte counts so CI can fail on a size regression.
- \`scripts/deploy.sh\` is untouched; this Makefile gives CI a build-only path that doesn't touch the network.

## Test plan

- [x] \`backend/tests/cors-config.test.js\` — isDevEnv truthy/falsy, validateCorsOrigin dev \`*\` allowed + prod \`*\` rejected + malformed URL + file:// rejected, resolveCorsOrigin dev default + prod missing-env throw + explicit value passthrough.
- [x] \`backend/tests/logger.test.js\` — resolveLevel defaults + case-insensitivity + typo fallback; VALID_LEVELS hierarchy.
- [x] \`frontend/src/lib/contract-errors.test.ts\` — SDK panic + code=N + Error instance + structured object inputs; unknown-code raw fallback; null/undefined safe; formatErrorForToast one-liner.
- [ ] CI: \`npm test --workspace backend\` — new files pass.
- [ ] CI: \`make build\` + \`make check-size\` on a Linux runner.