### PR TITLE
BUG 348: validate basis points for default recipients in set_default_…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,31 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[repr(u32)]
 pub enum ContractError {
     Underfunded = 1,
+    AlreadyInitialized,
+    EmptyCollaborators,
+    TooManyRecipients,
+    LengthMismatch,
+    InvalidShareTotal,
+    ZeroShare,
+    DuplicateRecipient,
+    InvalidBasisPoints,
+    NotInitialized,
+    NoCollaborators,
+    NoShareMap,
+    ArithmeticOverflow,
+    RoyaltyRateZero,
+    RoyaltyRateTooHigh,
+    ContractPaused,
+    AmountNotPositive,
+    InsufficientBalance,
+    EmptyRecipients,
+    AmountTooSmall,
+    PoolExceedsBalance,
+    NoSecondaryRoyalties,
+    NoSecondaryToken,
+    CollaboratorNotFound,
+    InvalidUpdatedShareTotal,
+    SalePriceNotPositive,
 }
 
 #[contract]
@@ -499,6 +524,7 @@ impl RoyaltySplitter {
         storage::extend_instance_ttl(&env);
 
         Self::check_admin_auth(&env, auth::msg::SET_DEFAULT_RECIPIENTS_ADMIN);
+        Self::validate_default_recipient_basis_points(&env, &recipients);
         Self::validate_recipient_list(&env, &recipients);
 
         // DefaultRecipients uses persistent storage (#322)
@@ -1237,6 +1263,15 @@ impl RoyaltySplitter {
 
         if total_shares != 10_000 {
             Self::fail(env, ContractError::InvalidShareTotal);
+        }
+    }
+
+    fn validate_default_recipient_basis_points(env: &Env, recipients: &Vec<Recipient>) {
+        for i in 0..recipients.len() {
+            let recipient = recipients.get(i).unwrap();
+            if recipient.share > 10_000 {
+                Self::fail(env, ContractError::InvalidBasisPoints);
+            }
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1420,6 +1420,26 @@ fn test_set_default_recipients_zero_share_panics() {
     client.set_default_recipients(&recipients);
 }
 
+/// Test that set_default_recipients rejects invalid basis-point values
+#[test]
+fn test_set_default_recipients_invalid_basis_points_rejected() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (_, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(&vec![&env, admin.clone()], &vec![&env, 10000_u32]);
+
+    let recipient = Recipient {
+        address: admin,
+        share: 10_001_u32,
+    };
+    let recipients = vec![&env, recipient];
+
+    let result = client.try_set_default_recipients(&recipients);
+    assert_eq!(result, Err(Ok(ContractError::InvalidBasisPoints)));
+}
+
 /// Test that set_default_recipients rejects duplicate addresses
 #[test]
 #[should_panic]


### PR DESCRIPTION
#closes #348 
**Title:**
BUG 348: validate basis points for default recipients in `set_default_recipients`

**Description:**
- Added explicit basis point validation in `set_default_recipients()`
- Ensures each `Recipient.share` is within the valid range `0..=10_000`
- Returns typed contract error `ContractError::InvalidBasisPoints` when invalid basis points are provided
- Added regression test `test_set_default_recipients_invalid_basis_points_rejected`
- Preserves existing recipient list validation and default recipient storage behavior

**Testing:**
- Added targeted integration test for invalid basis point rejection
- Recommended verification with `cargo test`

**Files changed:**
- `src/lib.rs`
- `tests/integration_test.rs`

#closes