### PR TITLE
feat: contract version, set_recipients, withdraw, and per-request sequence locking

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -140,4 +140,4 @@ environment variables:
 
 When the fee fetch fails the backend falls back to `BASE_FEE` (`100` stroops) so transaction submission keeps working.
 
-Transactions built via `retryBuildTx` refresh the account sequence (#275) on every attempt; retries never reuse a stale sequence.
+Transactions built via `retryBuildTx` refresh the account sequence (#275) on every attempt; retries never reuse a stale sequence. Concurrent builds for the same wallet address are serialized with a per-address lock (#294) so simultaneous requests never fetch the same sequence number and fail with `tx_bad_seq`.

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import StellarSdk from "@stellar/stellar-sdk";
-import { isContractInitialized, server, networkPassphrase, addressToScVal } from "../stellar.js";
+import { isContractInitialized, server, networkPassphrase, addressToScVal, getContractVersionFromContract } from "../stellar.js";
 import { validateContractIdMiddleware, validateContractId } from "../validation.js";
 
 const { Contract, SorobanRpc, TransactionBuilder, BASE_FEE, Account } = StellarSdk;
@@ -130,4 +130,32 @@ contractRouter.get(
       next(err);
     }
   }
+);
+
+/**
+ * GET /api/contract/version/:contractId
+ * Returns the on-chain contract version via simulation.
+ * Response: { contractId, version: string }
+ */
+contractRouter.get(
+  "/version/:contractId",
+  validateContractIdMiddleware,
+  async (req, res, next) => {
+    try {
+      const { contractId } = req.params;
+      const initialized = await isContractInitialized(contractId);
+      if (!initialized) {
+        return res.status(404).json({ error: "contract not initialized" });
+      }
+
+      const version = await getContractVersionFromContract(contractId);
+      if (!version) {
+        return res.status(404).json({ error: "contract version unavailable" });
+      }
+
+      res.json({ contractId, version });
+    } catch (err) {
+      next(err);
+    }
+  },
 );

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -12,6 +12,8 @@
  *     Falls back to BASE_FEE on fetch failure.
  *   - `retryBuildTx` calls `getFreshAccount()` on every attempt, so each
  *     rebuilt transaction carries a freshly refetched sequence number.
+ *   - Per-address build locks (#294) serialize concurrent `buildTx` calls for
+ *     the same wallet so two simultaneous requests never reuse one sequence.
  */
 import StellarSdk from "@stellar/stellar-sdk";
 import logger from "./logger.js";
@@ -231,7 +233,44 @@ export async function getRecommendedFee() {
   }
 }
 
-// ── Build path (#273, #274, #275) ──────────────────────────────────────────
+// ── Per-address build lock (#294) ──────────────────────────────────────────
+
+/** @type {Map<string, Promise<void>>} */
+const accountBuildLocks = new Map();
+
+/**
+ * Serialize async work per Stellar account so concurrent transaction builds
+ * never fetch the same sequence number (#294).
+ */
+export async function withAccountBuildLock(callerAddress, fn) {
+  const key = callerAddress;
+  const previous = accountBuildLocks.get(key) ?? Promise.resolve();
+  let release;
+  const current = new Promise((resolve) => {
+    release = resolve;
+  });
+  accountBuildLocks.set(
+    key,
+    previous.then(() => current),
+  );
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (accountBuildLocks.get(key) === current) {
+      accountBuildLocks.delete(key);
+    }
+  }
+}
+
+/** Reset build locks (for tests). */
+export function _resetAccountBuildLocks() {
+  accountBuildLocks.clear();
+}
+
+// ── Build path (#273, #274, #275, #294) ────────────────────────────────────
 
 /**
  * Fetch a fresh account record (including the current sequence number) for
@@ -251,24 +290,26 @@ export async function getFreshAccount(callerAddress) {
  * The frontend signs and submits it.
  */
 export async function buildTx(callerAddress, contractId, method, args = []) {
-  const account = await getFreshAccount(callerAddress);
-  const fee = await getRecommendedFee();
-  const contract = new Contract(contractId);
+  return withAccountBuildLock(callerAddress, async () => {
+    const account = await getFreshAccount(callerAddress);
+    const fee = await getRecommendedFee();
+    const contract = new Contract(contractId);
 
-  const tx = new TransactionBuilder(account, {
-    fee,
-    networkPassphrase,
-  })
-    .addOperation(contract.call(method, ...args))
-    .setTimeout(30)
-    .build();
+    const tx = new TransactionBuilder(account, {
+      fee,
+      networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
 
-  const prepared = await withTimeout(
-    server.prepareTransaction(tx),
-    SOROBAN_RPC_TIMEOUT_MS,
-    "Soroban prepareTransaction",
-  );
-  return prepared.toXDR();
+    const prepared = await withTimeout(
+      server.prepareTransaction(tx),
+      SOROBAN_RPC_TIMEOUT_MS,
+      "Soroban prepareTransaction",
+    );
+    return prepared.toXDR();
+  });
 }
 
 function isRateLimitError(error) {
@@ -288,10 +329,9 @@ function isTimeoutError(error) {
 /**
  * Retry wrapper for buildTx with exponential backoff.
  *
- * Sequence-number freshness (#275): every attempt re-enters `buildTx`,
- * which always calls `getFreshAccount` — the retry therefore carries the
- * latest sequence number from Horizon, not the one captured by the first
- * attempt.
+ * Sequence-number freshness (#275, #294): every attempt re-enters `buildTx`,
+ * which always calls `getFreshAccount` under a per-address lock — concurrent
+ * requests for the same wallet are serialized so they never reuse one sequence.
  *
  * Timeouts (#273) surface as `{ status: 504 }` and are retried like other
  * network errors up to `maxRetries`.
@@ -456,6 +496,41 @@ export async function isContractInitialized(contractId) {
   );
   if (SorobanRpc.Api.isSimulationError(sim)) return false;
   return sim.result?.retval?.bool() ?? false;
+}
+
+/**
+ * Fetch the on-chain contract version via read-only simulation.
+ * Returns the semver string, or null when the contract is not initialized.
+ */
+export async function getContractVersionFromContract(contractId) {
+  const contract = new Contract(contractId);
+  const dummyAccount = new Account(
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    "0",
+  );
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call("get_version"))
+    .setTimeout(30)
+    .build();
+
+  const sim = await withTimeout(
+    server.simulateTransaction(tx),
+    SOROBAN_RPC_TIMEOUT_MS,
+    "Soroban simulateTransaction",
+  );
+  if (SorobanRpc.Api.isSimulationError(sim)) return null;
+
+  const retval = sim.result?.retval;
+  if (!retval) return null;
+
+  try {
+    return retval.str().toString();
+  } catch {
+    return null;
+  }
 }
 
 // ── Test exports ───────────────────────────────────────────────────────────

--- a/backend/tests/stellar.test.js
+++ b/backend/tests/stellar.test.js
@@ -244,3 +244,104 @@ describe("retryBuildTx sequence-refresh contract (#275)", () => {
     }
   });
 });
+
+// ── #294 — Concurrent build lock ────────────────────────────────────────
+
+describe("buildTx concurrent locking (#294)", () => {
+  test("serializes getAccount for the same caller address", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const getAccount = jest.fn(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inFlight -= 1;
+      return {
+        accountId: () => "GTEST",
+        sequenceNumber: () => "1",
+      };
+    });
+    const prepareTransaction = jest.fn(async () => ({ toXDR: () => "MOCK_XDR" }));
+
+    jest.unstable_mockModule("@stellar/stellar-sdk", () => {
+      class Account {
+        constructor(id, seq) {
+          this.id = id;
+          this.seq = seq;
+        }
+        accountId() {
+          return this.id;
+        }
+        sequenceNumber() {
+          return this.seq;
+        }
+      }
+      const mock = {
+        Contract: class {
+          constructor(id) {
+            this.id = id;
+          }
+          call(method, ...args) {
+            return { kind: "op", method, args };
+          }
+        },
+        Networks: {
+          PUBLIC: "Public",
+          TESTNET: "Test SDF Network ; September 2015",
+        },
+        SorobanRpc: {
+          Server: class {
+            constructor() {}
+            getAccount = getAccount;
+            prepareTransaction = prepareTransaction;
+            simulateTransaction = jest.fn();
+          },
+          Api: { isSimulationError: () => false },
+        },
+        TransactionBuilder: class {
+          constructor() {
+            this.ops = [];
+          }
+          addOperation(op) {
+            this.ops.push(op);
+            return this;
+          }
+          setTimeout() {
+            return this;
+          }
+          build() {
+            return {};
+          }
+        },
+        BASE_FEE: "100",
+        nativeToScVal: () => ({}),
+        Address: class {
+          constructor(a) {
+            this.a = a;
+          }
+          toScVal() {
+            return { addr: this.a };
+          }
+        },
+        Account,
+        xdr: { ScVal: { scvU32: () => ({}), scvVec: () => ({}) } },
+      };
+      return { default: mock, ...mock };
+    });
+
+    global.fetch = jest.fn(async () => ({ ok: false, status: 500 }));
+
+    const stellar = await import("../src/stellar.js");
+    stellar._resetFeeCache();
+    stellar._resetAccountBuildLocks();
+
+    await Promise.all([
+      stellar.buildTx("GCALLER", "CCONTRACT", "noop", []),
+      stellar.buildTx("GCALLER", "CCONTRACT", "noop", []),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+    expect(getAccount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -245,6 +245,9 @@ export const api = {
   getContractStatus: (contractId: string) =>
     get<{ initialized: boolean }>(`/contract/status/${contractId}`),
 
+  getContractVersion: (contractId: string) =>
+    get<{ contractId: string; version: string }>(`/contract/version/${contractId}`),
+
   // NEW: Fetch royalty rate from contract
   getRoyaltyRate: (contractId: string) =>
     get<{ royaltyRate: number }>(`/secondary-royalty/rate/${contractId}`),

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 //! Authorization helpers with consistent, integrator-facing failure context.
 
-use soroban_sdk::{Address, Env, String, symbol_short};
+use soroban_sdk::{symbol_short, Address, Env, String};
 
 /// Static auth failure messages (function context + role).
 pub mod msg {
@@ -11,6 +11,8 @@ pub mod msg {
     pub const ADMIN_TRANSFER_ADMIN: &str = "admin_transfer: admin authorization required";
     pub const SET_DEFAULT_RECIPIENTS_ADMIN: &str =
         "set_default_recipients: admin authorization required";
+    pub const SET_RECIPIENTS_ADMIN: &str = "set_recipients: admin authorization required";
+    pub const WITHDRAW_ADMIN: &str = "withdraw: admin authorization required";
     pub const DISTRIBUTE_ADMIN: &str = "distribute: admin authorization required";
     pub const DISTRIBUTE_OVERRIDE_ADMIN: &str =
         "distribute_with_override: admin authorization required";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,7 @@ pub mod auth;
 mod storage;
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
-    token, Address, Env, Map, Vec, String,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, String, Vec,
 };
 
 #[contracttype]
@@ -38,12 +37,22 @@ pub type DataKey = StorageKey;
 const MIN_TTL: u32 = 17_280;
 const MAX_TTL: u32 = 34_560;
 
+/// On-chain contract version in [semantic versioning](https://semver.org/) format
+/// (`MAJOR.MINOR.PATCH`, e.g. `"0.1.0"`).
+///
+/// Written to `StorageKey::ContractVersion` during `initialize` and exposed via
+/// `get_version()`. Deploying upgraded WASM creates a new contract instance;
+/// existing instances retain their stored version so integrators can detect
+/// capability differences off-chain. No automatic state migration is performed
+/// between versions — read `get_version()` before invoking version-specific
+/// entrypoints and plan migrations explicitly when redeploying.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[contract]
 pub struct RoyaltySplitter;
 
 #[contractimpl]
 impl RoyaltySplitter {
-
     /// Initialize the contract with collaborators and their revenue shares.
     ///
     /// Can only be called once. The first address in `collaborators` becomes
@@ -66,11 +75,7 @@ impl RoyaltySplitter {
     /// * `"shares must sum to 10000"` — allocations don't total 100%
     /// * `"share cannot be zero"` — any individual share is 0
     /// * `"duplicate collaborator address"` — same address appears more than once
-    pub fn initialize(
-        env: Env,
-        collaborators: Vec<Address>,
-        shares: Vec<u32>,
-    ) {
+    pub fn initialize(env: Env, collaborators: Vec<Address>, shares: Vec<u32>) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
         if env.storage().instance().has(&StorageKey::Admin) {
@@ -128,11 +133,17 @@ impl RoyaltySplitter {
         admin.require_auth();
 
         env.storage().instance().set(&StorageKey::Admin, &admin);
-        env.storage().instance().set(&StorageKey::Collaborators, &collaborators);
-        env.storage().instance().set(&StorageKey::ShareMap, &share_map);
+        env.storage()
+            .instance()
+            .set(&StorageKey::Collaborators, &collaborators);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ShareMap, &share_map);
 
-        let version = String::from_str(&env, env!("CARGO_PKG_VERSION"));
-        env.storage().instance().set(&StorageKey::ContractVersion, &version);
+        let version = String::from_str(&env, VERSION);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ContractVersion, &version);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("init")),
@@ -171,7 +182,9 @@ impl RoyaltySplitter {
             panic!("royalty rate cannot exceed 10000 basis points");
         }
 
-        env.storage().instance().set(&StorageKey::RoyaltyRate, &new_rate);
+        env.storage()
+            .instance()
+            .set(&StorageKey::RoyaltyRate, &new_rate);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("rate_set")),
@@ -295,19 +308,8 @@ impl RoyaltySplitter {
     /// list is supplied to distribute(). Useful for standard royalty splits that
     /// don't change frequently.
     ///
-    /// # Arguments
-    /// * `recipients` - Ordered list of (address, share) pairs for default distribution.
-    ///   Maximum of 10 recipients allowed. Shares must sum to exactly 10,000 (100%).
-    ///
     /// # Authorization
     /// Requires admin signature.
-    ///
-    /// # Panics
-    /// * `"contract not initialized"` — called before `initialize`
-    /// * `"too many recipients: maximum 10 allowed"` — more than 10 recipients
-    /// * `"shares must sum to 10000"` — allocations don't total 100%
-    /// * `"share cannot be zero"` — any individual share is 0
-    /// * `"duplicate recipient address"` — same address appears more than once
     pub fn set_default_recipients(env: Env, recipients: Vec<Recipient>) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -318,45 +320,92 @@ impl RoyaltySplitter {
             .expect("contract not initialized");
 
         auth::require_admin(&env, &admin, auth::msg::SET_DEFAULT_RECIPIENTS_ADMIN);
+        Self::validate_recipient_list(&env, &recipients);
 
-        if recipients.is_empty() {
-            panic!("recipients list cannot be empty");
-        }
-
-        if recipients.len() > 10 {
-            panic!("too many recipients: maximum 10 allowed");
-        }
-
-        let mut total_shares: u32 = 0;
-        let mut address_set: Vec<Address> = Vec::new(&env);
-
-        for i in 0..recipients.len() {
-            let recipient = recipients.get(i).unwrap();
-            
-            if recipient.share == 0 {
-                panic!("share cannot be zero");
-            }
-
-            // Check for duplicate addresses
-            for j in 0..address_set.len() {
-                if address_set.get(j).unwrap() == recipient.address {
-                    panic!("duplicate recipient address");
-                }
-            }
-            address_set.push_back(recipient.address.clone());
-
-            total_shares += recipient.share;
-        }
-
-        if total_shares != 10_000 {
-            panic!("shares must sum to 10000");
-        }
-
-        env.storage().instance().set(&StorageKey::DefaultRecipients, &recipients);
+        env.storage()
+            .instance()
+            .set(&StorageKey::DefaultRecipients, &recipients);
 
         env.events().publish(
             (symbol_short!("default"), symbol_short!("recipients_set")),
             recipients.len(),
+        );
+    }
+
+    /// Update the primary collaborator recipient list stored in persistent storage.
+    ///
+    /// Replaces `StorageKey::Collaborators` and `StorageKey::ShareMap` so the
+    /// updated list survives ledger TTL and is returned by `get_recipients()`.
+    ///
+    /// # Authorization
+    /// Requires admin signature.
+    pub fn set_recipients(env: Env, recipients: Vec<Recipient>) {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("contract not initialized");
+
+        auth::require_admin(&env, &admin, auth::msg::SET_RECIPIENTS_ADMIN);
+        Self::validate_recipient_list(&env, &recipients);
+
+        let mut collaborators: Vec<Address> = Vec::new(&env);
+        let mut share_map: Map<Address, u32> = Map::new(&env);
+
+        for i in 0..recipients.len() {
+            let recipient = recipients.get(i).unwrap();
+            collaborators.push_back(recipient.address.clone());
+            share_map.set(recipient.address.clone(), recipient.share);
+        }
+
+        env.storage()
+            .instance()
+            .set(&StorageKey::Collaborators, &collaborators);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ShareMap, &share_map);
+
+        env.events().publish(
+            (symbol_short!("royalty"), symbol_short!("recip_set")),
+            recipients.len(),
+        );
+    }
+
+    /// Admin-only recovery of stuck token balances held by the contract.
+    ///
+    /// Transfers `amount` of `token` from the contract to the admin address.
+    /// Use when funds remain after a partial distribution failure.
+    ///
+    /// # Authorization
+    /// Requires admin signature.
+    pub fn withdraw(env: Env, token: Address, amount: i128) {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("contract not initialized");
+
+        auth::require_admin(&env, &admin, auth::msg::WITHDRAW_ADMIN);
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        let balance = token_client.balance(&env.current_contract_address());
+        if amount > balance {
+            panic!("insufficient balance");
+        }
+
+        token_client.transfer(&env.current_contract_address(), &admin, &amount);
+
+        env.events().publish(
+            (symbol_short!("royalty"), symbol_short!("withdraw")),
+            (token, amount),
         );
     }
 
@@ -402,7 +451,12 @@ impl RoyaltySplitter {
 
         auth::require_admin(&env, &admin, auth::msg::DISTRIBUTE_OVERRIDE_ADMIN);
 
-        if env.storage().instance().get::<StorageKey, bool>(&StorageKey::Paused).unwrap_or(false) {
+        if env
+            .storage()
+            .instance()
+            .get::<StorageKey, bool>(&StorageKey::Paused)
+            .unwrap_or(false)
+        {
             panic!("contract is paused");
         }
 
@@ -417,7 +471,7 @@ impl RoyaltySplitter {
                 .instance()
                 .get(&StorageKey::DefaultRecipients)
                 .unwrap_or(Vec::new(&env));
-            
+
             if !defaults.is_empty() {
                 defaults
             } else {
@@ -427,17 +481,20 @@ impl RoyaltySplitter {
                     .instance()
                     .get(&StorageKey::Collaborators)
                     .expect("no collaborators");
-                
+
                 let share_map: Map<Address, u32> = env
                     .storage()
                     .instance()
                     .get(&StorageKey::ShareMap)
                     .expect("no share map");
-                
+
                 let mut recipients: Vec<Recipient> = Vec::new(&env);
                 for addr in collaborators.iter() {
                     let share = share_map.get(addr.clone()).unwrap_or(0);
-                    recipients.push_back(Recipient { address: addr, share });
+                    recipients.push_back(Recipient {
+                        address: addr,
+                        share,
+                    });
                 }
                 recipients
             }
@@ -486,7 +543,8 @@ impl RoyaltySplitter {
 
         for (addr, payout) in payouts.iter() {
             token_client.transfer(&env.current_contract_address(), &addr, &payout);
-            env.events().publish((symbol_short!("dist"),), (addr, payout));
+            env.events()
+                .publish((symbol_short!("dist"),), (addr, payout));
         }
 
         env.events().publish(
@@ -504,7 +562,7 @@ impl RoyaltySplitter {
             .instance()
             .get(&StorageKey::DistributeHistory)
             .unwrap_or(0);
-        
+
         // Use saturating add to prevent overflow - will cap at u64::MAX
         let new_count = current_count.saturating_add(1);
         env.storage()
@@ -515,7 +573,7 @@ impl RoyaltySplitter {
     /// Get the total number of successful royalty distributions.
     ///
     /// Returns a monotonically increasing counter that increments on every
-    /// successful distribute() or distribute_with_override() call. Never decrements. 
+    /// successful distribute() or distribute_with_override() call. Never decrements.
     /// Uses saturating arithmetic to prevent overflow (caps at u64::MAX).
     ///
     /// Safe to call at any time — returns 0 if no distributions have occurred.
@@ -561,12 +619,7 @@ impl RoyaltySplitter {
     ///
     /// # Authorization
     /// Requires signature from `from`.
-    pub fn record_secondary_royalty(
-        env: Env,
-        token: Address,
-        from: Address,
-        royalty_amount: i128,
-    ) {
+    pub fn record_secondary_royalty(env: Env, token: Address, from: Address, royalty_amount: i128) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         auth::require_payer(&env, &from, auth::msg::RECORD_SECONDARY_PAYER);
 
@@ -589,7 +642,9 @@ impl RoyaltySplitter {
             .instance()
             .set(&StorageKey::SecondaryPool, &(current_pool + royalty_amount));
 
-        env.storage().instance().set(&StorageKey::SecondaryToken, &token);
+        env.storage()
+            .instance()
+            .set(&StorageKey::SecondaryToken, &token);
     }
 
     /// Distribute all accumulated secondary royalties to collaborators.
@@ -619,7 +674,12 @@ impl RoyaltySplitter {
 
         auth::require_admin(&env, &admin, auth::msg::DISTRIBUTE_SECONDARY_ADMIN);
 
-        if env.storage().instance().get::<StorageKey, bool>(&StorageKey::Paused).unwrap_or(false) {
+        if env
+            .storage()
+            .instance()
+            .get::<StorageKey, bool>(&StorageKey::Paused)
+            .unwrap_or(false)
+        {
             panic!("contract is paused");
         }
 
@@ -680,19 +740,23 @@ impl RoyaltySplitter {
 
         for (addr, payout) in payouts.iter() {
             token_client.transfer(&env.current_contract_address(), &addr, &payout);
-            env.events().publish((symbol_short!("sec_dist"),), (addr, payout));
+            env.events()
+                .publish((symbol_short!("sec_dist"),), (addr, payout));
         }
 
-        env.storage().instance().set(&StorageKey::SecondaryPool, &0_i128);
+        env.storage()
+            .instance()
+            .set(&StorageKey::SecondaryPool, &0_i128);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("sec_dist")),
             (token, pool),
         );
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::LastSecondaryDistribution, &env.ledger().timestamp());
+        env.storage().instance().set(
+            &StorageKey::LastSecondaryDistribution,
+            &env.ledger().timestamp(),
+        );
     }
 
     /// Calculate and return the royalty amount for a given secondary sale price.
@@ -728,7 +792,10 @@ impl RoyaltySplitter {
     /// Returns 0 if `set_royalty_rate` has never been called.
     pub fn get_royalty_rate(env: Env) -> u32 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
-        env.storage().instance().get(&StorageKey::RoyaltyRate).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&StorageKey::RoyaltyRate)
+            .unwrap_or(0)
     }
 
     /// Returns all recipients as an ordered list of (address, share) pairs.
@@ -754,22 +821,30 @@ impl RoyaltySplitter {
         let mut recipients: Vec<Recipient> = Vec::new(&env);
         for addr in collaborators.iter() {
             let share = share_map.get(addr.clone()).unwrap_or(0);
-            recipients.push_back(Recipient { address: addr, share });
+            recipients.push_back(Recipient {
+                address: addr,
+                share,
+            });
         }
         recipients
     }
 
-    /// Returns the contract's semantic version string (set from `CARGO_PKG_VERSION`
-    /// at initialization time).
+    /// Returns the contract's semantic version string (set from [`VERSION`] at
+    /// initialization time).
     ///
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
-    pub fn version(env: Env) -> String {
+    pub fn get_version(env: Env) -> String {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         env.storage()
             .instance()
             .get(&StorageKey::ContractVersion)
             .expect("contract not initialized")
+    }
+
+    /// Backward-compatible alias for [`get_version`].
+    pub fn version(env: Env) -> String {
+        Self::get_version(env)
     }
 
     /// Returns the basis-point share for a registered collaborator.
@@ -829,7 +904,9 @@ impl RoyaltySplitter {
         }
 
         share_map.set(collaborator.clone(), new_share);
-        env.storage().instance().set(&StorageKey::ShareMap, &share_map);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ShareMap, &share_map);
 
         env.events().publish(
             (symbol_short!("share"), symbol_short!("updated")),
@@ -889,7 +966,10 @@ impl RoyaltySplitter {
     /// Returns 0 if no royalties have been recorded yet.
     pub fn get_secondary_pool(env: Env) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
-        env.storage().instance().get(&StorageKey::SecondaryPool).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&StorageKey::SecondaryPool)
+            .unwrap_or(0)
     }
 
     /// Returns the timestamp of the last primary distribution, or None if never distributed.
@@ -901,7 +981,9 @@ impl RoyaltySplitter {
     /// Returns the timestamp of the last secondary distribution, or None if never distributed.
     pub fn get_last_secondary_distribution(env: Env) -> Option<u64> {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
-        env.storage().instance().get(&StorageKey::LastSecondaryDistribution)
+        env.storage()
+            .instance()
+            .get(&StorageKey::LastSecondaryDistribution)
     }
 
     /// Returns the sum of all collaborator basis-point shares.
@@ -924,5 +1006,39 @@ impl RoyaltySplitter {
             total += item.1;
         }
         total
+    }
+
+    fn validate_recipient_list(env: &Env, recipients: &Vec<Recipient>) {
+        if recipients.is_empty() {
+            panic!("recipients list cannot be empty");
+        }
+
+        if recipients.len() > 10 {
+            panic!("too many recipients: maximum 10 allowed");
+        }
+
+        let mut total_shares: u32 = 0;
+        let mut address_set: Vec<Address> = Vec::new(env);
+
+        for i in 0..recipients.len() {
+            let recipient = recipients.get(i).unwrap();
+
+            if recipient.share == 0 {
+                panic!("share cannot be zero");
+            }
+
+            for j in 0..address_set.len() {
+                if address_set.get(j).unwrap() == recipient.address {
+                    panic!("duplicate recipient address");
+                }
+            }
+            address_set.push_back(recipient.address.clone());
+
+            total_shares += recipient.share;
+        }
+
+        if total_shares != 10_000 {
+            panic!("shares must sum to 10000");
+        }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,9 +3,11 @@ use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
     token::{Client as TokenClient, StellarAssetClient},
-    vec, Address, Env, IntoVal, Map, Vec as SorobanVec,
+    vec, Address, Env, IntoVal, Map, String, Vec as SorobanVec,
 };
-use stellar_royalty_splitter::{auth, DataKey, RoyaltySplitterClient, StorageKey};
+use stellar_royalty_splitter::{
+    auth, DataKey, Recipient, RoyaltySplitterClient, StorageKey, VERSION,
+};
 
 fn setup(env: &Env) -> (Address, RoyaltySplitterClient) {
     let contract_id = env.register_contract(None, stellar_royalty_splitter::RoyaltySplitter);
@@ -45,7 +47,10 @@ fn test_distribute_rejects_invalid_share_total() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
     mint(&env, &token, &contract_id, 1000);
 
     // Corrupt share map so totals are 60% instead of 100% (defense-in-depth path).
@@ -53,9 +58,7 @@ fn test_distribute_rejects_invalid_share_total() {
     bad_map.set(admin.clone(), 3000);
     bad_map.set(b.clone(), 3000);
     env.as_contract(&contract_id, || {
-        env.storage()
-            .instance()
-            .set(&DataKey::ShareMap, &bad_map);
+        env.storage().instance().set(&DataKey::ShareMap, &bad_map);
     });
 
     client.distribute(&token);
@@ -132,7 +135,10 @@ fn test_distribute_requires_admin_auth() {
     let token = make_token(&env, &token_admin);
 
     env.mock_all_auths();
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
@@ -162,10 +168,14 @@ fn test_ttl_extended_after_ledger_advance() {
 
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    client.initialize(&vec![&env, a.clone(), b.clone()], &vec![&env, 6000_u32, 4000_u32]);
+    client.initialize(
+        &vec![&env, a.clone(), b.clone()],
+        &vec![&env, 6000_u32, 4000_u32],
+    );
 
     // Advance ledger sequence past MIN_TTL (17_280 ledgers).
-    env.ledger().set_sequence_number(env.ledger().sequence() + 17_281);
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 17_281);
 
     // Both read functions must still return correct data (TTL was extended).
     let collaborators = client.get_collaborators();
@@ -186,7 +196,10 @@ fn test_distribute_emits_event() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
     client.distribute(&token);
@@ -214,7 +227,10 @@ fn test_set_royalty_rate_emits_event() {
 
     let admin = Address::generate(&env);
     let b = Address::generate(&env);
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let rate: u32 = 250;
     client.set_royalty_rate(&rate);
@@ -245,7 +261,10 @@ fn test_distribute_secondary_royalties_emits_event() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let pool_amount: i128 = 500;
     mint(&env, &token, &admin, pool_amount);
@@ -317,7 +336,10 @@ fn test_distribute_blocked_when_paused() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
     mint(&env, &token, &contract_id, 1000);
 
     client.pause();
@@ -338,7 +360,10 @@ fn test_distribute_secondary_blocked_when_paused() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let pool_amount: i128 = 500;
     mint(&env, &token, &admin, pool_amount);
@@ -361,7 +386,10 @@ fn test_distribute_succeeds_after_unpause() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
     mint(&env, &token, &contract_id, 1000);
 
     client.pause();
@@ -386,7 +414,10 @@ fn test_pause_requires_admin_auth() {
     let admin = Address::generate(&env);
     let b = Address::generate(&env);
     env.mock_all_auths();
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
     // Clear auths so the next call has no authorization
     env.mock_auths(&[]);
     client.pause();
@@ -452,7 +483,10 @@ fn test_set_royalty_rate_unauthorized_caller() {
 
     // Initialize with mock_all_auths so setup succeeds
     env.mock_all_auths();
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     // Clear all auths — the next call has no authorization at all,
     // simulating a non-admin (or any unauthorized) caller.
@@ -480,7 +514,10 @@ fn test_distribute_unauthorized_caller() {
 
     // Initialize and fund the contract
     env.mock_all_auths();
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount: i128 = 1_000;
     mint(&env, &token, &contract_id, amount);
@@ -507,7 +544,8 @@ impl Lcg {
     }
 
     fn next(&mut self) -> u64 {
-        self.0 = self.0
+        self.0 = self
+            .0
             .wrapping_mul(6_364_136_223_846_793_005)
             .wrapping_add(1_442_695_040_888_963_407);
         self.0
@@ -661,7 +699,7 @@ fn test_distribute_property_royalty_split_arithmetic() {
 #[test]
 fn test_distribute_fuzz_large_amounts_no_overflow() {
     let large_amounts: [i128; 6] = [
-        i128::MAX / 10_001,       // just under overflow boundary
+        i128::MAX / 10_001, // just under overflow boundary
         i128::MAX / 20_000,
         1_000_000_000_000_000_000, // 10^18 stroops
         9_999_999_999_999_999,
@@ -669,12 +707,7 @@ fn test_distribute_fuzz_large_amounts_no_overflow() {
         10_000,
     ];
 
-    let split_configs: [(u32, u32); 4] = [
-        (5_000, 5_000),
-        (9_999, 1),
-        (1, 9_999),
-        (3_333, 6_667),
-    ];
+    let split_configs: [(u32, u32); 4] = [(5_000, 5_000), (9_999, 1), (1, 9_999), (3_333, 6_667)];
 
     for amount in large_amounts {
         for (share_a, share_b) in split_configs {
@@ -696,7 +729,10 @@ fn test_distribute_fuzz_large_amounts_no_overflow() {
 
             let paid = TokenClient::new(&env, &token).balance(&admin)
                 + TokenClient::new(&env, &token).balance(&b);
-            assert_eq!(paid, amount, "large amount={amount} share=({share_a},{share_b})");
+            assert_eq!(
+                paid, amount,
+                "large amount={amount} share=({share_a},{share_b})"
+            );
         }
     }
 }
@@ -760,7 +796,11 @@ fn test_distribute_secondary_fuzz_style() {
             total_paid, pool_amount,
             "Secondary pool must be fully distributed (n={n}, pool={pool_amount})"
         );
-        assert_eq!(client.get_secondary_pool(), 0, "Secondary pool must be zero after distribution");
+        assert_eq!(
+            client.get_secondary_pool(),
+            0,
+            "Secondary pool must be zero after distribution"
+        );
     }
 }
 
@@ -775,7 +815,7 @@ fn test_initialize_with_10_recipients_succeeds() {
 
     let mut addrs: SorobanVec<Address> = SorobanVec::new(&env);
     let mut shares: SorobanVec<u32> = SorobanVec::new(&env);
-    
+
     for _ in 0..10 {
         addrs.push_back(Address::generate(&env));
         shares.push_back(1_000_u32);
@@ -795,7 +835,7 @@ fn test_initialize_with_11_recipients_panics() {
 
     let mut addrs: SorobanVec<Address> = SorobanVec::new(&env);
     let mut shares: SorobanVec<u32> = SorobanVec::new(&env);
-    
+
     for i in 0..11 {
         addrs.push_back(Address::generate(&env));
         // First recipient gets 1000, others get 900 to sum to 10,000
@@ -815,7 +855,7 @@ fn test_initialize_with_15_recipients_panics() {
 
     let mut addrs: SorobanVec<Address> = SorobanVec::new(&env);
     let mut shares: SorobanVec<u32> = SorobanVec::new(&env);
-    
+
     for _ in 0..15 {
         addrs.push_back(Address::generate(&env));
         shares.push_back(666_u32); // Won't sum to 10,000 but cap check happens first
@@ -836,9 +876,12 @@ fn test_initialize_twice_panics() {
 
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
-    client.initialize(&vec![&env, a.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
-    
+
+    client.initialize(
+        &vec![&env, a.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
     // Second initialization attempt must panic
     let c = Address::generate(&env);
     let d = Address::generate(&env);
@@ -854,21 +897,24 @@ fn test_reinitialize_does_not_modify_state() {
 
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
-    client.initialize(&vec![&env, a.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
-    
+
+    client.initialize(
+        &vec![&env, a.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
     let original_count = client.collaborator_count();
     let original_share_a = client.get_share(&a);
-    
+
     // Attempt second initialization (will panic, but we catch it)
     let c = Address::generate(&env);
     let d = Address::generate(&env);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.initialize(&vec![&env, c, d], &vec![&env, 6000_u32, 4000_u32]);
     }));
-    
+
     assert!(result.is_err(), "Second initialization should panic");
-    
+
     // Verify original state is unchanged
     assert_eq!(client.collaborator_count(), original_count);
     assert_eq!(client.get_share(&a), original_share_a);
@@ -955,10 +1001,7 @@ fn test_admin_transfer_requires_admin_auth() {
     let new_admin = Address::generate(&env);
 
     env.mock_all_auths();
-    client.initialize(
-        &vec![&env, admin, b],
-        &vec![&env, 5000_u32, 5000_u32],
-    );
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
     // No mock auths for admin_transfer — must panic on require_auth
     client.admin_transfer(&new_admin);
@@ -1007,10 +1050,19 @@ fn test_set_default_recipients_requires_admin_auth() {
     let b = Address::generate(&env);
 
     env.mock_all_auths();
-    client.initialize(&vec![&env, admin.clone(), b], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
-    let recipient1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let recipient2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let recipient1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let recipient2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
 
     env.mock_auths(&[MockAuth {
@@ -1058,7 +1110,10 @@ fn test_set_default_recipients_too_many_panics() {
 
     let mut recipients: Vec<Recipient> = Vec::new(&env);
     for _ in 0..11 {
-        recipients.push_back(Recipient { address: Address::generate(&env), share: 909_u32 });
+        recipients.push_back(Recipient {
+            address: Address::generate(&env),
+            share: 909_u32,
+        });
     }
 
     client.set_default_recipients(&recipients);
@@ -1076,8 +1131,14 @@ fn test_set_default_recipients_invalid_share_sum_panics() {
     let b = Address::generate(&env);
     client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
-    let recipient1 = Recipient { address: admin, share: 5000_u32 };
-    let recipient2 = Recipient { address: b, share: 4000_u32 };
+    let recipient1 = Recipient {
+        address: admin,
+        share: 5000_u32,
+    };
+    let recipient2 = Recipient {
+        address: b,
+        share: 4000_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
 
     client.set_default_recipients(&recipients);
@@ -1095,8 +1156,14 @@ fn test_set_default_recipients_zero_share_panics() {
     let b = Address::generate(&env);
     client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
-    let recipient1 = Recipient { address: admin, share: 10000_u32 };
-    let recipient2 = Recipient { address: b, share: 0_u32 };
+    let recipient1 = Recipient {
+        address: admin,
+        share: 10000_u32,
+    };
+    let recipient2 = Recipient {
+        address: b,
+        share: 0_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
 
     client.set_default_recipients(&recipients);
@@ -1114,8 +1181,14 @@ fn test_set_default_recipients_duplicate_address_panics() {
     let b = Address::generate(&env);
     client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
-    let recipient1 = Recipient { address: admin.clone(), share: 5000_u32 };
-    let recipient2 = Recipient { address: admin.clone(), share: 5000_u32 };
+    let recipient1 = Recipient {
+        address: admin.clone(),
+        share: 5000_u32,
+    };
+    let recipient2 = Recipient {
+        address: admin.clone(),
+        share: 5000_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
 
     client.set_default_recipients(&recipients);
@@ -1132,8 +1205,14 @@ fn test_set_default_recipients_emits_event() {
     let b = Address::generate(&env);
     client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
-    let recipient1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let recipient2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let recipient1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let recipient2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
     client.set_default_recipients(&recipients);
 
@@ -1175,10 +1254,19 @@ fn test_get_default_recipients_returns_configured() {
 
     let admin = Address::generate(&env);
     let b = Address::generate(&env);
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
-    let recipient1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let recipient2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let recipient1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let recipient2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let recipients = vec![&env, recipient1, recipient2];
     client.set_default_recipients(&recipients);
 
@@ -1205,17 +1293,29 @@ fn test_distribute_with_override_uses_override() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
-    let default1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let default2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let default1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let default2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let defaults = vec![&env, default1, default2];
     client.set_default_recipients(&defaults);
 
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
 
-    let override1 = Recipient { address: c.clone(), share: 10000_u32 };
+    let override1 = Recipient {
+        address: c.clone(),
+        share: 10000_u32,
+    };
     let overrides = vec![&env, override1];
     client.distribute_with_override(&token, overrides);
 
@@ -1236,10 +1336,19 @@ fn test_distribute_with_override_falls_back_to_defaults() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
-    let default1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let default2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let default1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let default2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let defaults = vec![&env, default1, default2];
     client.set_default_recipients(&defaults);
 
@@ -1265,7 +1374,10 @@ fn test_distribute_with_override_falls_back_to_collaborators() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
@@ -1352,7 +1464,10 @@ fn test_get_distribute_count_increments_on_distribute() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     assert_eq!(client.get_distribute_count(), 0);
 
@@ -1380,7 +1495,10 @@ fn test_get_distribute_count_increments_on_distribute_with_override() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     assert_eq!(client.get_distribute_count(), 0);
 
@@ -1405,7 +1523,10 @@ fn test_get_distribute_count_never_decrements() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
@@ -1433,7 +1554,10 @@ fn test_distribute_history_overflow_safety() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     env.as_contract(&contract_id, || {
         env.storage()
@@ -1466,7 +1590,10 @@ fn test_multi_token_distribution() {
     let token1 = make_token(&env, &token_admin);
     let token2 = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount1: i128 = 1000;
     mint(&env, &token1, &contract_id, amount1);
@@ -1503,16 +1630,28 @@ fn test_multi_token_distribute_with_override() {
     let token1 = make_token(&env, &token_admin);
     let token2 = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
-    let default1 = Recipient { address: admin.clone(), share: 6000_u32 };
-    let default2 = Recipient { address: b.clone(), share: 4000_u32 };
+    let default1 = Recipient {
+        address: admin.clone(),
+        share: 6000_u32,
+    };
+    let default2 = Recipient {
+        address: b.clone(),
+        share: 4000_u32,
+    };
     let defaults = vec![&env, default1, default2];
     client.set_default_recipients(&defaults);
 
     let amount1: i128 = 1000;
     mint(&env, &token1, &contract_id, amount1);
-    let override1 = Recipient { address: c.clone(), share: 10000_u32 };
+    let override1 = Recipient {
+        address: c.clone(),
+        share: 10000_u32,
+    };
     let overrides = vec![&env, override1];
     client.distribute_with_override(&token1, overrides);
 
@@ -1541,7 +1680,10 @@ fn test_backward_compatibility_original_distribute() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     let amount: i128 = 1000;
     mint(&env, &token, &contract_id, amount);
@@ -1565,7 +1707,10 @@ fn test_existing_functionality_preserved() {
     let token_admin = Address::generate(&env);
     let token = make_token(&env, &token_admin);
 
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     client.pause();
     assert!(client.is_paused());
@@ -1593,7 +1738,10 @@ fn test_storage_key_isolation() {
 
     let admin = Address::generate(&env);
     let b = Address::generate(&env);
-    client.initialize(&vec![&env, admin.clone(), b.clone()], &vec![&env, 5000_u32, 5000_u32]);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
 
     assert_eq!(client.get_share(&admin), 5000);
     assert_eq!(client.get_share(&b), 5000);
@@ -1610,9 +1758,15 @@ fn test_storage_key_isolation() {
 
     // DataKey alias must match StorageKey serialization.
     env.as_contract(&contract_id, || {
-        let via_alias: u32 = env.storage().instance().get(&DataKey::RoyaltyRate).unwrap_or(0);
+        let via_alias: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RoyaltyRate)
+            .unwrap_or(0);
         assert_eq!(via_alias, 0);
-        env.storage().instance().set(&StorageKey::RoyaltyRate, &250_u32);
+        env.storage()
+            .instance()
+            .set(&StorageKey::RoyaltyRate, &250_u32);
     });
     assert_eq!(client.get_royalty_rate(), 250);
 }
@@ -1626,6 +1780,9 @@ fn test_auth_message_constants_include_function_context() {
     assert!(auth::msg::SET_ROYALTY_RATE_ADMIN.contains("set_royalty_rate"));
     assert!(auth::msg::DISTRIBUTE_OVERRIDE_ADMIN.contains("distribute_with_override"));
     assert!(auth::msg::RECORD_SECONDARY_PAYER.contains("record_secondary_royalty"));
+    assert!(auth::msg::SET_DEFAULT_RECIPIENTS_ADMIN.contains("set_default_recipients"));
+    assert!(auth::msg::SET_RECIPIENTS_ADMIN.contains("set_recipients"));
+    assert!(auth::msg::WITHDRAW_ADMIN.contains("withdraw"));
     assert!(auth::msg::INITIALIZE_ADMIN.contains("authorization required"));
 }
 
@@ -1642,11 +1799,309 @@ fn test_auth_req_event_emitted_on_initialize() {
 
     let events = env.events().all();
     let found = events.iter().any(|(_cid, topics, _data)| {
-        topics
-            == vec![
-                &env,
-                symbol_short!("auth_req").into_val(&env),
-            ]
+        topics == vec![&env, symbol_short!("auth_req").into_val(&env)]
     });
-    assert!(found, "auth_req event should be published before require_auth succeeds");
+    assert!(
+        found,
+        "auth_req event should be published before require_auth succeeds"
+    );
+}
+
+// ── Issue #286: contract version ────────────────────────────────────────────
+
+#[test]
+fn test_get_version_stored_on_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+
+    assert_eq!(client.get_version(), String::from_str(&env, VERSION));
+    assert_eq!(client.version(), client.get_version());
+}
+
+#[test]
+#[should_panic(expected = "contract not initialized")]
+fn test_get_version_before_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    client.get_version();
+}
+
+// ── Issue #288: set_recipients ──────────────────────────────────────────────
+
+#[test]
+fn test_set_recipients_updates_primary_list() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 7000_u32,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 3000_u32,
+        },
+    ];
+    client.set_recipients(&recipients);
+
+    let stored = client.get_recipients();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap().address, admin);
+    assert_eq!(stored.get(0).unwrap().share, 7000);
+    assert_eq!(stored.get(1).unwrap().address, c);
+    assert_eq!(stored.get(1).unwrap().share, 3000);
+    assert_eq!(client.get_share(&c), 3000);
+}
+
+#[test]
+fn test_set_recipients_requires_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 7000_u32,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 3000_u32,
+        },
+    ];
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_recipients",
+            args: (recipients.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.set_recipients(&recipients);
+}
+
+#[test]
+fn test_set_recipients_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 6000_u32,
+        },
+        Recipient {
+            address: b.clone(),
+            share: 4000_u32,
+        },
+    ];
+    client.set_recipients(&recipients);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("recip_set").into_val(&env),
+                ]
+            && data == 2_u32.into_val(&env)
+    });
+    assert!(found, "recip_set event not emitted");
+}
+
+#[test]
+#[should_panic]
+fn test_set_recipients_unauthorized_caller() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 6000_u32,
+        },
+        Recipient {
+            address: b.clone(),
+            share: 4000_u32,
+        },
+    ];
+
+    env.mock_auths(&[]);
+    client.set_recipients(&recipients);
+}
+
+// ── Issue #292: withdraw ────────────────────────────────────────────────────
+
+#[test]
+fn test_withdraw_transfers_to_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let amount: i128 = 750;
+    mint(&env, &token, &contract_id, amount);
+    client.withdraw(&token, &amount);
+
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), amount);
+    assert_eq!(TokenClient::new(&env, &token).balance(&contract_id), 0);
+}
+
+#[test]
+fn test_withdraw_requires_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    env.mock_all_auths();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let amount: i128 = 500;
+    mint(&env, &token, &contract_id, amount);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "withdraw",
+            args: (&token, amount).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.withdraw(&token, &amount);
+}
+
+#[test]
+fn test_withdraw_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let amount: i128 = 250;
+    mint(&env, &token, &contract_id, amount);
+    client.withdraw(&token, &amount);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("withdraw").into_val(&env),
+                ]
+            && data == (token.clone(), amount).into_val(&env)
+    });
+    assert!(found, "withdraw event not emitted");
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_withdraw_insufficient_balance_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+    client.withdraw(&token, &100_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_unauthorized_caller() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    env.mock_all_auths();
+    client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
+    mint(&env, &token, &contract_id, 100);
+
+    env.mock_auths(&[]);
+    client.withdraw(&token, &50_i128);
 }


### PR DESCRIPTION
## Summary

- **#286** — Store contract semver in `StorageKey::ContractVersion` on `initialize`, expose it via `get_version()` (with `version()` kept as an alias), and add a `GET /api/contract/version/:contractId` endpoint for the frontend.
- **#288** — Add admin-only `set_recipients()` to persistently update the primary collaborator list (`Collaborators` + `ShareMap`); `get_recipients()` returns the current list. Emits a `("royalty", "recip_set")` event.
- **#292** — Add admin-only `withdraw(token, amount)` to recover stuck token balances to the admin address, with event emission and integration tests.
- **#294** — Serialize concurrent `buildTx` calls per wallet address with a per-account lock so simultaneous requests no longer fetch the same sequence number and fail with `tx_bad_seq`.

Closes #286
Closes #288
Closes #292
Closes #294

## Test plan

- [ ] `cargo test` passes on Linux CI
- [ ] `cd backend && npm test` passes (includes concurrent build-lock test)
- [ ] Initialize a contract and confirm `get_version()` returns the expected semver
- [ ] Call `set_recipients()` as admin and verify `get_recipients()` reflects the update
- [ ] Fund the contract, call `withdraw()` as admin, and confirm tokens reach the admin address
- [ ] Send two concurrent transaction-build requests for the same wallet and confirm neither fails with `tx_bad_seq`
- [ ] Confirm existing `distribute`, `set_default_recipients`, and `version()` behavior is unchanged