### PR TITLE
fix: add initialize payload size validation

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -55,6 +55,24 @@ Build an unsigned `initialize` transaction XDR.
 
 **Response:** `{ xdr, transactionId }`
 
+Initialize requests are rejected before contract processing when the request body is too large or when the serialized `collaborators` array exceeds the initialize payload guard.
+
+**Oversized payload response:** `413 Payload Too Large`
+
+```json
+{
+  "error": "Payload too large"
+}
+```
+
+Collaborator-specific payload limit responses use:
+
+```json
+{
+  "error": "Collaborators payload too large"
+}
+```
+
 ## Distribute
 
 ### `POST /api/v1/distribute`

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { addressToScVal, u32ToScVal, vecToScVal, isContractInitialized } from "../stellar.js";
-import { validate, initializeSchema } from "../validation.js";
+import { validate, initializeSchema, validateInitializePayloadSize } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
 
 export const initializeRouter = Router();
@@ -10,57 +10,62 @@ export const initializeRouter = Router();
  * Body: { contractId, walletAddress, collaborators: string[], shares: number[] }
  * Returns: { xdr, transactionId } — unsigned transaction XDR for the frontend to sign & submit + tracking ID
  */
-initializeRouter.post("/", validate(initializeSchema), async (req, res, next) => {
-  try {
-    const { contractId, walletAddress, collaborators, shares } = req.body;
+initializeRouter.post(
+  "/",
+  validateInitializePayloadSize,
+  validate(initializeSchema),
+  async (req, res, next) => {
+    try {
+      const { contractId, walletAddress, collaborators, shares } = req.body;
 
-    if (!contractId || !walletAddress || !collaborators?.length || !shares?.length) {
-      return res.status(400).json({ error: "Missing required fields." });
-    }
-    if (collaborators.length !== shares.length) {
-      return res
-        .status(400)
-        .json({ error: "Collaborators and shares arrays must be the same length" });
-    }
-    const total = shares.reduce((s, n) => s + n, 0);
-    if (total !== 10_000) {
-      return res.status(400).json({ error: "Shares must sum to 10000 basis points" });
-    }
+      if (!contractId || !walletAddress || !collaborators?.length || !shares?.length) {
+        return res.status(400).json({ error: "Missing required fields." });
+      }
+      if (collaborators.length !== shares.length) {
+        return res
+          .status(400)
+          .json({ error: "Collaborators and shares arrays must be the same length" });
+      }
+      const total = shares.reduce((s, n) => s + n, 0);
+      if (total !== 10_000) {
+        return res.status(400).json({ error: "Shares must sum to 10000 basis points" });
+      }
 
-    // Check if contract is already initialized on-chain
-    const alreadyInitialized = await isContractInitialized(contractId);
-    if (alreadyInitialized) {
-      return res.status(409).json({
-        error: "Contract is already initialized. Cannot re-initialize an existing contract.",
+      // Check if contract is already initialized on-chain
+      const alreadyInitialized = await isContractInitialized(contractId);
+      if (alreadyInitialized) {
+        return res.status(409).json({
+          error: "Contract is already initialized. Cannot re-initialize an existing contract.",
+        });
+      }
+
+      // Build ScVal arguments for the contract call
+      const collaboratorVec = vecToScVal(collaborators.map(addressToScVal));
+      const sharesVec = vecToScVal(shares.map(u32ToScVal));
+
+      // Use shared handler to record transaction, build XDR, and log audit
+      const { xdr, transactionId } = await buildAndRecordTransaction({
+        contractId,
+        walletAddress,
+        transactionType: "initialize",
+        scvlArgs: [collaboratorVec, sharesVec],
+        auditAction: "contract_initialized",
+        auditMetadata: {
+          collaboratorCount: collaborators.length,
+          shares,
+        },
+        transactionMetadata: {
+          requestedAmount: null,
+          tokenId: null,
+        },
       });
+
+      res.json({ xdr, transactionId });
+    } catch (err) {
+      if (err.status) {
+        return res.status(err.status).json({ error: err.message });
+      }
+      next(err);
     }
-
-    // Build ScVal arguments for the contract call
-    const collaboratorVec = vecToScVal(collaborators.map(addressToScVal));
-    const sharesVec = vecToScVal(shares.map(u32ToScVal));
-
-    // Use shared handler to record transaction, build XDR, and log audit
-    const { xdr, transactionId } = await buildAndRecordTransaction({
-      contractId,
-      walletAddress,
-      transactionType: "initialize",
-      scvlArgs: [collaboratorVec, sharesVec],
-      auditAction: "contract_initialized",
-      auditMetadata: {
-        collaboratorCount: collaborators.length,
-        shares,
-      },
-      transactionMetadata: {
-        requestedAmount: null,
-        tokenId: null,
-      },
-    });
-
-    res.json({ xdr, transactionId });
-  } catch (err) {
-    if (err.status) {
-      return res.status(err.status).json({ error: err.message });
-    }
-    next(err);
   }
-});
+);

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -1,12 +1,8 @@
 import { z } from "zod";
 
-export const stellarAddress = z
-  .string()
-  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
+export const stellarAddress = z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
 
-export const contractAddress = z
-  .string()
-  .regex(/^C[A-Z2-7]{55}$/, "Invalid contract address");
+export const contractAddress = z.string().regex(/^C[A-Z2-7]{55}$/, "Invalid contract address");
 
 export const basisPoints = z.number().int().min(0).max(10000);
 
@@ -23,6 +19,9 @@ export const initializeSchema = z
   .refine((d) => d.shares.reduce((a, b) => a + b, 0) === 10000, {
     message: "shares must sum to 10000 basis points",
   });
+
+export const INITIALIZE_PAYLOAD_LIMIT_BYTES = 10 * 1024;
+export const INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES = 8 * 1024;
 
 export const distributeSchema = z.object({
   contractId: contractAddress,
@@ -84,6 +83,28 @@ export function validate(schema) {
     req.body = result.data;
     next();
   };
+}
+
+function getJsonByteLength(value) {
+  return Buffer.byteLength(JSON.stringify(value ?? ""), "utf8");
+}
+
+export function validateInitializePayloadSize(req, res, next) {
+  const totalBodyBytes = getJsonByteLength(req.body);
+
+  if (totalBodyBytes > INITIALIZE_PAYLOAD_LIMIT_BYTES) {
+    return res.status(413).json({ error: "Payload too large" });
+  }
+
+  if (Array.isArray(req.body?.collaborators)) {
+    const collaboratorsBytes = getJsonByteLength(req.body.collaborators);
+
+    if (collaboratorsBytes > INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES) {
+      return res.status(413).json({ error: "Collaborators payload too large" });
+    }
+  }
+
+  next();
 }
 
 /**

--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -1,5 +1,10 @@
 import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
 import request from "supertest";
+import {
+  INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES,
+  INITIALIZE_PAYLOAD_LIMIT_BYTES,
+} from "../src/validation.js";
 
 // Capture mock functions at factory time so we hold the same instances the route uses
 const retryBuildTx = jest.fn();
@@ -25,12 +30,22 @@ await jest.unstable_mockModule("../src/database/index.js", () => ({
   getMigrationVersion: jest.fn(() => 1),
 }));
 
-const { default: app } = await import("./app.js");
+const { initializeRouter } = await import("../src/routes/initialize.js");
+
+const app = express();
+app.use(express.json({ limit: "10kb" }));
+app.use("/api/v1/initialize", initializeRouter);
+app.use((err, _req, res, _next) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Payload too large" });
+  }
+  res.status(500).json({ error: err.message ?? "Internal server error" });
+});
 
 const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const COLLAB1  = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
-const COLLAB2  = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+const WALLET = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const COLLAB1 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB2 = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
 
 const validBody = {
   contractId: CONTRACT,
@@ -79,16 +94,47 @@ describe("POST /api/v1/initialize", () => {
   });
 
   test("400 when required fields are missing", async () => {
-    const res = await request(app)
-      .post("/api/v1/initialize")
-      .send({ contractId: CONTRACT });
+    const res = await request(app).post("/api/v1/initialize").send({ contractId: CONTRACT });
 
     expect(res.status).toBe(400);
   });
 
+  test("413 when initialize request body is too large", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, padding: "x".repeat(INITIALIZE_PAYLOAD_LIMIT_BYTES) });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ error: "Payload too large" });
+    expect(isContractInitialized).not.toHaveBeenCalled();
+    expect(retryBuildTx).not.toHaveBeenCalled();
+    expect(recordTransaction).not.toHaveBeenCalled();
+  });
+
+  test("413 when collaborators payload is too large", async () => {
+    const oversizedCollaborator = `G${"A".repeat(INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES)}`;
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validBody,
+        collaborators: [oversizedCollaborator],
+        shares: [10000],
+      });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ error: "Collaborators payload too large" });
+    expect(isContractInitialized).not.toHaveBeenCalled();
+    expect(retryBuildTx).not.toHaveBeenCalled();
+    expect(recordTransaction).not.toHaveBeenCalled();
+  });
+
   test("503 when Stellar RPC is unavailable", async () => {
     isContractInitialized.mockResolvedValue(false);
-    retryBuildTx.mockRejectedValue({ status: 503, message: "Stellar RPC is currently unavailable. Please try again later." });
+    retryBuildTx.mockRejectedValue({
+      status: 503,
+      message: "Stellar RPC is currently unavailable. Please try again later.",
+    });
     recordTransaction.mockReturnValue("tx-123");
 
     const res = await request(app).post("/api/v1/initialize").send(validBody);


### PR DESCRIPTION
This PR adds request payload-size validation to the initialize endpoint to prevent oversized collaborator payloads from reaching validation, transaction building, or contract-processing logic.

Changes Made
Added initialize payload-size validation middleware.
Added a guard for oversized serialized collaborators arrays.
Ensured oversized initialize requests return 413 Payload Too Large.
Ensured payload-size validation runs before schema validation and contract processing.
Added tests to confirm oversized requests are rejected before contract-related functions are called.
Updated API.md to document the new 413 Payload Too Large response behavior.
Testing

Ran npm test

Confirmed valid initialize requests still work.

Confirmed oversized request bodies return 413 Payload Too Large.

Confirmed oversized collaborators payloads return 413 Payload Too Large.

Confirmed contract-processing functions are not called for oversized requests.

Notes

This change does not modify the existing initializeSchema collaborator limits and does not change contract-level validation logic.

Closes #353