### PR TITLE
feat: add comprehensive API logging and request tracing (#396)

### DIFF
--- a/backend/src/correlation.js
+++ b/backend/src/correlation.js
@@ -1,0 +1,73 @@
+/**
+ * Correlation ID middleware for distributed request tracing (#396).
+ *
+ * Generates a UUID v4 correlation ID for every inbound request (or reads one
+ * from the X-Correlation-ID request header when present, so upstream callers
+ * can propagate their own IDs through the system).
+ *
+ * The ID is:
+ *   - Stored on `req.correlationId`
+ *   - Echoed back in the X-Correlation-ID response header
+ *   - Available via `getCorrelationId(req)` for use inside route handlers
+ *     and service helpers
+ *
+ * Usage:
+ *   import { correlationMiddleware } from './correlation.js';
+ *   app.use(correlationMiddleware);
+ *
+ * Then in a route:
+ *   logger.info('doing something', { correlationId: req.correlationId });
+ */
+
+/**
+ * Generate a UUID v4 string.
+ * Uses the built-in `crypto.randomUUID()` when available (Node ≥ 14.17),
+ * with a pure-JS fallback for test environments that stub crypto.
+ */
+export function generateCorrelationId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback: RFC 4122 compliant UUID v4
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate that a string looks like a UUID v4.
+ * Returns true if valid, false otherwise.
+ */
+export function isValidCorrelationId(id) {
+  return typeof id === "string" && UUID_V4_RE.test(id);
+}
+
+/**
+ * Express middleware that attaches a correlation ID to every request.
+ *
+ * Priority:
+ *   1. X-Correlation-ID request header (caller-provided, validated)
+ *   2. Freshly generated UUID v4
+ */
+export function correlationMiddleware(req, res, next) {
+  const incoming = req.headers["x-correlation-id"];
+  const correlationId =
+    incoming && isValidCorrelationId(incoming) ? incoming : generateCorrelationId();
+
+  req.correlationId = correlationId;
+  res.setHeader("X-Correlation-ID", correlationId);
+  next();
+}
+
+/**
+ * Convenience accessor — returns the correlation ID attached by the middleware.
+ * Falls back to "unknown" when called before the middleware runs (e.g. in tests).
+ */
+export function getCorrelationId(req) {
+  return req?.correlationId ?? "unknown";
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,8 @@ import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import logger from "./logger.js";
+import { correlationMiddleware } from "./correlation.js";
+import { recordHttpRequest } from "./metrics.js";
 import { resolveCorsOrigin } from "./cors-config.js";
 import { initializeRouter } from "./routes/initialize.js";
 import { distributeRouter } from "./routes/distribute.js";
@@ -21,8 +23,6 @@ import { closeDatabase, initializeDatabase } from "./database/index.js";
 import { createGracefulShutdownHandler } from "./shutdown.js";
 import { adminRouter } from "./routes/admin.js";
 import { metricsRouter } from "./routes/metrics.js";
-import { initializeDatabase } from "./database/index.js";
-import db from "./database/index.js";
 import { initializeSigningKey } from "./signing-key.js";
 
 // Initialize database on startup
@@ -31,16 +31,31 @@ initializeSigningKey();
 
 const app = express();
 
-// Request logging middleware
+// #396: Correlation ID — must be first so every subsequent middleware has req.correlationId
+app.use(correlationMiddleware);
+
+// #396: Request / response logging with correlation ID and timing
 app.use((req, res, next) => {
   const start = Date.now();
+  const requestBytes = parseInt(req.headers["content-length"] ?? "0", 10) || 0;
+
   res.on("finish", () => {
-    const duration = Date.now() - start;
-    logger.info(`${req.method} ${req.originalUrl} ${res.statusCode} ${duration}ms`, {
+    const durationMs = Date.now() - start;
+    const responseBytes = parseInt(res.getHeader("content-length") ?? "0", 10) || 0;
+
+    logger.info("HTTP request completed", {
+      correlationId: req.correlationId,
       method: req.method,
       path: req.originalUrl,
       status: res.statusCode,
-      duration,
+      durationMs,
+      requestBytes,
+      responseBytes,
+    });
+
+    recordHttpRequest(req.method, req.originalUrl, res.statusCode, durationMs, {
+      requestBytes,
+      responseBytes,
     });
   });
   next();
@@ -144,11 +159,15 @@ app.use("/api", (req, res) => {
 });
 
 // Central error handler
-app.use((err, _req, res, _next) => {
+app.use((err, req, res, _next) => {
   if (err.type === "entity.too.large") {
     return res.status(413).json({ error: "Payload too large" });
   }
-  logger.error(err);
+  logger.error("Unhandled error", {
+    correlationId: req.correlationId,
+    error: err.message ?? String(err),
+    stack: err.stack,
+  });
 
   // Structured errors thrown by stellar.js (Soroban / RPC errors)
   if (err.status && err.code) {

--- a/backend/src/logger.js
+++ b/backend/src/logger.js
@@ -1,4 +1,4 @@
-// Structured logger (#278).
+// Structured logger (#278, #396).
 //
 // Winston-backed JSON logger with env-driven log level. Levels:
 // error < warn < info < debug. Production deployments typically run
@@ -7,6 +7,10 @@
 //
 // Invalid `LOG_LEVEL` values fall back to `info` (and log a warning
 // once on boot) so a typo can't silence the whole app.
+//
+// #396: `createRequestLogger(req)` returns a child logger that automatically
+// includes `correlationId` in every log entry — use it inside route handlers
+// and service calls to keep all log lines for a single request correlated.
 
 import winston from "winston";
 
@@ -40,6 +44,26 @@ if (
   logger.warn(
     `Invalid LOG_LEVEL '${process.env.LOG_LEVEL}' — falling back to '${DEFAULT_LEVEL}'. Valid values: ${VALID_LEVELS.join(", ")}.`,
   );
+}
+
+/**
+ * Create a child logger bound to a specific request's correlation ID (#396).
+ *
+ * Every log call on the returned child automatically includes:
+ *   { correlationId: "<uuid-v4>" }
+ *
+ * Example:
+ *   const reqLogger = createRequestLogger(req);
+ *   reqLogger.info('distribute called', { contractId });
+ *   // → { "level":"info", "message":"distribute called",
+ *   //     "correlationId":"...", "contractId":"...", "timestamp":"..." }
+ *
+ * Using child loggers (not global variables) keeps context thread-safe
+ * for concurrent requests.
+ */
+export function createRequestLogger(req) {
+  const correlationId = req?.correlationId ?? "unknown";
+  return logger.child({ correlationId });
 }
 
 export { VALID_LEVELS };

--- a/backend/src/metrics.js
+++ b/backend/src/metrics.js
@@ -1,14 +1,56 @@
+/**
+ * In-memory metrics store (#396).
+ *
+ * Tracks:
+ *   - Distribute call totals (existing)
+ *   - Transaction success/failure totals (existing)
+ *   - Horizon response time average (existing)
+ *   - HTTP request counts by method+path+status (#396)
+ *   - HTTP response time observations for p50/p95/p99 latency (#396)
+ *   - Stellar RPC call counts by operation (#396)
+ *   - Request/response size totals (#396)
+ */
+
 const metrics = {
+  // ── Existing counters ──────────────────────────────────────────────────
   distributeCallsTotal: 0,
   transactionsSuccessfulTotal: 0,
   transactionsFailedTotal: 0,
   horizonResponseTimeMsTotal: 0,
   horizonResponseTimeCount: 0,
+
+  // ── #396: HTTP request tracking ───────────────────────────────────────
+  /** Map<"METHOD /path status"> → count */
+  httpRequestCounts: new Map(),
+  /** All response time observations in ms, kept for percentile calculation */
+  responseTimeObservations: [],
+  /** Total request body bytes received */
+  requestBytesTotal: 0,
+  /** Total response body bytes sent */
+  responseBytesTotal: 0,
+
+  // ── #396: Stellar RPC tracing ─────────────────────────────────────────
+  /** Map<operationLabel> → { count, totalMs } */
+  stellarRpcCalls: new Map(),
 };
+
+// ── Helpers ──────────────────────────────────────────────────────────────
 
 function formatMetricValue(value) {
   return Number.isFinite(value) ? value : 0;
 }
+
+/**
+ * Calculate a percentile value from a sorted (ascending) array.
+ * Returns 0 for empty arrays.
+ */
+function percentile(sortedArr, p) {
+  if (!sortedArr.length) return 0;
+  const idx = Math.ceil((p / 100) * sortedArr.length) - 1;
+  return sortedArr[Math.max(0, Math.min(idx, sortedArr.length - 1))];
+}
+
+// ── Existing recorders ───────────────────────────────────────────────────
 
 export function recordDistributeCall() {
   metrics.distributeCallsTotal += 1;
@@ -28,22 +70,101 @@ export function recordHorizonResponseTime(durationMs) {
   metrics.horizonResponseTimeCount += 1;
 }
 
+// ── #396: New recorders ───────────────────────────────────────────────────
+
+/**
+ * Record an HTTP request completion.
+ *
+ * @param {string} method  - HTTP method (GET, POST, …)
+ * @param {string} path    - Normalised route path (e.g. /api/v1/distribute)
+ * @param {number} status  - HTTP status code
+ * @param {number} durationMs - Response time in milliseconds
+ * @param {object} [sizes] - Optional { requestBytes, responseBytes }
+ */
+export function recordHttpRequest(method, path, status, durationMs, sizes = {}) {
+  const key = `${method} ${path} ${status}`;
+  metrics.httpRequestCounts.set(key, (metrics.httpRequestCounts.get(key) ?? 0) + 1);
+
+  if (Number.isFinite(durationMs) && durationMs >= 0) {
+    metrics.responseTimeObservations.push(durationMs);
+  }
+
+  if (Number.isFinite(sizes.requestBytes) && sizes.requestBytes >= 0) {
+    metrics.requestBytesTotal += sizes.requestBytes;
+  }
+  if (Number.isFinite(sizes.responseBytes) && sizes.responseBytes >= 0) {
+    metrics.responseBytesTotal += sizes.responseBytes;
+  }
+}
+
+/**
+ * Record a Stellar RPC call (prepareTransaction, getAccount, simulateTransaction, etc.).
+ *
+ * @param {string} operation  - Human-readable label, e.g. "Soroban prepareTransaction"
+ * @param {number} durationMs - How long the call took
+ * @param {boolean} [success=true]
+ */
+export function recordStellarRpcCall(operation, durationMs, success = true) {
+  const entry = metrics.stellarRpcCalls.get(operation) ?? {
+    count: 0,
+    successCount: 0,
+    failureCount: 0,
+    totalMs: 0,
+  };
+  entry.count += 1;
+  if (success) {
+    entry.successCount += 1;
+  } else {
+    entry.failureCount += 1;
+  }
+  if (Number.isFinite(durationMs) && durationMs >= 0) {
+    entry.totalMs += durationMs;
+  }
+  metrics.stellarRpcCalls.set(operation, entry);
+}
+
+// ── Snapshot ──────────────────────────────────────────────────────────────
+
 export function getMetricsSnapshot() {
   const averageHorizonResponseTimeMs =
     metrics.horizonResponseTimeCount === 0
       ? 0
       : metrics.horizonResponseTimeMsTotal / metrics.horizonResponseTimeCount;
 
+  const sorted = [...metrics.responseTimeObservations].sort((a, b) => a - b);
+
   return {
-    ...metrics,
+    // Existing
+    distributeCallsTotal: metrics.distributeCallsTotal,
+    transactionsSuccessfulTotal: metrics.transactionsSuccessfulTotal,
+    transactionsFailedTotal: metrics.transactionsFailedTotal,
+    horizonResponseTimeMsTotal: metrics.horizonResponseTimeMsTotal,
+    horizonResponseTimeCount: metrics.horizonResponseTimeCount,
     averageHorizonResponseTimeMs,
+
+    // #396
+    httpRequestCounts: Object.fromEntries(metrics.httpRequestCounts),
+    responseTimeP50Ms: percentile(sorted, 50),
+    responseTimeP95Ms: percentile(sorted, 95),
+    responseTimeP99Ms: percentile(sorted, 99),
+    responseTimeObservationCount: sorted.length,
+    requestBytesTotal: metrics.requestBytesTotal,
+    responseBytesTotal: metrics.responseBytesTotal,
+    stellarRpcCalls: Object.fromEntries(
+      [...metrics.stellarRpcCalls.entries()].map(([op, v]) => [
+        op,
+        { ...v, averageMs: v.count > 0 ? v.totalMs / v.count : 0 },
+      ]),
+    ),
   };
 }
+
+// ── Prometheus text format ────────────────────────────────────────────────
 
 export function prometheusMetrics() {
   const snapshot = getMetricsSnapshot();
 
-  return [
+  const lines = [
     "# HELP stellar_distribute_calls_total Total distribute endpoint calls.",
     "# TYPE stellar_distribute_calls_total counter",
     `stellar_distribute_calls_total ${snapshot.distributeCallsTotal}`,
@@ -55,15 +176,68 @@ export function prometheusMetrics() {
     `stellar_transactions_failed_total ${snapshot.transactionsFailedTotal}`,
     "# HELP stellar_horizon_response_time_average_ms Average Horizon response time in milliseconds.",
     "# TYPE stellar_horizon_response_time_average_ms gauge",
-    `stellar_horizon_response_time_average_ms ${formatMetricValue(
-      snapshot.averageHorizonResponseTimeMs,
-    )}`,
+    `stellar_horizon_response_time_average_ms ${formatMetricValue(snapshot.averageHorizonResponseTimeMs)}`,
     "# HELP stellar_horizon_response_time_count Horizon response time observations.",
     "# TYPE stellar_horizon_response_time_count counter",
     `stellar_horizon_response_time_count ${snapshot.horizonResponseTimeCount}`,
-    "",
-  ].join("\n");
+
+    // #396 — latency percentiles
+    "# HELP stellar_http_response_time_p50_ms 50th-percentile HTTP response time.",
+    "# TYPE stellar_http_response_time_p50_ms gauge",
+    `stellar_http_response_time_p50_ms ${formatMetricValue(snapshot.responseTimeP50Ms)}`,
+    "# HELP stellar_http_response_time_p95_ms 95th-percentile HTTP response time.",
+    "# TYPE stellar_http_response_time_p95_ms gauge",
+    `stellar_http_response_time_p95_ms ${formatMetricValue(snapshot.responseTimeP95Ms)}`,
+    "# HELP stellar_http_response_time_p99_ms 99th-percentile HTTP response time.",
+    "# TYPE stellar_http_response_time_p99_ms gauge",
+    `stellar_http_response_time_p99_ms ${formatMetricValue(snapshot.responseTimeP99Ms)}`,
+    "# HELP stellar_http_response_time_observations_total Number of HTTP response time samples.",
+    "# TYPE stellar_http_response_time_observations_total counter",
+    `stellar_http_response_time_observations_total ${snapshot.responseTimeObservationCount}`,
+
+    // #396 — traffic volume
+    "# HELP stellar_http_request_bytes_total Total request body bytes received.",
+    "# TYPE stellar_http_request_bytes_total counter",
+    `stellar_http_request_bytes_total ${snapshot.requestBytesTotal}`,
+    "# HELP stellar_http_response_bytes_total Total response body bytes sent.",
+    "# TYPE stellar_http_response_bytes_total counter",
+    `stellar_http_response_bytes_total ${snapshot.responseBytesTotal}`,
+  ];
+
+  // #396 — per-route HTTP counters
+  lines.push(
+    "# HELP stellar_http_requests_total HTTP requests by method, path and status.",
+    "# TYPE stellar_http_requests_total counter",
+  );
+  for (const [key, count] of Object.entries(snapshot.httpRequestCounts)) {
+    const [method, path, status] = key.split(" ");
+    lines.push(
+      `stellar_http_requests_total{method="${method}",path="${path}",status="${status}"} ${count}`,
+    );
+  }
+
+  // #396 — Stellar RPC call counters
+  lines.push(
+    "# HELP stellar_rpc_calls_total Stellar RPC calls by operation.",
+    "# TYPE stellar_rpc_calls_total counter",
+    "# HELP stellar_rpc_call_duration_ms_average Average Stellar RPC call duration by operation.",
+    "# TYPE stellar_rpc_call_duration_ms_average gauge",
+  );
+  for (const [op, v] of Object.entries(snapshot.stellarRpcCalls)) {
+    const label = `operation="${op}"`;
+    lines.push(
+      `stellar_rpc_calls_total{${label}} ${v.count}`,
+      `stellar_rpc_calls_total{${label},result="success"} ${v.successCount}`,
+      `stellar_rpc_calls_total{${label},result="failure"} ${v.failureCount}`,
+      `stellar_rpc_call_duration_ms_average{${label}} ${formatMetricValue(v.averageMs)}`,
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
 }
+
+// ── Reset (tests) ─────────────────────────────────────────────────────────
 
 export function resetMetrics() {
   metrics.distributeCallsTotal = 0;
@@ -71,4 +245,9 @@ export function resetMetrics() {
   metrics.transactionsFailedTotal = 0;
   metrics.horizonResponseTimeMsTotal = 0;
   metrics.horizonResponseTimeCount = 0;
+  metrics.httpRequestCounts.clear();
+  metrics.responseTimeObservations.length = 0;
+  metrics.requestBytesTotal = 0;
+  metrics.responseBytesTotal = 0;
+  metrics.stellarRpcCalls.clear();
 }

--- a/backend/src/routes/_shared.js
+++ b/backend/src/routes/_shared.js
@@ -4,11 +4,12 @@ import { recordTransaction, addAuditLog } from "../database/index.js";
 /**
  * Shared pattern for transaction-building routes:
  * 1. Record transaction in database
- * 2. Build transaction XDR
+ * 2. Build transaction XDR (with correlation ID threaded through RPC calls)
  * 3. Log audit event
  * 4. Return XDR and transaction ID
  *
- * This eliminates duplication across initialize, distribute, and similar routes.
+ * #396: Accepts an optional `correlationId` so every Stellar RPC call made
+ * during this request shares the same trace context in logs and metrics.
  */
 export async function buildAndRecordTransaction({
   contractId,
@@ -18,6 +19,7 @@ export async function buildAndRecordTransaction({
   auditAction,
   auditMetadata,
   transactionMetadata = {},
+  correlationId,
 }) {
   // Record transaction in database for audit trail
   const transactionId = recordTransaction(
@@ -27,8 +29,14 @@ export async function buildAndRecordTransaction({
     transactionMetadata
   );
 
-  // Build the transaction XDR
-  const txXdr = await retryBuildTx(walletAddress, contractId, transactionType, scvlArgs);
+  // Build the transaction XDR — pass correlationId for RPC tracing
+  const txXdr = await retryBuildTx(
+    walletAddress,
+    contractId,
+    transactionType,
+    scvlArgs,
+    correlationId,
+  );
 
   // Log the audit event
   addAuditLog(contractId, auditAction, walletAddress, {

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,6 +1,6 @@
 import express from "express";
 import db from "../database/index.js";
-import logger from "../logger.js";
+import { createRequestLogger } from "../logger.js";
 import { validateContractIdMiddleware } from "../validation.js";
 
 // Simple in-memory cache with TTL
@@ -10,6 +10,7 @@ const CACHE_TTL = 60 * 1000; // 60 seconds
 const router = express.Router();
 
 router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) => {
+  const log = createRequestLogger(req);
   const { contractId } = req.params;
   const { start, end } = req.query;
 
@@ -20,12 +21,15 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
 
     // Validate parsed dates
     if (start && isNaN(startDate.getTime())) {
+      log.warn("analytics invalid start date", { contractId, start });
       return res.status(400).json({ success: false, error: "Invalid start date. Use YYYY-MM-DD." });
     }
     if (end && isNaN(endDate.getTime())) {
+      log.warn("analytics invalid end date", { contractId, end });
       return res.status(400).json({ success: false, error: "Invalid end date. Use YYYY-MM-DD." });
     }
     if (start && end && startDate > endDate) {
+      log.warn("analytics start date after end date", { contractId, start, end });
       return res.status(400).json({ success: false, error: "start date must be before end date." });
     }
 
@@ -35,12 +39,19 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
     // Check cache
     const cached = cache.get(cacheKey);
     if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      log.debug("analytics cache hit", { contractId, cacheKey });
       res.set("Cache-Control", "max-age=60");
       return res.json(cached.data);
     }
 
-    // Run the same SQL-aggregated analytics that were previously provided
-    // by the database helper. Use the shared `db` instance.
+    log.info("analytics query started", {
+      contractId,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+    });
+
+    const queryStart = Date.now();
+
     const summary = db
       .prepare(
         `SELECT
@@ -101,6 +112,12 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
       )
       .all(contractId, startDate.toISOString(), endDate.toISOString());
 
+    log.info("analytics query completed", {
+      contractId,
+      durationMs: Date.now() - queryStart,
+      totalTransactions: summary.totalTransactions,
+    });
+
     const data = {
       success: true,
       data: {
@@ -128,7 +145,11 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
     res.set("Cache-Control", "max-age=60");
     res.json(data);
   } catch (error) {
-    logger.error("Analytics error:", error);
+    log.error("analytics query failed", {
+      contractId,
+      error: error.message ?? String(error),
+      stack: error.stack,
+    });
     res.status(500).json({ success: false, message: "Failed to load analytics data" });
   }
 });

--- a/backend/src/routes/distribute.js
+++ b/backend/src/routes/distribute.js
@@ -3,6 +3,7 @@ import { addressToScVal } from "../stellar.js";
 import { validate, distributeSchema } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
 import { idempotencyMiddleware } from "../idempotency.js";
+import { createRequestLogger } from "../logger.js";
 import {
   recordDistributeCall,
   recordTransactionFailure,
@@ -26,8 +27,11 @@ distributeRouter.post(
   idempotencyMiddleware,
   validate(distributeSchema),
   async (req, res, next) => {
+    const log = createRequestLogger(req);
     try {
       const { contractId, walletAddress, tokenId } = req.body;
+
+      log.info("distribute requested", { contractId, walletAddress, tokenId });
 
       // Use shared handler to record transaction, build XDR, and log audit
       const { xdr, transactionId } = await buildAndRecordTransaction({
@@ -38,11 +42,17 @@ distributeRouter.post(
         auditAction: "distribution_initiated",
         auditMetadata: { tokenId },
         transactionMetadata: { tokenId },
+        correlationId: req.correlationId,
       });
 
+      log.info("distribute transaction built", { contractId, transactionId });
       recordTransactionSuccess();
       res.json({ xdr, transactionId });
     } catch (err) {
+      log.error("distribute failed", {
+        error: err.message ?? String(err),
+        status: err.status,
+      });
       recordTransactionFailure();
       if (err.status) {
         return res.status(err.status).json({ error: err.message });

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { addressToScVal, u32ToScVal, vecToScVal, isContractInitialized } from "../stellar.js";
 import { validate, initializeSchema } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
+import { createRequestLogger } from "../logger.js";
 
 export const initializeRouter = Router();
 
@@ -11,6 +12,7 @@ export const initializeRouter = Router();
  * Returns: { xdr, transactionId } — unsigned transaction XDR for the frontend to sign & submit + tracking ID
  */
 initializeRouter.post("/", validate(initializeSchema), async (req, res, next) => {
+  const log = createRequestLogger(req);
   try {
     const { contractId, walletAddress, collaborators, shares } = req.body;
 
@@ -27,9 +29,16 @@ initializeRouter.post("/", validate(initializeSchema), async (req, res, next) =>
       return res.status(400).json({ error: "Shares must sum to 10000 basis points" });
     }
 
+    log.info("initialize requested", {
+      contractId,
+      walletAddress,
+      collaboratorCount: collaborators.length,
+    });
+
     // Check if contract is already initialized on-chain
     const alreadyInitialized = await isContractInitialized(contractId);
     if (alreadyInitialized) {
+      log.warn("contract already initialized", { contractId });
       return res.status(409).json({
         error: "Contract is already initialized. Cannot re-initialize an existing contract.",
       });
@@ -54,10 +63,16 @@ initializeRouter.post("/", validate(initializeSchema), async (req, res, next) =>
         requestedAmount: null,
         tokenId: null,
       },
+      correlationId: req.correlationId,
     });
 
+    log.info("initialize transaction built", { contractId, transactionId });
     res.json({ xdr, transactionId });
   } catch (err) {
+    log.error("initialize failed", {
+      error: err.message ?? String(err),
+      status: err.status,
+    });
     if (err.status) {
       return res.status(err.status).json({ error: err.message });
     }

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -17,7 +17,7 @@
  */
 import StellarSdk from "@stellar/stellar-sdk";
 import logger from "./logger.js";
-import { recordHorizonResponseTime } from "./metrics.js";
+import { recordHorizonResponseTime, recordStellarRpcCall } from "./metrics.js";
 
 const {
   Contract,
@@ -80,8 +80,12 @@ export function getConfiguredContractId() {
 /**
  * Reject `promise` after `ms` milliseconds with a `{ status: 504, message }`
  * shape so the route layer can pass the error straight through.
+ *
+ * #396: When `correlationId` is provided, records the RPC call duration and
+ * outcome via `recordStellarRpcCall` so it shows up in Prometheus metrics.
  */
-export function withTimeout(promise, ms, label) {
+export function withTimeout(promise, ms, label, correlationId) {
+  const start = Date.now();
   let timer;
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => {
@@ -91,9 +95,33 @@ export function withTimeout(promise, ms, label) {
       });
     }, ms);
   });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) clearTimeout(timer);
-  });
+  return Promise.race([promise, timeout])
+    .then((result) => {
+      recordStellarRpcCall(label, Date.now() - start, true);
+      if (correlationId) {
+        logger.debug("Stellar RPC call succeeded", {
+          correlationId,
+          operation: label,
+          durationMs: Date.now() - start,
+        });
+      }
+      return result;
+    })
+    .catch((err) => {
+      recordStellarRpcCall(label, Date.now() - start, false);
+      if (correlationId) {
+        logger.warn("Stellar RPC call failed", {
+          correlationId,
+          operation: label,
+          durationMs: Date.now() - start,
+          error: err instanceof Error ? err.message : String(err?.message ?? err),
+        });
+      }
+      throw err;
+    })
+    .finally(() => {
+      if (timer) clearTimeout(timer);
+    });
 }
 
 /**
@@ -346,12 +374,15 @@ export function _resetAccountBuildLocks() {
  * Fetch a fresh account record (including the current sequence number) for
  * `callerAddress`. Each `retryBuildTx` attempt funnels through here, which
  * is what guarantees retries don't reuse a stale sequence (#275).
+ *
+ * #396: Optional `correlationId` is forwarded to `withTimeout` for tracing.
  */
-export async function getFreshAccount(callerAddress) {
+export async function getFreshAccount(callerAddress, correlationId) {
   return withTimeout(
     server.getAccount(callerAddress),
     SOROBAN_RPC_TIMEOUT_MS,
     "Soroban getAccount",
+    correlationId,
   );
 }
 
@@ -418,10 +449,14 @@ export function parseSorobanError(error) {
 /**
  * Build an unsigned Soroban transaction XDR for a contract invocation.
  * The frontend signs and submits it.
+ *
+ * #396: Accepts an optional `correlationId` that is threaded through all
+ * RPC calls so every Stellar operation for a single HTTP request shares
+ * the same tracing context in logs and metrics.
  */
-export async function buildTx(callerAddress, contractId, method, args = []) {
+export async function buildTx(callerAddress, contractId, method, args = [], correlationId) {
   return withAccountBuildLock(callerAddress, async () => {
-    const account = await getFreshAccount(callerAddress);
+    const account = await getFreshAccount(callerAddress, correlationId);
     const fee = await getRecommendedFee();
     const contract = new Contract(contractId);
 
@@ -437,6 +472,7 @@ export async function buildTx(callerAddress, contractId, method, args = []) {
       server.prepareTransaction(tx),
       SOROBAN_RPC_TIMEOUT_MS,
       "Soroban prepareTransaction",
+      correlationId,
     );
     return prepared.toXDR();
   });
@@ -467,14 +503,17 @@ function isTimeoutError(error) {
  * network errors up to `maxRetries`.
  *
  * Handles HTTP 429 rate-limit responses from Horizon explicitly.
+ *
+ * #396: Optional `correlationId` is threaded through every `buildTx` call so
+ * all Stellar RPC operations for a single HTTP request share the same trace ID.
  */
-export async function retryBuildTx(callerAddress, contractId, method, args = []) {
+export async function retryBuildTx(callerAddress, contractId, method, args = [], correlationId) {
   const maxRetries = 3;
   const baseBackoffMs = 1000;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      return await buildTx(callerAddress, contractId, method, args);
+      return await buildTx(callerAddress, contractId, method, args, correlationId);
     } catch (error) {
       const isLastAttempt = attempt === maxRetries;
       const isNetworkError =
@@ -498,6 +537,7 @@ export async function retryBuildTx(callerAddress, contractId, method, args = [])
       if (isRateLimit) {
         if (isLastAttempt) {
           logger.warn("Horizon rate limit exceeded after max retries", {
+            correlationId,
             method,
             contractId,
             attempt,
@@ -510,6 +550,7 @@ export async function retryBuildTx(callerAddress, contractId, method, args = [])
         }
         const delay = baseBackoffMs * Math.pow(2, attempt - 1);
         logger.warn(`Horizon rate limit hit, retrying with backoff`, {
+          correlationId,
           method,
           contractId,
           attempt,
@@ -523,6 +564,7 @@ export async function retryBuildTx(callerAddress, contractId, method, args = [])
       if (isTimeout) {
         if (isLastAttempt) {
           logger.warn("Soroban RPC timed out after max retries", {
+            correlationId,
             method,
             contractId,
             attempt,

--- a/backend/tests/correlation.test.js
+++ b/backend/tests/correlation.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for correlation ID middleware (#396).
+ */
+import { describe, test, expect } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+import {
+  correlationMiddleware,
+  generateCorrelationId,
+  isValidCorrelationId,
+  getCorrelationId,
+} from "../src/correlation.js";
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+describe("generateCorrelationId (#396)", () => {
+  test("returns a valid UUID v4", () => {
+    const id = generateCorrelationId();
+    expect(isValidCorrelationId(id)).toBe(true);
+  });
+
+  test("returns a unique ID on every call", () => {
+    const ids = new Set(Array.from({ length: 20 }, generateCorrelationId));
+    expect(ids.size).toBe(20);
+  });
+});
+
+describe("isValidCorrelationId (#396)", () => {
+  test("accepts well-formed UUID v4", () => {
+    expect(isValidCorrelationId("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    // version nibble must be 4
+    expect(isValidCorrelationId("550e8400-e29b-41d4-8716-446655440000")).toBe(true);
+  });
+
+  test("rejects non-UUID strings", () => {
+    expect(isValidCorrelationId("not-a-uuid")).toBe(false);
+    expect(isValidCorrelationId("")).toBe(false);
+    expect(isValidCorrelationId(null)).toBe(false);
+    expect(isValidCorrelationId(undefined)).toBe(false);
+  });
+
+  test("rejects UUID v1 (version nibble ≠ 4)", () => {
+    expect(isValidCorrelationId("550e8400-e29b-11d4-a716-446655440000")).toBe(false);
+  });
+});
+
+describe("getCorrelationId (#396)", () => {
+  test("returns correlationId from req when present", () => {
+    const fakeReq = { correlationId: "abc123-test" };
+    expect(getCorrelationId(fakeReq)).toBe("abc123-test");
+  });
+
+  test("returns 'unknown' when req has no correlationId", () => {
+    expect(getCorrelationId({})).toBe("unknown");
+    expect(getCorrelationId(null)).toBe("unknown");
+    expect(getCorrelationId(undefined)).toBe("unknown");
+  });
+});
+
+// ── Middleware integration tests ──────────────────────────────────────────
+
+function makeApp() {
+  const app = express();
+  app.use(correlationMiddleware);
+  app.get("/ping", (req, res) => {
+    res.json({ correlationId: req.correlationId });
+  });
+  return app;
+}
+
+describe("correlationMiddleware (#396)", () => {
+  test("generates a UUID v4 when no X-Correlation-ID header is sent", async () => {
+    const res = await request(makeApp()).get("/ping");
+    expect(res.status).toBe(200);
+    expect(isValidCorrelationId(res.body.correlationId)).toBe(true);
+    expect(isValidCorrelationId(res.headers["x-correlation-id"])).toBe(true);
+  });
+
+  test("echoes a valid incoming X-Correlation-ID back in the response header", async () => {
+    const id = generateCorrelationId();
+    const res = await request(makeApp()).get("/ping").set("X-Correlation-ID", id);
+    expect(res.headers["x-correlation-id"]).toBe(id);
+    expect(res.body.correlationId).toBe(id);
+  });
+
+  test("generates a fresh ID when the incoming header is not a valid UUID v4", async () => {
+    const res = await request(makeApp())
+      .get("/ping")
+      .set("X-Correlation-ID", "not-a-valid-uuid");
+    const returnedId = res.headers["x-correlation-id"];
+    expect(returnedId).not.toBe("not-a-valid-uuid");
+    expect(isValidCorrelationId(returnedId)).toBe(true);
+  });
+
+  test("each request gets a unique correlation ID", async () => {
+    const app = makeApp();
+    const [r1, r2] = await Promise.all([
+      request(app).get("/ping"),
+      request(app).get("/ping"),
+    ]);
+    expect(r1.headers["x-correlation-id"]).not.toBe(r2.headers["x-correlation-id"]);
+  });
+
+  test("sets X-Correlation-ID response header on every request", async () => {
+    const res = await request(makeApp()).get("/ping");
+    expect(res.headers).toHaveProperty("x-correlation-id");
+  });
+});

--- a/backend/tests/observability.test.js
+++ b/backend/tests/observability.test.js
@@ -1,0 +1,194 @@
+/**
+ * Observability tests — request tracing, latency percentiles, RPC metrics (#396).
+ */
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+
+import { correlationMiddleware, isValidCorrelationId } from "../src/correlation.js";
+import { createRequestLogger } from "../src/logger.js";
+import {
+  recordHttpRequest,
+  recordStellarRpcCall,
+  getMetricsSnapshot,
+  prometheusMetrics,
+  resetMetrics,
+} from "../src/metrics.js";
+import { metricsRouter } from "../src/routes/metrics.js";
+
+beforeEach(() => resetMetrics());
+
+// ── Correlation ID propagation ────────────────────────────────────────────
+
+describe("Correlation ID propagation (#396)", () => {
+  function makeTracingApp() {
+    const app = express();
+    app.use(correlationMiddleware);
+    app.get("/test", (req, res) => {
+      res.json({ correlationId: req.correlationId });
+    });
+    return app;
+  }
+
+  test("correlation ID is present on req and echoed in response header", async () => {
+    const res = await request(makeTracingApp()).get("/test");
+    expect(res.status).toBe(200);
+    expect(isValidCorrelationId(res.body.correlationId)).toBe(true);
+    expect(res.headers["x-correlation-id"]).toBe(res.body.correlationId);
+  });
+
+  test("caller-supplied valid UUID v4 is preserved end-to-end", async () => {
+    // Use a known valid UUID v4
+    const id = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+    const res = await request(makeTracingApp())
+      .get("/test")
+      .set("X-Correlation-ID", id);
+    expect(res.body.correlationId).toBe(id);
+    expect(res.headers["x-correlation-id"]).toBe(id);
+  });
+});
+
+// ── createRequestLogger ───────────────────────────────────────────────────
+
+describe("createRequestLogger (#396)", () => {
+  test("returns a logger with correlationId bound to it", () => {
+    const fakeReq = { correlationId: "test-corr-id-1234" };
+    const log = createRequestLogger(fakeReq);
+    // Winston child loggers expose the defaultMeta / or can be inspected
+    expect(log).toBeDefined();
+    expect(typeof log.info).toBe("function");
+    expect(typeof log.error).toBe("function");
+    expect(typeof log.warn).toBe("function");
+    expect(typeof log.debug).toBe("function");
+  });
+
+  test("falls back to 'unknown' when req has no correlationId", () => {
+    const log = createRequestLogger({});
+    expect(log).toBeDefined();
+  });
+});
+
+// ── HTTP request metrics ──────────────────────────────────────────────────
+
+describe("recordHttpRequest — latency percentiles (#396)", () => {
+  test("p50, p95, p99 calculated correctly from observations", () => {
+    // Record 100 requests with response times 1ms–100ms
+    for (let i = 1; i <= 100; i++) {
+      recordHttpRequest("GET", "/api/v1/test", 200, i);
+    }
+    const snap = getMetricsSnapshot();
+    expect(snap.responseTimeObservationCount).toBe(100);
+    expect(snap.responseTimeP50Ms).toBe(50);
+    expect(snap.responseTimeP95Ms).toBe(95);
+    expect(snap.responseTimeP99Ms).toBe(99);
+  });
+
+  test("request and response byte totals are accumulated", () => {
+    recordHttpRequest("POST", "/api/v1/distribute", 200, 50, {
+      requestBytes: 256,
+      responseBytes: 128,
+    });
+    recordHttpRequest("POST", "/api/v1/distribute", 200, 30, {
+      requestBytes: 512,
+      responseBytes: 64,
+    });
+    const snap = getMetricsSnapshot();
+    expect(snap.requestBytesTotal).toBe(768);
+    expect(snap.responseBytesTotal).toBe(192);
+  });
+
+  test("per-route counts are tracked by method+path+status", () => {
+    recordHttpRequest("GET", "/api/v1/health", 200, 5);
+    recordHttpRequest("GET", "/api/v1/health", 200, 6);
+    recordHttpRequest("POST", "/api/v1/distribute", 400, 10);
+    const snap = getMetricsSnapshot();
+    expect(snap.httpRequestCounts["GET /api/v1/health 200"]).toBe(2);
+    expect(snap.httpRequestCounts["POST /api/v1/distribute 400"]).toBe(1);
+  });
+
+  test("p50/p95/p99 are 0 when no observations recorded", () => {
+    const snap = getMetricsSnapshot();
+    expect(snap.responseTimeP50Ms).toBe(0);
+    expect(snap.responseTimeP95Ms).toBe(0);
+    expect(snap.responseTimeP99Ms).toBe(0);
+  });
+});
+
+// ── Stellar RPC metrics ───────────────────────────────────────────────────
+
+describe("recordStellarRpcCall (#396)", () => {
+  test("records count, successCount, failureCount and averageMs", () => {
+    recordStellarRpcCall("Soroban prepareTransaction", 120, true);
+    recordStellarRpcCall("Soroban prepareTransaction", 80, true);
+    recordStellarRpcCall("Soroban prepareTransaction", 200, false);
+
+    const snap = getMetricsSnapshot();
+    const entry = snap.stellarRpcCalls["Soroban prepareTransaction"];
+    expect(entry.count).toBe(3);
+    expect(entry.successCount).toBe(2);
+    expect(entry.failureCount).toBe(1);
+    expect(entry.averageMs).toBeCloseTo((120 + 80 + 200) / 3, 5);
+  });
+
+  test("multiple operations are tracked independently", () => {
+    recordStellarRpcCall("Soroban getAccount", 50, true);
+    recordStellarRpcCall("Horizon getTransaction", 300, false);
+
+    const snap = getMetricsSnapshot();
+    expect(snap.stellarRpcCalls["Soroban getAccount"].count).toBe(1);
+    expect(snap.stellarRpcCalls["Horizon getTransaction"].count).toBe(1);
+    expect(snap.stellarRpcCalls["Horizon getTransaction"].failureCount).toBe(1);
+  });
+});
+
+// ── Prometheus export ─────────────────────────────────────────────────────
+
+describe("prometheusMetrics with #396 additions", () => {
+  test("includes p50/p95/p99 latency gauges", () => {
+    recordHttpRequest("GET", "/api/v1/health", 200, 42);
+    const text = prometheusMetrics();
+    expect(text).toContain("stellar_http_response_time_p50_ms");
+    expect(text).toContain("stellar_http_response_time_p95_ms");
+    expect(text).toContain("stellar_http_response_time_p99_ms");
+  });
+
+  test("includes per-route HTTP counters with labels", () => {
+    recordHttpRequest("POST", "/api/v1/distribute", 200, 55);
+    const text = prometheusMetrics();
+    expect(text).toContain('stellar_http_requests_total{method="POST"');
+    expect(text).toContain('status="200"');
+  });
+
+  test("includes Stellar RPC call counters", () => {
+    recordStellarRpcCall("Soroban prepareTransaction", 100, true);
+    const text = prometheusMetrics();
+    expect(text).toContain("stellar_rpc_calls_total");
+    expect(text).toContain('operation="Soroban prepareTransaction"');
+  });
+
+  test("includes request/response byte totals", () => {
+    recordHttpRequest("POST", "/api/v1/initialize", 200, 30, {
+      requestBytes: 100,
+      responseBytes: 50,
+    });
+    const text = prometheusMetrics();
+    expect(text).toContain("stellar_http_request_bytes_total 100");
+    expect(text).toContain("stellar_http_response_bytes_total 50");
+  });
+});
+
+// ── /metrics endpoint integration ────────────────────────────────────────
+
+describe("GET /metrics with observability additions (#396)", () => {
+  const app = express();
+  app.use("/metrics", metricsRouter);
+
+  test("returns 200 and includes new latency percentile metrics", async () => {
+    recordHttpRequest("GET", "/api/v1/health", 200, 10);
+    const res = await request(app).get("/metrics");
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("stellar_http_response_time_p50_ms");
+    expect(res.text).toContain("stellar_http_response_time_p95_ms");
+    expect(res.text).toContain("stellar_http_response_time_p99_ms");
+  });
+});


### PR DESCRIPTION
- Add correlation.js: UUID v4 correlation ID middleware
  - Generates fresh UUID v4 per request, or propagates caller-supplied X-Correlation-ID header (validated)
  - Attaches correlationId to req and echoes it in X-Correlation-ID response header
  - Exports generateCorrelationId, isValidCorrelationId, getCorrelationId helpers

- Update logger.js: add createRequestLogger(req)
  - Returns a Winston child logger with correlationId bound in every log entry
  - Uses child loggers (not globals) for safe concurrent-request context

- Update metrics.js: latency percentiles and RPC tracing
  - Track HTTP request counts by method/path/status
  - Record p50/p95/p99 response time percentiles from all observations
  - Track request/response byte totals
  - recordStellarRpcCall() tracks count, success, failure, avg duration per operation
  - Full Prometheus export for all new metrics

- Update stellar.js: thread correlationId through RPC calls
  - withTimeout() now records every RPC call via recordStellarRpcCall()
  - getFreshAccount(), buildTx(), retryBuildTx() accept optional correlationId
  - Warn logs on RPC failures include correlationId for tracing

- Update index.js: wire up correlation middleware
  - correlationMiddleware applied first, before all other middleware
  - Request logging includes correlationId, durationMs, requestBytes, responseBytes
  - recordHttpRequest() called on every response for metrics

- Update routes/initialize.js, distribute.js: per-request child loggers
  - Log request start, success, and failure with correlationId context
  - Pass correlationId into buildAndRecordTransaction

- Update routes/_shared.js: forward correlationId to retryBuildTx

- Update routes/analytics.js: structured error logging with correlationId
  - Log query start, completion (with durationMs), and errors with full context

- Add tests/correlation.test.js: 10 unit + integration tests
- Add tests/observability.test.js: 13 tests covering
  - Correlation ID propagation and header echoing
  - createRequestLogger child logger behaviour
  - p50/p95/p99 percentile calculations
  - Per-route HTTP counter tracking
  - Request/response byte accumulation
  - Stellar RPC call metrics
  - Prometheus text format for all new metrics
  - /metrics endpoint integration closes #396 