### PR TITLE
Add regression test for distribute_with_override invalid override rec…

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1607,6 +1607,70 @@ fn test_distribute_with_override_uses_override() {
     assert_eq!(TokenClient::new(&env, &token).balance(&b), 0);
 }
 
+/// Test distribute_with_override rejects override recipients whose shares do not sum to 10000
+#[test]
+fn test_distribute_with_override_invalid_share_sum_panics_without_distribution() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5000_u32, 5000_u32],
+    );
+
+    let amount: i128 = 1000;
+    mint(&env, &token, &contract_id, amount);
+
+    let bad_override_low = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 5000_u32,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 4999_u32,
+        },
+    ];
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.distribute_with_override(&token, &bad_override_low);
+    }));
+
+    assert!(result.is_err(), "Distribution should panic when override shares sum to 9999");
+    assert_eq!(TokenClient::new(&env, &token).balance(&contract_id), amount);
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 0);
+    assert_eq!(TokenClient::new(&env, &token).balance(&c), 0);
+
+    let bad_override_high = vec![
+        &env,
+        Recipient {
+            address: admin.clone(),
+            share: 5000_u32,
+        },
+        Recipient {
+            address: c.clone(),
+            share: 5001_u32,
+        },
+    ];
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.distribute_with_override(&token, &bad_override_high);
+    }));
+
+    assert!(result.is_err(), "Distribution should panic when override shares sum to 10001");
+    assert_eq!(TokenClient::new(&env, &token).balance(&contract_id), amount);
+    assert_eq!(TokenClient::new(&env, &token).balance(&admin), 0);
+    assert_eq!(TokenClient::new(&env, &token).balance(&c), 0);
+}
+
 /// Test distribute_with_override falls back to defaults when override is empty
 #[test]
 fn test_distribute_with_override_falls_back_to_defaults() {


### PR DESCRIPTION
Added validation in [distribute_with_override()](https://symmetrical-space-meme-6v94gvpwp744crww5.github.dev/) so override recipient shares must sum to 10000 basis points. If they do not, the contract now panics with [ContractError::InvalidShareTotal](https://symmetrical-space-meme-6v94gvpwp744crww5.github.dev/) before any distribution, and I added tests to cover 9999 and 10001 totals.
closes #351