### PR TITLE
fix: add get_admin view function (#290)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,13 +68,7 @@ impl RoyaltySplitter {
     /// Requires signature from `collaborators[0]` (the admin).
     ///
     /// # Panics
-    /// * `"already initialized"` — contract has already been set up
-    /// * `"need at least one collaborator"` — empty collaborator list
-    /// * `"too many recipients: maximum 10 allowed"` — more than 10 recipients
-    /// * `"collaborators and shares length mismatch"` — vec lengths differ
-    /// * `"shares must sum to 10000"` — allocations don't total 100%
-    /// * `"share cannot be zero"` — any individual share is 0
-    /// * `"duplicate collaborator address"` — same address appears more than once
+    /// On invalid collaborators/shares, duplicate addresses, or re-initialization.
     pub fn initialize(env: Env, collaborators: Vec<Address>, shares: Vec<u32>) {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
 
@@ -284,20 +278,25 @@ impl RoyaltySplitter {
         env.storage().instance().has(&StorageKey::Admin)
     }
 
+    /// Returns the current contract admin address.
+    ///
+    /// Read-only view for integrators and frontends.
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        env.storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("contract not initialized")
+    }
+
     /// Returns the contract's current on-chain balance of `token`.
     ///
     /// # Arguments
     /// * `token` - The token contract address to query.
     pub fn get_balance(env: Env, token: Address) -> i128 {
-        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
-        token::Client::new(&env, &token).balance(&env.current_contract_address())
-    }
-
-    /// Alias for `get_balance`. Returns the contract's on-chain balance of `token`.
-    ///
-    /// # Arguments
-    /// * `token` - The token contract address to query.
-    pub fn get_token_balance(env: Env, token: Address) -> i128 {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         token::Client::new(&env, &token).balance(&env.current_contract_address())
     }
@@ -327,7 +326,7 @@ impl RoyaltySplitter {
             .set(&StorageKey::DefaultRecipients, &recipients);
 
         env.events().publish(
-            (symbol_short!("default"), symbol_short!("recipients_set")),
+            (symbol_short!("default"), symbol_short!("recip_set")),
             recipients.len(),
         );
     }
@@ -603,7 +602,7 @@ impl RoyaltySplitter {
     /// * `"contract is paused"` — contract is currently paused
     pub fn distribute(env: Env, token: Address) {
         // Call the enhanced version with empty override for backward compatibility
-        Self::distribute_with_override(env, token, Vec::new(&env));
+        Self::distribute_with_override(env.clone(), token, Vec::new(&env));
     }
 
     /// Record a secondary royalty payment transferred from a resale.
@@ -840,11 +839,6 @@ impl RoyaltySplitter {
             .instance()
             .get(&StorageKey::ContractVersion)
             .expect("contract not initialized")
-    }
-
-    /// Backward-compatible alias for [`get_version`].
-    pub fn version(env: Env) -> String {
-        Self::get_version(env)
     }
 
     /// Returns the basis-point share for a registered collaborator.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1223,11 +1223,11 @@ fn test_set_default_recipients_emits_event() {
                 == vec![
                     &env,
                     symbol_short!("default").into_val(&env),
-                    symbol_short!("recipients_set").into_val(&env),
+                    symbol_short!("recip_set").into_val(&env),
                 ]
             && data == 2_u32.into_val(&env)
     });
-    assert!(found, "recipients_set event not emitted");
+    assert!(found, "recip_set event not emitted");
 }
 
 /// Test get_default_recipients returns empty when not set
@@ -1807,6 +1807,53 @@ fn test_auth_req_event_emitted_on_initialize() {
     );
 }
 
+// ── Issue #290: get_admin ───────────────────────────────────────────────────
+
+#[test]
+fn test_get_admin_returns_initial_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_get_admin_reflects_admin_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    assert_eq!(client.get_admin(), admin);
+
+    client.admin_transfer(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "contract not initialized")]
+fn test_get_admin_before_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    client.get_admin();
+}
+
 // ── Issue #286: contract version ────────────────────────────────────────────
 
 #[test]
@@ -1820,7 +1867,6 @@ fn test_get_version_stored_on_initialize() {
     client.initialize(&vec![&env, admin, b], &vec![&env, 5000_u32, 5000_u32]);
 
     assert_eq!(client.get_version(), String::from_str(&env, VERSION));
-    assert_eq!(client.version(), client.get_version());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds a read-only `get_admin()` view function so integrators and frontends can query the current admin address without parsing raw contract storage.

## Purpose / Motivation
The admin address is stored under `StorageKey::Admin` during `initialize`, but there was no public getter. Off-chain clients had no supported way to discover who can authorize admin-only operations.

## Changes Made
- Added `get_admin(env) -> Address` in `src/lib.rs`, reading from `StorageKey::Admin` with TTL extension (same pattern as other view functions).
- Panics with `"contract not initialized"` when called before `initialize`, consistent with `get_version()` and other state-dependent getters.
- Removed redundant `get_token_balance` and `version` exports (identical to `get_balance` / `get_version`) to keep the contract within Soroban export limits.
- Trimmed `initialize` contract spec documentation (was over the 1024-byte `SC_SPEC_DOC_LIMIT`, which blocked compilation).
- Fixed `set_default_recipients` event topic symbol (`recip_set`, max 9 chars) and `distribute` env borrow.
- Added integration tests for `get_admin`.

## How to Test
1. `cargo test`
2. Confirm `test_get_admin_returns_initial_admin`, `test_get_admin_reflects_admin_transfer`, and `test_get_admin_before_initialize_panics` pass.
3. `cargo build --target wasm32-unknown-unknown --release` should succeed.

## Breaking Changes
- `get_token_balance` removed (use `get_balance`).
- `version` removed (use `get_version`).
- Default-recipients event second topic renamed from `recipients_set` to `recip_set` (symbol length limit).
- New read-only `get_admin` entrypoint added.

## Related Issues
Closes Just-Bamford/Stellar-Royalty-Splitter#290

## Test plan
- [ ] `cargo build --target wasm32-unknown-unknown --release`
- [ ] `cargo test` (Contract CI)
- [ ] Verify `get_admin` returns first collaborator after `initialize`
- [ ] Verify `get_admin` updates after `admin_transfer`