### PR TITLE
fix: clearer shares sum error message + real-time ARIA feedback in InitializeForm

### DIFF
--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -20,8 +20,15 @@ export const initializeSchema = z
   .refine((d) => d.collaborators.length === d.shares.length, {
     message: "collaborators and shares must be the same length",
   })
-  .refine((d) => d.shares.reduce((a, b) => a + b, 0) === 10000, {
-    message: "shares must sum to 10000 basis points",
+  .superRefine((d, ctx) => {
+    const actual = d.shares.reduce((a, b) => a + b, 0);
+    if (actual !== 10000) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["shares"],
+        message: `shares must sum to 10000 basis points (got ${actual}, expected 10000)`,
+      });
+    }
   });
 
 export const distributeSchema = z.object({

--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -62,12 +62,38 @@ describe("POST /api/v1/initialize", () => {
     expect(res.body.error).toMatch(/already initialized/i);
   });
 
-  test("400 when shares do not sum to 10000", async () => {
+  test("400 when shares do not sum to 10000 — error message shows actual and expected sums", async () => {
     const res = await request(app)
       .post("/api/v1/initialize")
       .send({ ...validBody, shares: [3000, 3000] });
 
     expect(res.status).toBe(400);
+    // Issue #356: error message must include the actual sum (6000) and expected (10000).
+    const details = JSON.stringify(res.body);
+    expect(details).toMatch(/6000/);
+    expect(details).toMatch(/10000/);
+  });
+
+  test("400 when shares sum to 9999 — error shows 9999 vs 10000", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, shares: [4999, 5000] });
+
+    expect(res.status).toBe(400);
+    const details = JSON.stringify(res.body);
+    expect(details).toMatch(/9999/);
+    expect(details).toMatch(/10000/);
+  });
+
+  test("400 when shares sum to 10001 — error shows 10001 vs 10000", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, shares: [5001, 5000] });
+
+    expect(res.status).toBe(400);
+    const details = JSON.stringify(res.body);
+    expect(details).toMatch(/10001/);
+    expect(details).toMatch(/10000/);
   });
 
   test("400 when collaborators and shares lengths differ", async () => {

--- a/backend/tests/validation.test.js
+++ b/backend/tests/validation.test.js
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for validation.js — shares sum error message clarity (issue #356).
+ *
+ * Focuses on the initializeSchema shares-sum refine: verifies that the error
+ * message includes the actual sum and the expected sum (10000) for all edge
+ * cases near the boundary.
+ */
+import { describe, test, expect } from "@jest/globals";
+import { initializeSchema } from "../src/validation.js";
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const COLLAB1  = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB2  = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+function parseShares(shares) {
+  return initializeSchema.safeParse({
+    contractId: CONTRACT,
+    walletAddress: WALLET,
+    collaborators: shares.map((_, i) => (i === 0 ? COLLAB1 : COLLAB2)),
+    shares,
+  });
+}
+
+describe("initializeSchema — shares sum validation (issue #356)", () => {
+  test("valid: [5000, 5000] sums to 10000 — passes", () => {
+    const result = parseShares([5000, 5000]);
+    expect(result.success).toBe(true);
+  });
+
+  test("valid: [10000] single collaborator — passes", () => {
+    const result = initializeSchema.safeParse({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaborators: [COLLAB1],
+      shares: [10000],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("error: [9999, 0] = 9999 — message includes actual (9999) and expected (10000)", () => {
+    const result = parseShares([9999, 0]);
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/9999/);
+    expect(msg).toMatch(/10000/);
+  });
+
+  test("error: [5000, 5001] = 10001 — message includes actual (10001) and expected (10000)", () => {
+    const result = parseShares([5000, 5001]);
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/10001/);
+    expect(msg).toMatch(/10000/);
+  });
+
+  test("error: [0, 0] = 0 — message includes actual (0) and expected (10000)", () => {
+    const result = parseShares([0, 0]);
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/\b0\b/);
+    expect(msg).toMatch(/10000/);
+  });
+
+  test("error: [3000, 3000] = 6000 — message includes actual (6000) and expected (10000)", () => {
+    const result = parseShares([3000, 3000]);
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/6000/);
+    expect(msg).toMatch(/10000/);
+  });
+
+  test("error: [10000, 1] = 10001 — over by 1 — message includes both sums", () => {
+    const result = parseShares([10000, 1]);
+    // Note: basisPoints max is 10000 so 10001 itself is invalid; the share[1]=1 is valid
+    // but sum = 10001. Expect the sum error to appear.
+    expect(result.success).toBe(false);
+    const allMessages = result.error.issues.map((i) => i.message).join(" ");
+    // Either a max constraint fires or the sum error fires; both must not succeed.
+    expect(allMessages.length).toBeGreaterThan(0);
+  });
+
+  test("error message path is 'shares' for sum mismatch", () => {
+    const result = parseShares([9999, 0]);
+    expect(result.success).toBe(false);
+    const sumIssue = result.error.issues.find((i) => i.message.includes("10000"));
+    expect(sumIssue).toBeDefined();
+    expect(sumIssue.path).toContain("shares");
+  });
+
+  test("error: [5001, 5001] = 10002 — message includes actual (10002)", () => {
+    const result = parseShares([5001, 5001]);
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/10002/);
+  });
+
+  test("valid: [3333, 3333, 3334] three collaborators summing to 10000", () => {
+    const result = initializeSchema.safeParse({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaborators: [COLLAB1, COLLAB2, "GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"],
+      shares: [3333, 3333, 3334],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -302,8 +302,19 @@ export default function InitializeForm({
         </div>
       ))}
 
-      <div className={`share-total ${Math.round(total * 100) === 10_000 ? "share-total--valid" : "share-total--invalid"}`}>
+      <div
+        className={`share-total ${Math.round(total * 100) === 10_000 ? "share-total--valid" : "share-total--invalid"}`}
+        role="status"
+        aria-live="polite"
+        aria-label={`Share total: ${total.toFixed(2)}% of 100% required`}
+        data-testid="share-total"
+      >
         Total: {total.toFixed(2)}% / 100%
+        {Math.round(total * 100) !== 10_000 && total > 0 && (
+          <span className="share-total__hint" aria-hidden="true">
+            {" "}({Math.round(total * 100) < 10_000 ? `${(100 - total).toFixed(2)}% remaining` : `${(total - 100).toFixed(2)}% over`})
+          </span>
+        )}
       </div>
 
       {collaborators.length >= MAX_COLLABORATORS - 5 && collaborators.length < MAX_COLLABORATORS && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -183,6 +183,10 @@ td:last-child {
 .share-total--invalid {
   color: var(--error-color);
 }
+.share-total__hint {
+  opacity: 0.8;
+  font-size: 0.75rem;
+}
 
 .field-error {
   display: block;


### PR DESCRIPTION
## Summary

- **#356** — Backend `validation.js`: error message now shows the actual sum vs expected when shares don't add to 10000
- **#357** — Frontend `InitializeForm.tsx`: share-total display gets `role="status"`, `aria-live="polite"`, and a remaining/over hint

## Issue #356 — Shares validation error message

Changed the shares-sum `.refine()` to `.superRefine()` so the error message is computed from the actual value:

**Before:** `"shares must sum to 10000 basis points"`

**After:** `"shares must sum to 10000 basis points (got 6000, expected 10000)"`

New test file `backend/tests/validation.test.js` covers edge cases: 9999, 10001, 6000, 0, 10002, single-collaborator valid case, multi-collaborator valid case, and verifies the path is `["shares"]`.

`backend/tests/initialize.test.js` updated with 3 API-level assertions confirming the actual and expected sums appear in the 400 response body.

## Issue #357 — Real-time validation feedback

The share-total div already renders with `share-total--valid` (green) / `share-total--invalid` (red) classes on every keystroke. This PR adds:

- `role="status"` + `aria-live="polite"` — screen readers announce the running total as users type
- `aria-label` with explicit percentage values
- `data-testid="share-total"` for test selectors
- Inline hint: `"2.50% remaining"` or `"0.50% over"` when the total is not 100%
- `.share-total__hint` CSS class (subtle opacity for the secondary text)

## Tests

- 9 new unit tests in `backend/tests/validation.test.js` (all pass)
- 3 new API tests in `backend/tests/initialize.test.js` (all pass)
- Pre-existing failures in `signing-key.test.js` and `distribute-idempotency.test.js` are unrelated to this change (confirmed on upstream `main` before our edits)

closes #356
closes #357