### PR TITLE
fix: add signing key hot-reload via /admin/rotate-key (#293)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ cp backend/.env.example backend/.env
 | `HORIZON_URL`       | Horizon REST endpoint for the chosen network                                            |
 | `SOROBAN_RPC_URL`   | Soroban RPC endpoint for simulating and preparing transactions                          |
 | `SERVER_SECRET_KEY` | Server-side keypair used for read-only simulations only — never signs user transactions |
+| `SIGNING_KEY_FILE` | Optional secrets-manager file path; takes precedence over `SERVER_SECRET_KEY` on load |
+| `ADMIN_ROTATE_TOKEN` | Bearer token for `POST /admin/rotate-key` hot-reload without redeploy (#293) |
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,15 @@ SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # SERVER_SECRET_KEY — server-side signing key (only used for read-only simulation; real txs are signed client-side)
 SERVER_SECRET_KEY=S...
 
+# SIGNING_KEY_FILE — optional path to a secrets-manager file containing the signing secret (takes precedence over SERVER_SECRET_KEY on startup and file reload)
+# SIGNING_KEY_FILE=/run/secrets/server_signing_key
+
+# ADMIN_ROTATE_TOKEN — bearer token required for POST /admin/rotate-key (hot-reload without redeploy)
+ADMIN_ROTATE_TOKEN=
+
+# RATE_LIMIT_ADMIN_MAX — max POST /admin/* requests per minute per IP (default: 5)
+# RATE_LIMIT_ADMIN_MAX=5
+
 # HORIZON_URL — Horizon REST API endpoint for account and transaction queries
 # Testnet (default):
 HORIZON_URL=https://horizon-testnet.stellar.org

--- a/backend/API.md
+++ b/backend/API.md
@@ -141,3 +141,46 @@ environment variables:
 When the fee fetch fails the backend falls back to `BASE_FEE` (`100` stroops) so transaction submission keeps working.
 
 Transactions built via `retryBuildTx` refresh the account sequence (#275) on every attempt; retries never reuse a stale sequence. Concurrent builds for the same wallet address are serialized with a per-address lock (#294) so simultaneous requests never fetch the same sequence number and fail with `tx_bad_seq`.
+
+## Admin — signing key rotation
+
+### `POST /admin/rotate-key`
+
+Hot-reload the server signing key without redeploying the backend (#293). The in-memory key is used for server-side operations that require a keypair (for example read-only simulations). User-facing transaction routes still return unsigned XDR for client-side signing.
+
+**Authentication:** `Authorization: Bearer <ADMIN_ROTATE_TOKEN>`
+
+**Body (JSON):** provide one of:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `secretKey` | string | New Stellar secret key (`S...`) to load immediately |
+| `reloadFromFile` | boolean | When `true`, re-read `SIGNING_KEY_FILE` from disk |
+
+**Response:**
+
+```json
+{
+  "publicKey": "G...",
+  "rotatedAt": "2026-05-30T12:00:00.000Z",
+  "source": "api"
+}
+```
+
+| Status | Meaning |
+| ------ | ------- |
+| `200` | Key rotated successfully |
+| `400` | Validation error (missing body fields or invalid secret) |
+| `401` | Missing or invalid admin token |
+| `503` | `ADMIN_ROTATE_TOKEN` is not configured on the server |
+
+**Configuration**
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `SERVER_SECRET_KEY` | — | Initial signing secret from environment |
+| `SIGNING_KEY_FILE` | — | Path to a secrets-manager file; takes precedence on startup and when `reloadFromFile` is true |
+| `ADMIN_ROTATE_TOKEN` | — | Bearer token required to call `/admin/rotate-key` |
+| `RATE_LIMIT_ADMIN_MAX` | `5` | Per-IP rate limit for admin routes (per minute) |
+
+Key rotation events are written to structured logs (`signing_key_rotated`) with previous and new **public** keys only — secret material is never logged.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -16,11 +16,14 @@ import historyRouter from "./routes/history.js";
 import { analyticsRouter } from "./routes/analytics.js";
 import { contractRouter } from "./routes/contract.js";
 import { healthRouter } from "./routes/health.js";
+import { adminRouter } from "./routes/admin.js";
 import { initializeDatabase } from "./database/index.js";
 import db from "./database/index.js";
+import { initializeSigningKey } from "./signing-key.js";
 
 // Initialize database on startup
 initializeDatabase();
+initializeSigningKey();
 
 const app = express();
 
@@ -115,6 +118,17 @@ app.use("/api/v1", historyRouter);
 app.use("/api/v1", analyticsRouter);
 app.use("/api/v1/contract", contractRouter);
 app.use("/api/v1/health", healthRouter);
+
+// Admin operations (separate from /api/v1; protected by ADMIN_ROTATE_TOKEN)
+const adminLimiter = rateLimit({
+  windowMs: 60_000,
+  max: parseInt(process.env.RATE_LIMIT_ADMIN_MAX ?? "5"),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many admin requests, please slow down." },
+});
+app.use("/admin", adminLimiter);
+app.use("/admin", adminRouter);
 
 // Legacy /api/* redirect to /api/v1/*
 app.use("/api", (req, res) => {

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,78 @@
+import { Router } from "express";
+import { z } from "zod";
+import logger from "../logger.js";
+import { validate } from "../validation.js";
+import {
+  isAdminRotateTokenValid,
+  reloadSigningKeyFromSecretsFile,
+  rotateSigningKey,
+} from "../signing-key.js";
+
+export const adminRouter = Router();
+
+const rotateKeySchema = z
+  .object({
+    secretKey: z
+      .string()
+      .regex(/^S[A-Z2-7]{55}$/, "Invalid Stellar secret key")
+      .optional(),
+    reloadFromFile: z.boolean().optional(),
+  })
+  .refine((body) => Boolean(body.secretKey) || body.reloadFromFile === true, {
+    message: "Provide secretKey or set reloadFromFile to true",
+  });
+
+function extractBearerToken(req) {
+  const header = req.get("Authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  return header.slice("Bearer ".length).trim();
+}
+
+function requireAdminRotateToken(req, res, next) {
+  if (!process.env.ADMIN_ROTATE_TOKEN) {
+    logger.warn("Admin rotate-key rejected: ADMIN_ROTATE_TOKEN not configured", {
+      event: "signing_key_rotate_denied",
+      reason: "token_not_configured",
+    });
+    return res.status(503).json({
+      error: "Key rotation is not configured on this server",
+    });
+  }
+
+  const token = extractBearerToken(req);
+  if (!isAdminRotateTokenValid(token)) {
+    logger.warn("Admin rotate-key rejected: invalid token", {
+      event: "signing_key_rotate_denied",
+      reason: "invalid_token",
+    });
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  next();
+}
+
+/**
+ * POST /admin/rotate-key
+ * Body: { secretKey?: string, reloadFromFile?: boolean }
+ * Header: Authorization: Bearer <ADMIN_ROTATE_TOKEN>
+ */
+adminRouter.post(
+  "/rotate-key",
+  requireAdminRotateToken,
+  validate(rotateKeySchema),
+  (req, res, next) => {
+    try {
+      const result = req.body.reloadFromFile
+        ? reloadSigningKeyFromSecretsFile()
+        : rotateSigningKey(req.body.secretKey, { source: "api" });
+
+      res.json({
+        publicKey: result.publicKey,
+        rotatedAt: result.rotatedAt,
+        source: result.source,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);

--- a/backend/src/signing-key.js
+++ b/backend/src/signing-key.js
@@ -1,0 +1,173 @@
+/**
+ * Server signing key lifecycle (#293).
+ *
+ * Loads the key from SIGNING_KEY_FILE (secrets-manager mount) or
+ * SERVER_SECRET_KEY, keeps it in memory for hot rotation without redeploy,
+ * and never logs secret material.
+ */
+import { readFileSync, existsSync } from "fs";
+import { timingSafeEqual } from "crypto";
+import StellarSdk from "@stellar/stellar-sdk";
+import logger from "./logger.js";
+
+const { Keypair } = StellarSdk;
+
+let activeKeypair = null;
+let lastRotationAt = null;
+let lastRotationSource = null;
+
+function normalizeSecret(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Parse and validate a Stellar secret key. Throws on invalid input.
+ */
+export function parseSigningSecret(secret) {
+  const normalized = normalizeSecret(secret);
+  if (!normalized) {
+    throw new Error("Signing secret key is required");
+  }
+  if (!normalized.startsWith("S")) {
+    throw new Error("Signing secret key must start with 'S'");
+  }
+  try {
+    return Keypair.fromSecret(normalized);
+  } catch {
+    throw new Error("Invalid Stellar signing secret key");
+  }
+}
+
+function readSecretsFilePath() {
+  return normalizeSecret(process.env.SIGNING_KEY_FILE);
+}
+
+function readSecretFromFile(filePath) {
+  if (!existsSync(filePath)) {
+    throw new Error(`Signing key file not found: ${filePath}`);
+  }
+  const contents = readFileSync(filePath, "utf8");
+  return normalizeSecret(contents);
+}
+
+function setActiveKeypair(keypair, source) {
+  const previousPublicKey = activeKeypair?.publicKey() ?? null;
+  activeKeypair = keypair;
+  lastRotationAt = new Date().toISOString();
+  lastRotationSource = source;
+
+  logger.info("Signing key rotated", {
+    event: "signing_key_rotated",
+    source,
+    previousPublicKey,
+    publicKey: keypair.publicKey(),
+    rotatedAt: lastRotationAt,
+  });
+}
+
+/**
+ * Load signing key from SIGNING_KEY_FILE or SERVER_SECRET_KEY.
+ * Missing configuration is allowed (server may run without a signing key).
+ */
+export function initializeSigningKey() {
+  const filePath = readSecretsFilePath();
+  if (filePath) {
+    const secret = readSecretFromFile(filePath);
+    activeKeypair = parseSigningSecret(secret);
+    lastRotationSource = "file";
+    lastRotationAt = new Date().toISOString();
+    logger.info("Signing key loaded from secrets file", {
+      event: "signing_key_loaded",
+      source: "file",
+      publicKey: activeKeypair.publicKey(),
+      filePath,
+    });
+    return activeKeypair;
+  }
+
+  const envSecret = normalizeSecret(process.env.SERVER_SECRET_KEY);
+  if (envSecret) {
+    activeKeypair = parseSigningSecret(envSecret);
+    lastRotationSource = "env";
+    lastRotationAt = new Date().toISOString();
+    logger.info("Signing key loaded from environment", {
+      event: "signing_key_loaded",
+      source: "env",
+      publicKey: activeKeypair.publicKey(),
+    });
+    return activeKeypair;
+  }
+
+  activeKeypair = null;
+  lastRotationAt = null;
+  lastRotationSource = null;
+  logger.warn("No server signing key configured", {
+    event: "signing_key_unconfigured",
+  });
+  return null;
+}
+
+export function getSigningKeypair() {
+  return activeKeypair;
+}
+
+export function getSigningPublicKey() {
+  return activeKeypair?.publicKey() ?? null;
+}
+
+export function getSigningKeyStatus() {
+  return {
+    configured: activeKeypair !== null,
+    publicKey: getSigningPublicKey(),
+    lastRotationAt,
+    lastRotationSource,
+  };
+}
+
+/**
+ * Hot-reload the in-memory signing key from a new secret.
+ */
+export function rotateSigningKey(secret, { source = "api" } = {}) {
+  const keypair = parseSigningSecret(secret);
+  setActiveKeypair(keypair, source);
+  return {
+    publicKey: keypair.publicKey(),
+    rotatedAt: lastRotationAt,
+    source: lastRotationSource,
+  };
+}
+
+/**
+ * Re-read SIGNING_KEY_FILE and apply the updated secret without redeploy.
+ */
+export function reloadSigningKeyFromSecretsFile() {
+  const filePath = readSecretsFilePath();
+  if (!filePath) {
+    throw new Error("SIGNING_KEY_FILE is not configured");
+  }
+  const secret = readSecretFromFile(filePath);
+  return rotateSigningKey(secret, { source: "file_reload" });
+}
+
+/**
+ * Constant-time comparison for the admin rotate token (#293).
+ */
+export function isAdminRotateTokenValid(providedToken) {
+  const expected = normalizeSecret(process.env.ADMIN_ROTATE_TOKEN);
+  if (!expected || typeof providedToken !== "string" || providedToken.length === 0) {
+    return false;
+  }
+  const a = Buffer.from(providedToken);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Reset module state (tests only). */
+export function _resetSigningKeyState() {
+  activeKeypair = null;
+  lastRotationAt = null;
+  lastRotationSource = null;
+}

--- a/backend/tests/admin.test.js
+++ b/backend/tests/admin.test.js
@@ -1,0 +1,133 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import request from "supertest";
+import StellarSdk from "@stellar/stellar-sdk";
+
+const ENV_KEYS = ["ADMIN_ROTATE_TOKEN", "SERVER_SECRET_KEY", "SIGNING_KEY_FILE"];
+
+let snapshot = {};
+let tempDir = null;
+
+beforeEach(() => {
+  snapshot = {};
+  for (const k of ENV_KEYS) {
+    snapshot[k] = process.env[k];
+    delete process.env[k];
+  }
+  tempDir = mkdtempSync(join(tmpdir(), "admin-route-test-"));
+});
+
+afterEach(async () => {
+  const { _resetSigningKeyState } = await import("../src/signing-key.js");
+  _resetSigningKeyState();
+  for (const [k, v] of Object.entries(snapshot)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+  jest.resetModules();
+});
+
+async function buildAdminApp() {
+  const express = (await import("express")).default;
+  const { adminRouter } = await import("../src/routes/admin.js");
+  const { initializeSigningKey } = await import("../src/signing-key.js");
+  initializeSigningKey();
+  const app = express();
+  app.use(express.json());
+  app.use("/admin", adminRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ error: err.message ?? "Internal server error" });
+  });
+  return app;
+}
+
+describe("POST /admin/rotate-key (#293)", () => {
+  test("returns 503 when ADMIN_ROTATE_TOKEN is not configured", async () => {
+    const app = await buildAdminApp();
+    const res = await request(app)
+      .post("/admin/rotate-key")
+      .set("Authorization", "Bearer anything")
+      .send({ secretKey: StellarSdk.Keypair.random().secret() });
+
+    expect(res.status).toBe(503);
+  });
+
+  test("returns 401 for missing or invalid bearer token", async () => {
+    process.env.ADMIN_ROTATE_TOKEN = "admin-secret";
+    const app = await buildAdminApp();
+    const secret = StellarSdk.Keypair.random().secret();
+
+    const missing = await request(app)
+      .post("/admin/rotate-key")
+      .send({ secretKey: secret });
+    expect(missing.status).toBe(401);
+
+    const invalid = await request(app)
+      .post("/admin/rotate-key")
+      .set("Authorization", "Bearer wrong")
+      .send({ secretKey: secret });
+    expect(invalid.status).toBe(401);
+  });
+
+  test("rotates key when authorized with secretKey body", async () => {
+    process.env.ADMIN_ROTATE_TOKEN = "admin-secret";
+    const initial = StellarSdk.Keypair.random();
+    const rotated = StellarSdk.Keypair.random();
+    process.env.SERVER_SECRET_KEY = initial.secret();
+
+    const app = await buildAdminApp();
+    const res = await request(app)
+      .post("/admin/rotate-key")
+      .set("Authorization", "Bearer admin-secret")
+      .send({ secretKey: rotated.secret() });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      publicKey: rotated.publicKey(),
+      source: "api",
+      rotatedAt: expect.any(String),
+    });
+
+    const { getSigningPublicKey } = await import("../src/signing-key.js");
+    expect(getSigningPublicKey()).toBe(rotated.publicKey());
+  });
+
+  test("reloads key from SIGNING_KEY_FILE when reloadFromFile is true", async () => {
+    process.env.ADMIN_ROTATE_TOKEN = "admin-secret";
+    const first = StellarSdk.Keypair.random();
+    const second = StellarSdk.Keypair.random();
+    const filePath = join(tempDir, "signing.key");
+    writeFileSync(filePath, first.secret());
+    process.env.SIGNING_KEY_FILE = filePath;
+
+    const app = await buildAdminApp();
+    writeFileSync(filePath, second.secret());
+
+    const res = await request(app)
+      .post("/admin/rotate-key")
+      .set("Authorization", "Bearer admin-secret")
+      .send({ reloadFromFile: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.publicKey).toBe(second.publicKey());
+    expect(res.body.source).toBe("file_reload");
+  });
+
+  test("returns 400 when body omits secretKey and reloadFromFile", async () => {
+    process.env.ADMIN_ROTATE_TOKEN = "admin-secret";
+    const app = await buildAdminApp();
+
+    const res = await request(app)
+      .post("/admin/rotate-key")
+      .set("Authorization", "Bearer admin-secret")
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/tests/signing-key.test.js
+++ b/backend/tests/signing-key.test.js
@@ -1,0 +1,112 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import StellarSdk from "@stellar/stellar-sdk";
+
+const ENV_KEYS = ["SERVER_SECRET_KEY", "SIGNING_KEY_FILE", "ADMIN_ROTATE_TOKEN"];
+
+let snapshot = {};
+let tempDir = null;
+
+beforeEach(() => {
+  snapshot = {};
+  for (const k of ENV_KEYS) {
+    snapshot[k] = process.env[k];
+    delete process.env[k];
+  }
+  tempDir = mkdtempSync(join(tmpdir(), "signing-key-test-"));
+});
+
+afterEach(async () => {
+  const { _resetSigningKeyState } = await import("../src/signing-key.js");
+  _resetSigningKeyState();
+  for (const [k, v] of Object.entries(snapshot)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+describe("signing-key (#293)", () => {
+  test("loads key from SERVER_SECRET_KEY", async () => {
+    const kp = StellarSdk.Keypair.random();
+    process.env.SERVER_SECRET_KEY = kp.secret();
+
+    const { initializeSigningKey, getSigningPublicKey } = await import(
+      "../src/signing-key.js"
+    );
+    initializeSigningKey();
+
+    expect(getSigningPublicKey()).toBe(kp.publicKey());
+  });
+
+  test("SIGNING_KEY_FILE takes precedence over env", async () => {
+    const fileKp = StellarSdk.Keypair.random();
+    const envKp = StellarSdk.Keypair.random();
+    const filePath = join(tempDir, "signing.key");
+    writeFileSync(filePath, fileKp.secret());
+    process.env.SIGNING_KEY_FILE = filePath;
+    process.env.SERVER_SECRET_KEY = envKp.secret();
+
+    const { initializeSigningKey, getSigningPublicKey } = await import(
+      "../src/signing-key.js"
+    );
+    initializeSigningKey();
+
+    expect(getSigningPublicKey()).toBe(fileKp.publicKey());
+  });
+
+  test("rotateSigningKey updates in-memory public key", async () => {
+    const first = StellarSdk.Keypair.random();
+    const second = StellarSdk.Keypair.random();
+    process.env.SERVER_SECRET_KEY = first.secret();
+
+    const { initializeSigningKey, rotateSigningKey, getSigningPublicKey } =
+      await import("../src/signing-key.js");
+    initializeSigningKey();
+    const result = rotateSigningKey(second.secret(), { source: "api" });
+
+    expect(result.publicKey).toBe(second.publicKey());
+    expect(getSigningPublicKey()).toBe(second.publicKey());
+  });
+
+  test("reloadSigningKeyFromSecretsFile reads updated file contents", async () => {
+    const first = StellarSdk.Keypair.random();
+    const second = StellarSdk.Keypair.random();
+    const filePath = join(tempDir, "signing.key");
+    writeFileSync(filePath, first.secret());
+    process.env.SIGNING_KEY_FILE = filePath;
+
+    const {
+      initializeSigningKey,
+      reloadSigningKeyFromSecretsFile,
+      getSigningPublicKey,
+    } = await import("../src/signing-key.js");
+    initializeSigningKey();
+    expect(getSigningPublicKey()).toBe(first.publicKey());
+
+    writeFileSync(filePath, second.secret());
+    const result = reloadSigningKeyFromSecretsFile();
+
+    expect(result.publicKey).toBe(second.publicKey());
+    expect(result.source).toBe("file_reload");
+  });
+
+  test("isAdminRotateTokenValid uses constant-time comparison", async () => {
+    process.env.ADMIN_ROTATE_TOKEN = "rotate-token-secret";
+    const { isAdminRotateTokenValid } = await import("../src/signing-key.js");
+
+    expect(isAdminRotateTokenValid("rotate-token-secret")).toBe(true);
+    expect(isAdminRotateTokenValid("wrong-token")).toBe(false);
+    expect(isAdminRotateTokenValid("")).toBe(false);
+  });
+
+  test("parseSigningSecret rejects invalid secrets", async () => {
+    const { parseSigningSecret } = await import("../src/signing-key.js");
+    expect(() => parseSigningSecret("not-a-key")).toThrow(/Signing secret key must start/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds hot-reload support for the server signing key so operators can rotate it without redeploying the backend.

## Purpose / Motivation
The backend previously loaded `SERVER_SECRET_KEY` only at process start. There was no way to rotate the signing key without a full redeploy, which is risky during incident response and routine key rotation.

## Changes Made
- New `signing-key.js` module loads the key from `SIGNING_KEY_FILE` (secrets-manager mount) or `SERVER_SECRET_KEY`, keeps it in memory, and exposes rotation helpers.
- `POST /admin/rotate-key` accepts a new `secretKey` or `reloadFromFile: true` to re-read the secrets file.
- Endpoint is protected with `Authorization: Bearer <ADMIN_ROTATE_TOKEN>` (constant-time comparison) and a dedicated admin rate limiter.
- Structured logs record `signing_key_rotated` with previous/new public keys only (never secrets).
- Documented in `backend/API.md`, `backend/.env.example`, and README env table.
- Tests: `tests/signing-key.test.js`, `tests/admin.test.js`.

## How to Test
1. Set `SERVER_SECRET_KEY`, `ADMIN_ROTATE_TOKEN`, and start the backend (`npm run dev` in `backend/`).
2. `curl -X POST http://localhost:3001/admin/rotate-key -H "Authorization: Bearer $ADMIN_ROTATE_TOKEN" -H "Content-Type: application/json" -d '{"secretKey":"S..."}'` — expect `200` with new `publicKey`.
3. Without the bearer token — expect `401`.
4. With `SIGNING_KEY_FILE` set, update the file and POST `{"reloadFromFile":true}` — expect the new public key from disk.
5. Run `npm test` in `backend/` — all tests should pass.

## Screenshots (if applicable)
N/A — backend-only change.

## Breaking Changes
- None. Existing `/api/v1/*` routes are unchanged.

## Related Issues
Closes Just-Bamford/Stellar-Royalty-Splitter#293

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)