### PR TITLE
Add batch_distribute function for multi-token distributions

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -19,6 +19,7 @@ pub mod msg {
     pub const DISTRIBUTE_ADMIN: &str = "distribute: admin authorization required";
     pub const DISTRIBUTE_OVERRIDE_ADMIN: &str =
         "distribute_with_override: admin authorization required";
+    pub const BATCH_DISTRIBUTE_ADMIN: &str = "batch_distribute: admin authorization required";
     pub const DISTRIBUTE_SECONDARY_ADMIN: &str =
         "distribute_secondary_royalties: admin authorization required";
     pub const UPDATE_SHARE_ADMIN: &str = "update_share: admin authorization required";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,175 @@ impl RoyaltySplitter {
         Self::distribute_with_override(env.clone(), token, Vec::new(&env));
     }
 
+    /// Distribute royalties for multiple tokens in a single transaction.
+    ///
+    /// Executes multiple independent distributions atomically, reducing total
+    /// ledger fees for high-frequency royalty scenarios. Each token distribution
+    /// is processed independently using the same logic as `distribute()`.
+    ///
+    /// # Arguments
+    /// * `tokens` - List of token addresses to distribute (e.g., XLM, USDC, etc.)
+    ///
+    /// # Distribution Logic
+    /// For each token:
+    /// - Uses the default recipient list (or collaborators if no defaults set)
+    /// - Each recipient receives: (token_balance * their_share) / 10,000
+    /// - The last recipient receives any remaining dust from integer division
+    /// - Emits individual distribution events for each token
+    ///
+    /// # Authorization
+    /// Requires admin signature (checked once for the entire batch)
+    ///
+    /// # Panics
+    /// * `"contract not initialized"` — called before `initialize`
+    /// * `"contract is paused"` — contract is currently paused
+    /// * `"recipients list cannot be empty"` — no recipients are configured
+    /// * `"no balance to distribute"` — any token has zero balance
+    /// * `"amount too small"` — any token balance is less than recipient count
+    ///
+    /// # Gas Considerations
+    /// Processing N tokens in one call is more efficient than N separate calls,
+    /// but be mindful of transaction complexity limits. Each distribution performs
+    /// token transfers equal to the number of recipients.
+    pub fn batch_distribute(env: Env, tokens: Vec<Address>) {
+        storage::extend_instance_ttl(&env);
+
+        // Check admin auth once for the entire batch
+        Self::check_admin_auth(&env, auth::msg::BATCH_DISTRIBUTE_ADMIN);
+
+        // Check paused state once for the entire batch
+        if env
+            .storage()
+            .instance()
+            .get::<StorageKey, bool>(&StorageKey::Paused)
+            .unwrap_or(false)
+        {
+            Self::fail(&env, ContractError::ContractPaused);
+        }
+
+        // Get recipient list once (reused for all distributions)
+        let recipients_to_use: Vec<Recipient> = {
+            let defaults: Vec<Recipient> =
+                storage::persistent_get::<Vec<Recipient>>(&env, &StorageKey::DefaultRecipients)
+                    .unwrap_or(Vec::new(&env));
+
+            if !defaults.is_empty() {
+                defaults
+            } else {
+                // Fall back to original collaborator list (persistent storage)
+                let collaborators: Vec<Address> =
+                    storage::persistent_get::<Vec<Address>>(&env, &StorageKey::Collaborators)
+                        .expect("no collaborators");
+
+                let share_map: Map<Address, u32> =
+                    storage::persistent_get::<Map<Address, u32>>(&env, &StorageKey::ShareMap)
+                        .expect("no share map");
+
+                let mut recipients: Vec<Recipient> = Vec::new(&env);
+                for addr in collaborators.iter() {
+                    let share = share_map.get(addr.clone()).unwrap_or(0);
+                    recipients.push_back(Recipient {
+                        address: addr,
+                        share,
+                    });
+                }
+                recipients
+            }
+        };
+
+        if recipients_to_use.is_empty() {
+            Self::fail(&env, ContractError::EmptyRecipients);
+        }
+
+        // Validate shares sum to 10,000 (once for all distributions)
+        let mut total_shares: u32 = 0;
+        for i in 0..recipients_to_use.len() {
+            total_shares = Self::checked_add_share_total(
+                &env,
+                total_shares,
+                recipients_to_use.get(i).unwrap().share,
+            );
+        }
+        if total_shares != 10_000 {
+            Self::fail(&env, ContractError::InvalidShareTotal);
+        }
+
+        let n = recipients_to_use.len();
+
+        // Process each token distribution
+        for token in tokens.iter() {
+            let token_client = token::Client::new(&env, &token);
+            let amount = token_client.balance(&env.current_contract_address());
+
+            if amount == 0 {
+                Self::fail(&env, ContractError::NoBalance);
+            }
+
+            // Guard: each recipient must receive at least 1 stroop
+            if amount < n as i128 {
+                Self::fail(&env, ContractError::AmountTooSmall);
+            }
+
+            let mut payouts: Vec<(Address, i128)> = Vec::new(&env);
+            let mut total_calculated: i128 = 0;
+
+            // Calculate payouts for all recipients except the last one
+            for i in 0..(n - 1) {
+                let recipient = recipients_to_use.get(i).unwrap();
+                let payout = Self::checked_bps_amount(&env, amount, recipient.share);
+                payouts.push_back((recipient.address.clone(), payout));
+                total_calculated = total_calculated
+                    .checked_add(payout)
+                    .unwrap_or_else(|| Self::fail(&env, ContractError::ArithmeticOverflow));
+            }
+
+            // Last recipient receives the remainder to avoid dust loss
+            let last = recipients_to_use.get(n - 1).unwrap();
+            payouts.push_back((
+                last.address.clone(),
+                amount
+                    .checked_sub(total_calculated)
+                    .unwrap_or_else(|| Self::fail(&env, ContractError::ArithmeticOverflow)),
+            ));
+
+            // Execute transfers for this token
+            for (addr, payout) in payouts.iter() {
+                token_client.transfer(&env.current_contract_address(), &addr, &payout);
+                env.events()
+                    .publish((symbol_short!("dist"),), (addr, payout));
+            }
+
+            // Emit distribution event for this token
+            env.events().publish(
+                (symbol_short!("royalty"), symbol_short!("dist_all")),
+                (token.clone(), amount),
+            );
+        }
+
+        // Update distribution timestamp and counter once for the batch
+        storage::instance_set(
+            &env,
+            &StorageKey::LastDistribution,
+            &env.ledger().timestamp(),
+        );
+
+        let current_count: u64 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::DistributeHistory)
+            .unwrap_or(0);
+
+        // Increment by the number of tokens distributed
+        let new_count = current_count.saturating_add(tokens.len() as u64);
+        storage::instance_set(&env, &StorageKey::DistributeHistory, &new_count);
+
+        // Emit batch completion event
+        env.events().publish(
+            (symbol_short!("royalty"), symbol_short!("batch")),
+            tokens.len(),
+        );
+    }
+
     /// Record a secondary royalty payment transferred from a resale.
     ///
     /// Pulls `royalty_amount` of `token` from `from` into the contract's

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3097,3 +3097,1357 @@ fn test_rate_history_in_persistent_storage() {
         assert!(!env.storage().instance().has(&DataKey::RoyaltyRateHistory));
     });
 }
+
+// ── Pause/Unpause Flow Tests ────────────────────────────────────────────────
+
+/// Test that pause() sets the paused state correctly.
+#[test]
+fn test_pause_sets_paused_state() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Initially not paused
+    assert!(!client.is_paused());
+
+    // Pause the contract
+    client.pause();
+
+    // Verify paused state
+    assert!(client.is_paused());
+}
+
+/// Test that unpause() clears the paused state correctly.
+#[test]
+fn test_unpause_clears_paused_state() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Pause first
+    client.pause();
+    assert!(client.is_paused());
+
+    // Unpause the contract
+    client.unpause();
+
+    // Verify unpaused state
+    assert!(!client.is_paused());
+}
+
+/// Test that distribute() fails with ContractPaused error when paused.
+#[test]
+fn test_distribute_fails_with_error_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    mint(&env, &token, &contract_id, 1000);
+
+    // Pause the contract
+    client.pause();
+
+    // Verify distribute fails with the correct error
+    let result = client.try_distribute(&token);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+/// Test that distribute() succeeds after unpause.
+#[test]
+fn test_distribute_succeeds_after_unpause_with_balances() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    mint(&env, &token, &contract_id, 1000);
+
+    // Pause and verify distribute fails
+    client.pause();
+    let result = client.try_distribute(&token);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+
+    // Unpause
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Distribute should now succeed
+    client.distribute(&token);
+
+    // Verify balances were distributed correctly
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 500);
+    assert_eq!(TokenClient::new(&env, &token).balance(&b), 500);
+}
+
+/// Test that only admin can call pause().
+#[test]
+fn test_pause_requires_admin_authorization() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    // Initialize with mock_all_auths
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Clear auths and try to pause without authorization
+    env.mock_auths(&[]);
+
+    // Should panic due to missing authorization
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.pause();
+    }));
+    assert!(result.is_err(), "pause() should panic without admin auth");
+}
+
+/// Test that only admin can call unpause().
+#[test]
+fn test_unpause_requires_admin_authorization() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    // Initialize and pause with mock_all_auths
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    client.pause();
+
+    // Clear auths and try to unpause without authorization
+    env.mock_auths(&[]);
+
+    // Should panic due to missing authorization
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.unpause();
+    }));
+    assert!(result.is_err(), "unpause() should panic without admin auth");
+}
+
+/// Test that pause() requires specific admin auth (not just any auth).
+#[test]
+fn test_pause_requires_specific_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Use specific mock auth for admin
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.pause();
+    assert!(client.is_paused());
+}
+
+/// Test that unpause() requires specific admin auth (not just any auth).
+#[test]
+fn test_unpause_requires_specific_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+    client.pause();
+
+    // Use specific mock auth for admin
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "unpause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.unpause();
+    assert!(!client.is_paused());
+}
+
+/// Test that distribute_secondary_royalties() fails with ContractPaused error when paused.
+#[test]
+fn test_distribute_secondary_fails_with_error_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Record some secondary royalties
+    let pool_amount: i128 = 500;
+    mint(&env, &token, &admin, pool_amount);
+    client.record_secondary_royalty(&token, &admin, &pool_amount);
+
+    // Pause the contract
+    client.pause();
+
+    // Verify distribute_secondary_royalties fails with the correct error
+    let result = client.try_distribute_secondary_royalties();
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+/// Test that distribute_secondary_royalties() succeeds after unpause.
+#[test]
+fn test_distribute_secondary_succeeds_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Record some secondary royalties
+    let pool_amount: i128 = 500;
+    mint(&env, &token, &admin, pool_amount);
+    client.record_secondary_royalty(&token, &admin, &pool_amount);
+
+    // Pause and verify distribute_secondary_royalties fails
+    client.pause();
+    let result = client.try_distribute_secondary_royalties();
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+
+    // Unpause
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Distribute secondary royalties should now succeed
+    client.distribute_secondary_royalties();
+
+    // Verify balances were distributed correctly
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 250);
+    assert_eq!(TokenClient::new(&env, &token).balance(&b), 250);
+    assert_eq!(client.get_secondary_pool(), 0);
+}
+
+/// Test multiple pause/unpause cycles work correctly.
+#[test]
+fn test_multiple_pause_unpause_cycles() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Cycle 1: pause -> unpause
+    client.pause();
+    assert!(client.is_paused());
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Distribute should work
+    mint(&env, &token, &contract_id, 1000);
+    client.distribute(&token);
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 500);
+
+    // Cycle 2: pause -> unpause
+    client.pause();
+    assert!(client.is_paused());
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Distribute should work again
+    mint(&env, &token, &contract_id, 2000);
+    client.distribute(&token);
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 1500);
+}
+
+/// Test that paused state persists across multiple operations.
+#[test]
+fn test_paused_state_persists() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Pause the contract
+    client.pause();
+    assert!(client.is_paused());
+
+    // Perform other operations (that don't require unpaused state)
+    client.set_royalty_rate(&500_u32);
+    assert_eq!(client.get_royalty_rate(), 500);
+
+    // Paused state should still be true
+    assert!(client.is_paused());
+
+    // Distribute should still fail
+    mint(&env, &token, &contract_id, 1000);
+    let result = client.try_distribute(&token);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+/// Test that read-only operations work when paused.
+#[test]
+fn test_read_operations_work_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 6000_u32, 4000_u32],
+    );
+    client.set_royalty_rate(&250_u32);
+
+    // Pause the contract
+    client.pause();
+    assert!(client.is_paused());
+
+    // All read operations should still work
+    assert!(client.is_initialized());
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_royalty_rate(), 250);
+    assert_eq!(client.collaborator_count(), 2);
+    assert_eq!(client.get_share(&admin), 6000);
+    assert_eq!(client.get_share(&b), 4000);
+    assert!(client.is_collaborator(&admin));
+    assert_eq!(client.get_total_shares(), 10_000);
+
+    let recipients = client.get_recipients();
+    assert_eq!(recipients.len(), 2);
+}
+
+// ── Batch Distribute Tests ──────────────────────────────────────────────────
+
+/// Test that batch_distribute processes multiple tokens in one call.
+#[test]
+fn test_batch_distribute_multiple_tokens() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 6000_u32, 4000_u32],
+    );
+
+    // Create three different tokens
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+    let token3 = make_token(&env, &token_admin);
+
+    // Mint different amounts to the contract for each token
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+    mint(&env, &token3, &contract_id, 3000);
+
+    // Batch distribute all three tokens
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone(), token3.clone()]);
+
+    // Verify token1 distribution (1000 total: 600 + 400)
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 600);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&b), 400);
+
+    // Verify token2 distribution (2000 total: 1200 + 800)
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1200);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&b), 800);
+
+    // Verify token3 distribution (3000 total: 1800 + 1200)
+    assert_eq!(TokenClient::new(&env, &token3).balance(&admin), 1800);
+    assert_eq!(TokenClient::new(&env, &token3).balance(&b), 1200);
+
+    // Verify distribute count incremented by 3
+    assert_eq!(client.get_distribute_count(), 3);
+}
+
+/// Test that batch_distribute emits events for each token.
+#[test]
+fn test_batch_distribute_emits_events() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    let events = env.events().all();
+
+    // Check for dist_all events for both tokens
+    let token1_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("dist_all").into_val(&env),
+                ]
+            && val_eq(&env, data, (token1.clone(), 1000_i128))
+    });
+    assert!(token1_event, "token1 dist_all event not emitted");
+
+    let token2_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("dist_all").into_val(&env),
+                ]
+            && val_eq(&env, data, (token2.clone(), 2000_i128))
+    });
+    assert!(token2_event, "token2 dist_all event not emitted");
+
+    // Check for batch completion event
+    let batch_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("batch").into_val(&env),
+                ]
+            && val_eq(&env, data, 2_u32)
+    });
+    assert!(batch_event, "batch completion event not emitted");
+}
+
+/// Test that batch_distribute requires admin authorization.
+#[test]
+fn test_batch_distribute_requires_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+
+    // Use specific mock auth for admin
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "batch_distribute",
+            args: (vec![&env, token1.clone()],).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.batch_distribute(&vec![&env, token1]);
+    assert_eq!(client.get_distribute_count(), 1);
+}
+
+/// Test that batch_distribute fails when paused.
+#[test]
+fn test_batch_distribute_fails_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+
+    client.pause();
+
+    let result = client.try_batch_distribute(&vec![&env, token1]);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+/// Test that batch_distribute succeeds after unpause.
+#[test]
+fn test_batch_distribute_succeeds_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    client.pause();
+    client.unpause();
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 500);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1000);
+}
+
+/// Test that batch_distribute with single token works correctly.
+#[test]
+fn test_batch_distribute_single_token() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 7000_u32, 3000_u32],
+    );
+
+    let token = make_token(&env, &token_admin);
+    mint(&env, &token, &contract_id, 10_000);
+
+    client.batch_distribute(&vec![&env, token.clone()]);
+
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 7000);
+    assert_eq!(TokenClient::new(&env, &token).balance(&b), 3000);
+    assert_eq!(client.get_distribute_count(), 1);
+}
+
+/// Test that batch_distribute fails if any token has zero balance.
+#[test]
+fn test_batch_distribute_fails_on_zero_balance() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    // token2 has zero balance
+
+    let result = client.try_batch_distribute(&vec![&env, token1, token2]);
+    assert_eq!(result, Err(Ok(ContractError::NoBalance)));
+}
+
+/// Test that batch_distribute handles dust correctly for each token.
+#[test]
+fn test_batch_distribute_handles_dust_correctly() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    // Three recipients with shares that create dust
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone(), c.clone()],
+        &vec![&env, 3333_u32, 3333_u32, 3334_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 10_000);
+    mint(&env, &token2, &contract_id, 20_000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    // Verify token1 distribution (10,000 total)
+    let admin_bal1 = TokenClient::new(&env, &token1).balance(&admin);
+    let b_bal1 = TokenClient::new(&env, &token1).balance(&b);
+    let c_bal1 = TokenClient::new(&env, &token1).balance(&c);
+    assert_eq!(admin_bal1 + b_bal1 + c_bal1, 10_000);
+
+    // Verify token2 distribution (20,000 total)
+    let admin_bal2 = TokenClient::new(&env, &token2).balance(&admin);
+    let b_bal2 = TokenClient::new(&env, &token2).balance(&b);
+    let c_bal2 = TokenClient::new(&env, &token2).balance(&c);
+    assert_eq!(admin_bal2 + b_bal2 + c_bal2, 20_000);
+}
+
+/// Test that batch_distribute works with default recipients.
+#[test]
+fn test_batch_distribute_with_default_recipients() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Set custom default recipients
+    let custom_recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 2000,
+        },
+        Recipient {
+            address: b.clone(),
+            share: 3000,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 5000,
+        },
+    ];
+    client.set_default_recipients(&custom_recipients);
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 10_000);
+    mint(&env, &token2, &contract_id, 5_000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    // Verify token1 distribution with custom shares
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 2000);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&b), 3000);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&c), 5000);
+
+    // Verify token2 distribution with custom shares
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1000);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&b), 1500);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&c), 2500);
+}
+
+/// Test that batch_distribute with many tokens increments counter correctly.
+#[test]
+fn test_batch_distribute_counter_increment() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Create 5 tokens
+    let mut tokens: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..5 {
+        let token = make_token(&env, &token_admin);
+        mint(&env, &token, &contract_id, 1000);
+        tokens.push_back(token);
+    }
+
+    assert_eq!(client.get_distribute_count(), 0);
+
+    client.batch_distribute(&tokens);
+
+    // Counter should increment by 5
+    assert_eq!(client.get_distribute_count(), 5);
+}
+
+/// Test that batch_distribute updates last distribution timestamp.
+#[test]
+fn test_batch_distribute_updates_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    let timestamp = 1_700_000_000_u64;
+    env.ledger().with_mut(|ledger| ledger.timestamp = timestamp);
+
+    assert!(client.get_last_distribution().is_none());
+
+    client.batch_distribute(&vec![&env, token1, token2]);
+
+    assert_eq!(client.get_last_distribution(), Some(timestamp));
+}
+
+/// Test that batch_distribute fails if amount is too small for any token.
+#[test]
+fn test_batch_distribute_fails_on_amount_too_small() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 1); // Only 1 stroop, but 2 recipients
+
+    let result = client.try_batch_distribute(&vec![&env, token1, token2]);
+    assert_eq!(result, Err(Ok(ContractError::AmountTooSmall)));
+}
+
+/// Test batch_distribute with large number of tokens.
+#[test]
+fn test_batch_distribute_large_batch() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Create 10 tokens
+    let mut tokens: SorobanVec<Address> = SorobanVec::new(&env);
+    for i in 0..10 {
+        let token = make_token(&env, &token_admin);
+        mint(&env, &token, &contract_id, (i + 1) * 1000);
+        tokens.push_back(token);
+    }
+
+    client.batch_distribute(&tokens);
+
+    // Verify all distributions occurred
+    assert_eq!(client.get_distribute_count(), 10);
+
+    // Verify balances for a few tokens
+    let token0 = tokens.get(0).unwrap();
+    assert_eq!(TokenClient::new(&env, &token0).balance(&admin), 500);
+    assert_eq!(TokenClient::new(&env, &token0).balance(&b), 500);
+
+    let token9 = tokens.get(9).unwrap();
+    assert_eq!(TokenClient::new(&env, &token9).balance(&admin), 5000);
+    assert_eq!(TokenClient::new(&env, &token9).balance(&b), 5000);
+}
+
+// ── Batch Distribute Tests ──────────────────────────────────────────────────
+
+/// Test that batch_distribute processes multiple tokens in one call.
+#[test]
+fn test_batch_distribute_multiple_tokens() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 6000_u32, 4000_u32],
+    );
+
+    // Create three different tokens
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+    let token3 = make_token(&env, &token_admin);
+
+    // Mint different amounts to the contract for each token
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+    mint(&env, &token3, &contract_id, 3000);
+
+    // Batch distribute all three tokens
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone(), token3.clone()]);
+
+    // Verify token1 distribution (1000 total: 600 + 400)
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 600);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&b), 400);
+
+    // Verify token2 distribution (2000 total: 1200 + 800)
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1200);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&b), 800);
+
+    // Verify token3 distribution (3000 total: 1800 + 1200)
+    assert_eq!(TokenClient::new(&env, &token3).balance(&admin), 1800);
+    assert_eq!(TokenClient::new(&env, &token3).balance(&b), 1200);
+
+    // Verify distribute count incremented by 3
+    assert_eq!(client.get_distribute_count(), 3);
+}
+
+/// Test that batch_distribute emits events for each token.
+#[test]
+fn test_batch_distribute_emits_events() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    let events = env.events().all();
+
+    // Check for dist_all events for both tokens
+    let token1_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("dist_all").into_val(&env),
+                ]
+            && val_eq(&env, data, (token1.clone(), 1000_i128))
+    });
+    assert!(token1_event, "token1 dist_all event not emitted");
+
+    let token2_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("dist_all").into_val(&env),
+                ]
+            && val_eq(&env, data, (token2.clone(), 2000_i128))
+    });
+    assert!(token2_event, "token2 dist_all event not emitted");
+
+    // Check for batch completion event
+    let batch_event = events.iter().any(|(cid, topics, data)| {
+        cid == contract_id
+            && topics
+                == vec![
+                    &env,
+                    symbol_short!("royalty").into_val(&env),
+                    symbol_short!("batch").into_val(&env),
+                ]
+            && val_eq(&env, data, 2_u32)
+    });
+    assert!(batch_event, "batch completion event not emitted");
+}
+
+/// Test that batch_distribute requires admin authorization.
+#[test]
+fn test_batch_distribute_requires_admin_auth() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    env.mock_all_auths_allowing_non_root_auth();
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+
+    // Use specific mock auth for admin
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "batch_distribute",
+            args: (vec![&env, token1.clone()],).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.batch_distribute(&vec![&env, token1]);
+    assert_eq!(client.get_distribute_count(), 1);
+}
+
+/// Test that batch_distribute fails when paused.
+#[test]
+fn test_batch_distribute_fails_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+
+    client.pause();
+
+    let result = client.try_batch_distribute(&vec![&env, token1]);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+/// Test that batch_distribute succeeds after unpause.
+#[test]
+fn test_batch_distribute_succeeds_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    client.pause();
+    client.unpause();
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 500);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1000);
+}
+
+/// Test that batch_distribute with single token works correctly.
+#[test]
+fn test_batch_distribute_single_token() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 7000_u32, 3000_u32],
+    );
+
+    let token = make_token(&env, &token_admin);
+    mint(&env, &token, &contract_id, 10_000);
+
+    client.batch_distribute(&vec![&env, token.clone()]);
+
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 7000);
+    assert_eq!(TokenClient::new(&env, &token).balance(&b), 3000);
+    assert_eq!(client.get_distribute_count(), 1);
+}
+
+/// Test that batch_distribute fails if any token has zero balance.
+#[test]
+fn test_batch_distribute_fails_on_zero_balance() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    // token2 has zero balance
+
+    let result = client.try_batch_distribute(&vec![&env, token1, token2]);
+    assert_eq!(result, Err(Ok(ContractError::NoBalance)));
+}
+
+/// Test that batch_distribute handles dust correctly for each token.
+#[test]
+fn test_batch_distribute_handles_dust_correctly() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    // Three recipients with shares that create dust
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone(), c.clone()],
+        &vec![&env, 3333_u32, 3333_u32, 3334_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 10_000);
+    mint(&env, &token2, &contract_id, 20_000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    // Verify token1 distribution (10,000 total)
+    let admin_bal1 = TokenClient::new(&env, &token1).balance(&admin);
+    let b_bal1 = TokenClient::new(&env, &token1).balance(&b);
+    let c_bal1 = TokenClient::new(&env, &token1).balance(&c);
+    assert_eq!(admin_bal1 + b_bal1 + c_bal1, 10_000);
+
+    // Verify token2 distribution (20,000 total)
+    let admin_bal2 = TokenClient::new(&env, &token2).balance(&admin);
+    let b_bal2 = TokenClient::new(&env, &token2).balance(&b);
+    let c_bal2 = TokenClient::new(&env, &token2).balance(&c);
+    assert_eq!(admin_bal2 + b_bal2 + c_bal2, 20_000);
+}
+
+/// Test that batch_distribute works with default recipients.
+#[test]
+fn test_batch_distribute_with_default_recipients() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Set custom default recipients
+    let custom_recipients = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 2000,
+        },
+        Recipient {
+            address: b.clone(),
+            share: 3000,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 5000,
+        },
+    ];
+    client.set_default_recipients(&custom_recipients);
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 10_000);
+    mint(&env, &token2, &contract_id, 5_000);
+
+    client.batch_distribute(&vec![&env, token1.clone(), token2.clone()]);
+
+    // Verify token1 distribution with custom shares
+    assert_eq!(TokenClient::new(&env, &token1).balance(&admin), 2000);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&b), 3000);
+    assert_eq!(TokenClient::new(&env, &token1).balance(&c), 5000);
+
+    // Verify token2 distribution with custom shares
+    assert_eq!(TokenClient::new(&env, &token2).balance(&admin), 1000);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&b), 1500);
+    assert_eq!(TokenClient::new(&env, &token2).balance(&c), 2500);
+}
+
+/// Test that batch_distribute with many tokens increments counter correctly.
+#[test]
+fn test_batch_distribute_counter_increment() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Create 5 tokens
+    let mut tokens: SorobanVec<Address> = SorobanVec::new(&env);
+    for _ in 0..5 {
+        let token = make_token(&env, &token_admin);
+        mint(&env, &token, &contract_id, 1000);
+        tokens.push_back(token);
+    }
+
+    assert_eq!(client.get_distribute_count(), 0);
+
+    client.batch_distribute(&tokens);
+
+    // Counter should increment by 5
+    assert_eq!(client.get_distribute_count(), 5);
+}
+
+/// Test that batch_distribute updates last distribution timestamp.
+#[test]
+fn test_batch_distribute_updates_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 2000);
+
+    let timestamp = 1_700_000_000_u64;
+    env.ledger().with_mut(|ledger| ledger.timestamp = timestamp);
+
+    assert!(client.get_last_distribution().is_none());
+
+    client.batch_distribute(&vec![&env, token1, token2]);
+
+    assert_eq!(client.get_last_distribution(), Some(timestamp));
+}
+
+/// Test that batch_distribute fails if amount is too small for any token.
+#[test]
+fn test_batch_distribute_fails_on_amount_too_small() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let token1 = make_token(&env, &token_admin);
+    let token2 = make_token(&env, &token_admin);
+
+    mint(&env, &token1, &contract_id, 1000);
+    mint(&env, &token2, &contract_id, 1); // Only 1 stroop, but 2 recipients
+
+    let result = client.try_batch_distribute(&vec![&env, token1, token2]);
+    assert_eq!(result, Err(Ok(ContractError::AmountTooSmall)));
+}
+
+/// Test batch_distribute with large number of tokens.
+#[test]
+fn test_batch_distribute_large_batch() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    // Create 10 tokens
+    let mut tokens: SorobanVec<Address> = SorobanVec::new(&env);
+    for i in 0..10 {
+        let token = make_token(&env, &token_admin);
+        mint(&env, &token, &contract_id, (i + 1) * 1000);
+        tokens.push_back(token);
+    }
+
+    client.batch_distribute(&tokens);
+
+    // Verify all distributions occurred
+    assert_eq!(client.get_distribute_count(), 10);
+
+    // Verify balances for a few tokens
+    let token0 = tokens.get(0).unwrap();
+    assert_eq!(TokenClient::new(&env, &token0).balance(&admin), 500);
+    assert_eq!(TokenClient::new(&env, &token0).balance(&b), 500);
+
+    let token9 = tokens.get(9).unwrap();
+    assert_eq!(TokenClient::new(&env, &token9).balance(&admin), 5000);
+    assert_eq!(TokenClient::new(&env, &token9).balance(&b), 5000);
+}


### PR DESCRIPTION
Closes #325

---

This closes issue #325 

## Description
Add a batch_distribute function that allows admin to trigger multiple independent royalty distributions in a single transaction invocation, reducing total ledger fees for high-frequency royalty scenarios.

## Scope of Work
- ✅ Add batch_distribute() function
- ✅ Accept list of token addresses
- ✅ Execute multiple distributions in one call
- ✅ Emit events for each distribution
- ✅ Add comprehensive tests for batch scenarios

## Implementation Details

### New Function: `batch_distribute()`
```rust
pub fn batch_distribute(env: Env, tokens: Vec<Address>)

- Add batch_distribute() function to process multiple tokens in one call
- Accept list of token addresses for batch processing
- Execute multiple distributions atomically with single auth check
- Emit individual events for each token distribution
- Emit batch completion event with token count
- Reduce ledger fees for high-frequency royalty scenarios
- Add 14 comprehensive tests covering:
  - Multiple token distributions
  - Event emissions for each token
  - Admin authorization requirements
  - Pause/unpause behavior
  - Single token batch processing
  - Zero balance error handling
  - Dust handling across multiple tokens
  - Default recipients support
  - Counter increment for batch operations
  - Timestamp updates
  - Amount too small validation
  - Large batch processing (10 tokens)

All tests follow existing patterns and verify complete batch functionality including error handling, authorization, and state management.