### PR TITLE
fix: centralize instance storage TTL extension (#289)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ pub enum StorageKey {
 /// Backward-compatible alias for integration tests and external references.
 pub type DataKey = StorageKey;
 
-const MIN_TTL: u32 = 17_280;
-const MAX_TTL: u32 = 34_560;
+pub use storage::MIN_TTL;
 
 /// On-chain contract version in [semantic versioning](https://semver.org/) format
 /// (`MAJOR.MINOR.PATCH`, e.g. `"0.1.0"`).
@@ -76,7 +75,7 @@ impl RoyaltySplitter {
     /// * `"share cannot be zero"` — any individual share is 0
     /// * `"duplicate collaborator address"` — same address appears more than once
     pub fn initialize(env: Env, collaborators: Vec<Address>, shares: Vec<u32>) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         if env.storage().instance().has(&StorageKey::Admin) {
             panic!("already initialized");
@@ -132,18 +131,12 @@ impl RoyaltySplitter {
         // an invalid or uncontrolled address from taking admin control (#264).
         admin.require_auth();
 
-        env.storage().instance().set(&StorageKey::Admin, &admin);
-        env.storage()
-            .instance()
-            .set(&StorageKey::Collaborators, &collaborators);
-        env.storage()
-            .instance()
-            .set(&StorageKey::ShareMap, &share_map);
+        storage::instance_set(&env, &StorageKey::Admin, &admin);
+        storage::instance_set(&env, &StorageKey::Collaborators, &collaborators);
+        storage::instance_set(&env, &StorageKey::ShareMap, &share_map);
 
         let version = String::from_str(&env, VERSION);
-        env.storage()
-            .instance()
-            .set(&StorageKey::ContractVersion, &version);
+        storage::instance_set(&env, &StorageKey::ContractVersion, &version);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("init")),
@@ -164,7 +157,7 @@ impl RoyaltySplitter {
     /// * `"contract not initialized"` — called before `initialize`
     /// * `"royalty rate cannot exceed 10000 basis points"` — `new_rate > 10_000`
     pub fn set_royalty_rate(env: Env, new_rate: u32) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -182,9 +175,7 @@ impl RoyaltySplitter {
             panic!("royalty rate cannot exceed 10000 basis points");
         }
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::RoyaltyRate, &new_rate);
+        storage::instance_set(&env, &StorageKey::RoyaltyRate, &new_rate);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("rate_set")),
@@ -203,7 +194,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
     pub fn pause(env: Env) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -212,7 +203,7 @@ impl RoyaltySplitter {
             .expect("contract not initialized");
 
         auth::require_admin(&env, &admin, auth::msg::PAUSE_ADMIN);
-        env.storage().instance().set(&StorageKey::Paused, &true);
+        storage::instance_set(&env, &StorageKey::Paused, &true);
     }
 
     /// Transfer admin rights to a new address.
@@ -226,7 +217,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
     pub fn admin_transfer(env: Env, new_admin: Address) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -237,7 +228,7 @@ impl RoyaltySplitter {
         auth::require_admin(&env, &admin, auth::msg::ADMIN_TRANSFER_ADMIN);
 
         let previous_admin = admin.clone();
-        env.storage().instance().set(&StorageKey::Admin, &new_admin);
+        storage::instance_set(&env, &StorageKey::Admin, &new_admin);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("admin_xfr")),
@@ -253,7 +244,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
     pub fn unpause(env: Env) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -262,13 +253,13 @@ impl RoyaltySplitter {
             .expect("contract not initialized");
 
         auth::require_admin(&env, &admin, auth::msg::UNPAUSE_ADMIN);
-        env.storage().instance().set(&StorageKey::Paused, &false);
+        storage::instance_set(&env, &StorageKey::Paused, &false);
     }
 
     /// Returns `true` if the contract is currently paused, `false` otherwise.
     /// Defaults to `false` before `pause` is ever called.
     pub fn is_paused(env: Env) -> bool {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::Paused)
@@ -280,7 +271,7 @@ impl RoyaltySplitter {
     /// Safe to call at any time — does not require initialization.
     /// Extends TTL on every call so the storage entry stays live.
     pub fn is_initialized(env: Env) -> bool {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage().instance().has(&StorageKey::Admin)
     }
 
@@ -289,7 +280,7 @@ impl RoyaltySplitter {
     /// # Arguments
     /// * `token` - The token contract address to query.
     pub fn get_balance(env: Env, token: Address) -> i128 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
     }
 
@@ -298,7 +289,7 @@ impl RoyaltySplitter {
     /// # Arguments
     /// * `token` - The token contract address to query.
     pub fn get_token_balance(env: Env, token: Address) -> i128 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
     }
 
@@ -311,7 +302,7 @@ impl RoyaltySplitter {
     /// # Authorization
     /// Requires admin signature.
     pub fn set_default_recipients(env: Env, recipients: Vec<Recipient>) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -322,9 +313,7 @@ impl RoyaltySplitter {
         auth::require_admin(&env, &admin, auth::msg::SET_DEFAULT_RECIPIENTS_ADMIN);
         Self::validate_recipient_list(&env, &recipients);
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::DefaultRecipients, &recipients);
+        storage::instance_set(&env, &StorageKey::DefaultRecipients, &recipients);
 
         env.events().publish(
             (symbol_short!("default"), symbol_short!("recipients_set")),
@@ -340,7 +329,7 @@ impl RoyaltySplitter {
     /// # Authorization
     /// Requires admin signature.
     pub fn set_recipients(env: Env, recipients: Vec<Recipient>) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -360,12 +349,8 @@ impl RoyaltySplitter {
             share_map.set(recipient.address.clone(), recipient.share);
         }
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::Collaborators, &collaborators);
-        env.storage()
-            .instance()
-            .set(&StorageKey::ShareMap, &share_map);
+        storage::instance_set(&env, &StorageKey::Collaborators, &collaborators);
+        storage::instance_set(&env, &StorageKey::ShareMap, &share_map);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("recip_set")),
@@ -381,7 +366,7 @@ impl RoyaltySplitter {
     /// # Authorization
     /// Requires admin signature.
     pub fn withdraw(env: Env, token: Address, amount: i128) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -414,7 +399,7 @@ impl RoyaltySplitter {
     /// Returns the configured default recipient list, or an empty vec if none has been set.
     /// Safe to call before initialization or when no defaults are configured.
     pub fn get_default_recipients(env: Env) -> Vec<Recipient> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::DefaultRecipients)
@@ -441,7 +426,7 @@ impl RoyaltySplitter {
     /// * `"no balance to distribute"` — contract has zero balance of the token
     /// * `"contract is paused"` — contract is currently paused
     pub fn distribute_with_override(env: Env, token: Address, override_recipients: Vec<Recipient>) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -552,9 +537,11 @@ impl RoyaltySplitter {
             (token, amount),
         );
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::LastDistribution, &env.ledger().timestamp());
+        storage::instance_set(
+            &env,
+            &StorageKey::LastDistribution,
+            &env.ledger().timestamp(),
+        );
 
         // Increment distribute history counter with overflow safety
         let current_count: u64 = env
@@ -565,9 +552,7 @@ impl RoyaltySplitter {
 
         // Use saturating add to prevent overflow - will cap at u64::MAX
         let new_count = current_count.saturating_add(1);
-        env.storage()
-            .instance()
-            .set(&StorageKey::DistributeHistory, &new_count);
+        storage::instance_set(&env, &StorageKey::DistributeHistory, &new_count);
     }
 
     /// Get the total number of successful royalty distributions.
@@ -578,7 +563,7 @@ impl RoyaltySplitter {
     ///
     /// Safe to call at any time — returns 0 if no distributions have occurred.
     pub fn get_distribute_count(env: Env) -> u64 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::DistributeHistory)
@@ -620,7 +605,7 @@ impl RoyaltySplitter {
     /// # Authorization
     /// Requires signature from `from`.
     pub fn record_secondary_royalty(env: Env, token: Address, from: Address, royalty_amount: i128) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         auth::require_payer(&env, &from, auth::msg::RECORD_SECONDARY_PAYER);
 
         let token_client = token::Client::new(&env, &token);
@@ -638,13 +623,13 @@ impl RoyaltySplitter {
             .get(&StorageKey::SecondaryPool)
             .unwrap_or(0);
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::SecondaryPool, &(current_pool + royalty_amount));
+        storage::instance_set(
+            &env,
+            &StorageKey::SecondaryPool,
+            &(current_pool + royalty_amount),
+        );
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::SecondaryToken, &token);
+        storage::instance_set(&env, &StorageKey::SecondaryToken, &token);
     }
 
     /// Distribute all accumulated secondary royalties to collaborators.
@@ -664,7 +649,7 @@ impl RoyaltySplitter {
     /// * `"total shares must sum to 10000"` — share map does not total 100%
     /// * `"pool exceeds contract balance"` — pool accounting is inconsistent
     pub fn distribute_secondary_royalties(env: Env) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -744,16 +729,15 @@ impl RoyaltySplitter {
                 .publish((symbol_short!("sec_dist"),), (addr, payout));
         }
 
-        env.storage()
-            .instance()
-            .set(&StorageKey::SecondaryPool, &0_i128);
+        storage::instance_set(&env, &StorageKey::SecondaryPool, &0_i128);
 
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("sec_dist")),
             (token, pool),
         );
 
-        env.storage().instance().set(
+        storage::instance_set(
+            &env,
             &StorageKey::LastSecondaryDistribution,
             &env.ledger().timestamp(),
         );
@@ -773,7 +757,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"sale price must be positive"` — `sale_price <= 0`
     pub fn record_secondary_sale(env: Env, sale_price: i128) -> i128 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         if sale_price <= 0 {
             panic!("sale price must be positive");
@@ -791,7 +775,7 @@ impl RoyaltySplitter {
     /// Returns the current secondary royalty rate in basis points (0–10,000).
     /// Returns 0 if `set_royalty_rate` has never been called.
     pub fn get_royalty_rate(env: Env) -> u32 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::RoyaltyRate)
@@ -804,7 +788,7 @@ impl RoyaltySplitter {
     /// Preserves the insertion order from `initialize`. Returns an empty vec if
     /// called before initialization.
     pub fn get_recipients(env: Env) -> Vec<Recipient> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let collaborators: Vec<Address> = env
             .storage()
@@ -835,7 +819,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
     pub fn get_version(env: Env) -> String {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::ContractVersion)
@@ -856,7 +840,7 @@ impl RoyaltySplitter {
     /// * `"contract not initialized"` — called before `initialize`
     /// * `"collaborator not found"` — address is not a registered collaborator
     pub fn get_share(env: Env, collaborator: Address) -> u32 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         let share_map: Map<Address, u32> = env
             .storage()
             .instance()
@@ -871,7 +855,7 @@ impl RoyaltySplitter {
     /// # Authorization
     /// Requires admin signature
     pub fn update_share(env: Env, collaborator: Address, new_share: u32) {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
 
         let admin: Address = env
             .storage()
@@ -904,9 +888,7 @@ impl RoyaltySplitter {
         }
 
         share_map.set(collaborator.clone(), new_share);
-        env.storage()
-            .instance()
-            .set(&StorageKey::ShareMap, &share_map);
+        storage::instance_set(&env, &StorageKey::ShareMap, &share_map);
 
         env.events().publish(
             (symbol_short!("share"), symbol_short!("updated")),
@@ -921,7 +903,7 @@ impl RoyaltySplitter {
     /// # Arguments
     /// * `addr` - Address to check.
     pub fn is_collaborator(env: Env, addr: Address) -> bool {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         let share_map: Map<Address, u32> = env
             .storage()
             .instance()
@@ -934,7 +916,7 @@ impl RoyaltySplitter {
     /// Returns the number of registered collaborators.
     /// Returns 0 if called before initialization.
     pub fn collaborator_count(env: Env) -> u32 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         let collaborators: Vec<Address> = env
             .storage()
             .instance()
@@ -946,7 +928,7 @@ impl RoyaltySplitter {
     /// Returns the ordered list of all registered collaborator addresses.
     /// Returns an empty vec if called before initialization.
     pub fn get_collaborators(env: Env) -> Vec<Address> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::Collaborators)
@@ -955,7 +937,7 @@ impl RoyaltySplitter {
 
     /// Returns the full share map (Address → basis points) in a single call.
     pub fn get_all_shares(env: Env) -> Map<Address, u32> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::ShareMap)
@@ -965,7 +947,7 @@ impl RoyaltySplitter {
     /// Returns the current size of the secondary royalty pool (undistributed amount).
     /// Returns 0 if no royalties have been recorded yet.
     pub fn get_secondary_pool(env: Env) -> i128 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::SecondaryPool)
@@ -974,13 +956,13 @@ impl RoyaltySplitter {
 
     /// Returns the timestamp of the last primary distribution, or None if never distributed.
     pub fn get_last_distribution(env: Env) -> Option<u64> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage().instance().get(&StorageKey::LastDistribution)
     }
 
     /// Returns the timestamp of the last secondary distribution, or None if never distributed.
     pub fn get_last_secondary_distribution(env: Env) -> Option<u64> {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::LastSecondaryDistribution)
@@ -994,7 +976,7 @@ impl RoyaltySplitter {
     /// # Panics
     /// * `"contract not initialized"` — called before `initialize`
     pub fn get_total_shares(env: Env) -> u32 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        storage::extend_instance_ttl(&env);
         let share_map: Map<Address, u32> = env
             .storage()
             .instance()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,6 +4,16 @@ use soroban_sdk::{Env, IntoVal, TryFromVal, Val};
 
 use crate::StorageKey;
 
+/// Minimum ledgers to extend instance storage TTL when bumped.
+pub const MIN_TTL: u32 = 17_280;
+/// Maximum target TTL for instance storage (Soroban caps extension at this bound).
+pub const MAX_TTL: u32 = 34_560;
+
+/// Bump instance storage TTL so contract state does not expire on Mainnet.
+pub fn extend_instance_ttl(env: &Env) {
+    env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+}
+
 /// Read a value from instance storage.
 pub fn instance_get<T>(env: &Env, key: &StorageKey) -> Option<T>
 where

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, Map, String, Vec as SorobanVec,
 };
 use stellar_royalty_splitter::{
-    auth, DataKey, Recipient, RoyaltySplitterClient, StorageKey, VERSION,
+    auth, DataKey, Recipient, RoyaltySplitterClient, StorageKey, MIN_TTL, VERSION,
 };
 
 fn setup(env: &Env) -> (Address, RoyaltySplitterClient) {
@@ -175,13 +175,55 @@ fn test_ttl_extended_after_ledger_advance() {
 
     // Advance ledger sequence past MIN_TTL (17_280 ledgers).
     env.ledger()
-        .set_sequence_number(env.ledger().sequence() + 17_281);
+        .set_sequence_number(env.ledger().sequence() + MIN_TTL as u32 + 1);
 
     // Both read functions must still return correct data (TTL was extended).
     let collaborators = client.get_collaborators();
     assert_eq!(collaborators.len(), 2);
     assert_eq!(client.get_share(&a), 6000);
     assert_eq!(client.get_share(&b), 4000);
+}
+
+/// Issue #289 — state-writing entrypoints must extend TTL so writes succeed
+/// after the ledger advances past MIN_TTL.
+#[test]
+fn test_ttl_state_writes_after_ledger_advance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    client.set_royalty_rate(&500_u32);
+
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + MIN_TTL as u32 + 1);
+
+    client.set_royalty_rate(&750_u32);
+    assert_eq!(client.get_royalty_rate(), 750);
+
+    client.pause();
+    assert!(client.is_paused());
+    client.unpause();
+    assert!(!client.is_paused());
+
+    client.update_share(&b, &6000_u32);
+    client.update_share(&admin, &4000_u32);
+
+    mint(&env, &token, &contract_id, 1000);
+    client.distribute(&token);
+    assert!(client.get_last_distribution().is_some());
+    assert_eq!(client.get_distribute_count(), 1);
+
+    client.record_secondary_royalty(&token, &admin, &100_i128);
+    assert_eq!(client.get_secondary_pool(), 100);
 }
 
 /// Events — distribute emits a ("royalty", "dist_all") event with (token, amount).


### PR DESCRIPTION
## Summary
Centralizes Soroban instance-storage TTL extension in `storage.rs` and adds integration tests that verify state-writing entrypoints still succeed after advancing the ledger past `MIN_TTL`.

## Purpose / Motivation
Soroban contract instance storage expires if its TTL is not bumped. Without explicit extension, deployed contract state can silently disappear on Mainnet. Issue #289 requires consistent TTL extension on every state-writing call and test coverage to guard against regressions.

## Changes Made
- Moved `MIN_TTL` / `MAX_TTL` and `extend_instance_ttl()` into `src/storage.rs` as the single TTL extension helper
- Replaced inline `extend_ttl` calls in every public contract entrypoint with `storage::extend_instance_ttl()`
- Routed all instance storage writes through `storage::instance_set()` for a consistent write path
- Exported `MIN_TTL` for tests
- Added `test_ttl_state_writes_after_ledger_advance` covering `set_royalty_rate`, `pause`/`unpause`, `update_share`, `distribute`, and `record_secondary_royalty` after ledger advance
- Updated existing TTL read test to use the exported `MIN_TTL` constant

## How to Test
1. Run `cargo test --locked` from the repo root
2. Confirm `test_ttl_extended_after_ledger_advance` and `test_ttl_state_writes_after_ledger_advance` pass
3. Run `cargo fmt --all -- --check` to verify formatting

Expected: all integration tests pass on Linux CI with no change to contract behavior or entrypoint signatures.

## Screenshots (if applicable)
N/A — smart contract only.

## Breaking Changes
- None.

## Related Issues
Closes Just-Bamford/Stellar-Royalty-Splitter#289

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)