### PR TITLE
fix: clear local session state on wallet disconnect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,7 +139,10 @@ export default function App() {
   }, [toggleTheme]);
 
   function handleDisconnect() {
+    // Clear all wallet state and any cached wallet data from localStorage
     setWalletAddress(null);
+    localStorage.removeItem("lastWalletAddress");
+    localStorage.removeItem("freighter_connected");
   }
 
   const renderPage = () => {

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -53,6 +53,7 @@ export default function WalletConnect({ walletAddress, onConnect, onDisconnect }
     setError("");
     setCopied(false);
     localStorage.removeItem("lastWalletAddress");
+    localStorage.removeItem("freighter_connected");
     onDisconnect?.();
   }
 


### PR DESCRIPTION
Closes #240 

- handleDisconnect in App.tsx now removes lastWalletAddress and freighter_connected keys from localStorage in addition to clearing walletAddress state
- WalletConnect.tsx disconnect() also removes freighter_connected from localStorage so no stale data remains after disconnecting Freighter
- UI immediately reflects disconnected state without requiring a hard refresh