### PR TITLE
Implement security hardening, dark mode, and commit-reveal init (#390…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,6 +79,13 @@ CORS_PREFLIGHT_MAX_AGE=86400
 # LOG_LEVEL — winston log level: error | warn | info | http | verbose | debug | silly (default: info)
 LOG_LEVEL=info
 
+# REQUEST_SIGNING_REQUIRED — require Ed25519 signatures on write requests (default: false)
+# REQUEST_SIGNING_MAX_AGE_MS — signature timestamp window in ms (default: 300000)
+# REQUEST_SIGNING_REQUIRED=true
+
+# RATE_LIMIT_ANALYTICS_MAX — max history/analytics/audit requests per minute per IP (default: 30)
+# RATE_LIMIT_ANALYTICS_MAX=30
+
 # Rate limiting
 # RATE_LIMIT_WINDOW_MS — sliding window duration for rate limiting in milliseconds (default: 15 minutes)
 RATE_LIMIT_WINDOW_MS=900000

--- a/backend/API.md
+++ b/backend/API.md
@@ -45,6 +45,29 @@ Configure the default contract with `ROYALTY_CONTRACT_ID` or `CONTRACT_ID`. Resp
 
 Legacy `/api/*` paths redirect to `/api/v1/*`.
 
+## Request signing (#392)
+
+Write operations (`POST`, `PUT`, `DELETE`) may require Ed25519 request signatures when `REQUEST_SIGNING_REQUIRED=true`.
+
+**Headers:**
+
+| Header | Description |
+| ------ | ----------- |
+| `X-Wallet-Address` | Stellar `G...` address of the signer |
+| `X-Timestamp` | Unix epoch seconds (max age 5 minutes) |
+| `X-Nonce` | Unique UUID per request (replay protection) |
+| `X-Signature` | Base64 Ed25519 signature |
+
+**Canonical message:**
+
+```
+METHOD\nPATH\nTIMESTAMP\nNONCE\nSHA256_HEX(body)
+```
+
+Example path: `/api/v1/initialize`. Unsigned requests are allowed when signing is not required (default in development).
+
+Invalid or missing signatures return `401`.
+
 ## Initialize
 
 ### `POST /api/v1/initialize`
@@ -72,6 +95,22 @@ Collaborator-specific payload limit responses use:
   "error": "Collaborators payload too large"
 }
 ```
+
+### `POST /api/v1/initialize/commit` (#403)
+
+Commit-reveal phase 1 — stores hashed collaborator/share data on-chain.
+
+**Body:** `{ contractId, walletAddress, collaboratorsHash, sharesHash, nonce }` (64-char hex strings)
+
+**Response:** `{ xdr, transactionId, phase: "commit" }`
+
+### `POST /api/v1/initialize/reveal` (#403)
+
+Commit-reveal phase 2 — reveals collaborators and initializes after ≥1 ledger delay.
+
+**Body:** `{ contractId, walletAddress, collaborators, shares, salt }`
+
+**Response:** `{ xdr, transactionId, phase: "reveal" }`
 
 ## Distribute
 
@@ -254,8 +293,52 @@ See route module `src/routes/secondary-royalty.js` for pool, sales, and distribu
 
 ## History & analytics
 
-- `GET /api/v1/history/:contractId`
-- `GET /api/v1/analytics/:contractId`
+### `GET /api/v1/history/:contractId`
+
+Paginated transaction history for a contract.
+
+**Query parameters:**
+
+| Param | Type | Default | Constraints |
+| ----- | ---- | ------- | ----------- |
+| `limit` | integer | `10` | `1`–`100` |
+| `offset` | integer | `0` | `0`–`1000000` |
+
+Invalid pagination returns `400` with validation details.
+
+**Example:**
+
+```bash
+curl "http://localhost:3001/api/v1/history/C...?limit=10&offset=0"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [],
+  "pagination": { "limit": 10, "offset": 0, "total": 0 }
+}
+```
+
+### `GET /api/v1/audit/:contractId`
+
+Paginated audit log. Same `limit` / `offset` constraints as history.
+
+### `GET /api/v1/analytics/:contractId`
+
+Aggregated analytics for a contract.
+
+**Query parameters:**
+
+| Param | Type | Default | Constraints |
+| ----- | ---- | ------- | ----------- |
+| `start` | ISO date | 90 days ago | Valid date string |
+| `end` | ISO date | now | Valid date string |
+| `collaboratorLimit` | integer | `10` | `1`–`100` — caps `collaboratorStats` rows |
+
+**Rate limiting:** History, audit, and analytics endpoints share a dedicated limiter (default 30 req/min per IP) in addition to the general API limiter.
 
 ## Transaction confirmation
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -21,10 +21,9 @@ import { closeDatabase, initializeDatabase } from "./database/index.js";
 import { createGracefulShutdownHandler } from "./shutdown.js";
 import { adminRouter } from "./routes/admin.js";
 import { metricsRouter } from "./routes/metrics.js";
-import { initializeDatabase } from "./database/index.js";
-import db from "./database/index.js";
 import { initializeSigningKey } from "./signing-key.js";
-import { sendError, normalizeErrorCode } from "./error-response.js";
+import { sendError } from "./error-response.js";
+import { verifyRequestSignatureMiddleware } from "./request-signing.js";
 
 // Initialize database on startup
 initializeDatabase();
@@ -61,7 +60,16 @@ logger.info("CORS origin configured", { origin: corsOrigin });
 app.use(
   cors({
     origin: corsOrigin,
-    methods: ["GET", "POST"],
+    methods: ["GET", "POST", "DELETE"],
+    allowedHeaders: [
+      "Content-Type",
+      "Authorization",
+      "Idempotency-Key",
+      "X-Wallet-Address",
+      "X-Timestamp",
+      "X-Nonce",
+      "X-Signature",
+    ],
     maxAge: Number.isNaN(corsPreflightMaxAge) ? 86400 : corsPreflightMaxAge,
   })
 );
@@ -85,8 +93,27 @@ const writeLimiter = rateLimit({
   handler: (_req, res) => sendError(res, 429, "too_many_requests", "Too many write requests, please slow down."),
 });
 
+// Read limiter for history/analytics: 30 req / 1 min per IP (issue #394)
+const readAnalyticsLimiter = rateLimit({
+  windowMs: 60_000,
+  max: parseInt(process.env.RATE_LIMIT_ANALYTICS_MAX ?? "30"),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req, res) =>
+    sendError(res, 429, "too_many_requests", "Too many analytics/history requests, please slow down."),
+});
+
 app.use(generalLimiter);
 app.use(express.json({ limit: "10kb" }));
+
+// Ed25519 request signature verification for write operations (#392)
+app.use((req, res, next) => {
+  if (req.path.startsWith("/admin")) return next();
+  if (["POST", "PUT", "DELETE"].includes(req.method)) {
+    return verifyRequestSignatureMiddleware(req, res, next);
+  }
+  next();
+});
 
 // Enforce Content-Type: application/json on POST requests
 app.use((req, res, next) => {
@@ -114,6 +141,11 @@ app.use("/api/v1/initialize", writeLimiter);
 app.use("/api/v1/distribute", writeLimiter);
 app.use("/api/v1/secondary-royalty", writeLimiter);
 app.use("/api/v1/webhooks", writeLimiter);
+
+// Per-endpoint rate limits for read-heavy analytics/history routes (#394)
+app.use("/api/v1/history", readAnalyticsLimiter);
+app.use("/api/v1/audit", readAnalyticsLimiter);
+app.use("/api/v1/analytics", readAnalyticsLimiter);
 
 app.use("/api/v1/initialize", initializeRouter);
 app.use("/api/v1/distribute", distributeRouter);

--- a/backend/src/request-signing.js
+++ b/backend/src/request-signing.js
@@ -1,0 +1,203 @@
+/**
+ * Ed25519 HTTP request signature verification (issue #392).
+ *
+ * Canonical signing message:
+ *   METHOD\nPATH\nTIMESTAMP\nNONCE\nBODY_SHA256_HEX
+ *
+ * Headers:
+ *   X-Wallet-Address — Stellar G-address of the signer
+ *   X-Timestamp      — Unix epoch seconds
+ *   X-Nonce          — Unique per-request UUID
+ *   X-Signature      — Base64 Ed25519 signature over the canonical message
+ */
+import { createHash, timingSafeEqual, randomUUID } from "crypto";
+import StellarSdk from "@stellar/stellar-sdk";
+import { sendError } from "./error-response.js";
+import logger from "./logger.js";
+
+const { Keypair } = StellarSdk;
+
+const MAX_SIGNATURE_AGE_MS = parseInt(
+  process.env.REQUEST_SIGNING_MAX_AGE_MS ?? String(5 * 60 * 1000),
+  10
+);
+
+/** When false, unsigned requests are allowed (backwards compatibility). */
+export function isRequestSigningRequired() {
+  return process.env.REQUEST_SIGNING_REQUIRED === "true";
+}
+
+/** In-memory nonce cache with TTL to prevent replay attacks. */
+const usedNonces = new Map();
+
+function pruneNonces() {
+  const now = Date.now();
+  for (const [nonce, expiresAt] of usedNonces) {
+    if (expiresAt <= now) usedNonces.delete(nonce);
+  }
+}
+
+function markNonceUsed(nonce) {
+  pruneNonces();
+  if (usedNonces.has(nonce)) return false;
+  usedNonces.set(nonce, Date.now() + MAX_SIGNATURE_AGE_MS);
+  return true;
+}
+
+export function hashRequestBody(body) {
+  const serialized =
+    body === undefined || body === null
+      ? ""
+      : typeof body === "string"
+        ? body
+        : JSON.stringify(body);
+  return createHash("sha256").update(serialized).digest("hex");
+}
+
+/**
+ * Build the canonical message clients must sign.
+ */
+export function buildCanonicalMessage({ method, path, timestamp, nonce, bodyHash }) {
+  return `${method.toUpperCase()}\n${path}\n${timestamp}\n${nonce}\n${bodyHash}`;
+}
+
+/**
+ * Verify an Ed25519 signature for a wallet address.
+ */
+export function verifyWalletSignature(walletAddress, message, signatureBase64) {
+  try {
+    const keypair = Keypair.fromPublicKey(walletAddress);
+    const signature = Buffer.from(signatureBase64, "base64");
+    const payload = Buffer.from(message, "utf8");
+    return keypair.verify(payload, signature);
+  } catch {
+    return false;
+  }
+}
+
+function safeEqual(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Sign a request (used by tests and documented for clients).
+ */
+export function signRequest({
+  method,
+  path,
+  body,
+  walletSecret,
+  timestamp = Math.floor(Date.now() / 1000),
+  nonce = randomUUID(),
+}) {
+  const keypair = Keypair.fromSecret(walletSecret);
+  const bodyHash = hashRequestBody(body);
+  const message = buildCanonicalMessage({
+    method,
+    path,
+    timestamp,
+    nonce,
+    bodyHash,
+  });
+  const signature = keypair.sign(Buffer.from(message, "utf8")).toString("base64");
+  return {
+    headers: {
+      "X-Wallet-Address": keypair.publicKey(),
+      "X-Timestamp": String(timestamp),
+      "X-Nonce": nonce,
+      "X-Signature": signature,
+    },
+    message,
+  };
+}
+
+/**
+ * Express middleware — validates Ed25519 signatures on write operations.
+ */
+export function verifyRequestSignatureMiddleware(req, res, next) {
+  const walletAddress = req.get("X-Wallet-Address");
+  const timestampHeader = req.get("X-Timestamp");
+  const nonce = req.get("X-Nonce");
+  const signature = req.get("X-Signature");
+
+  const hasAnyHeader = walletAddress || timestampHeader || nonce || signature;
+  const required = isRequestSigningRequired();
+
+  if (!hasAnyHeader && !required) {
+    return next();
+  }
+
+  if (!walletAddress || !timestampHeader || !nonce || !signature) {
+    return sendError(
+      res,
+      401,
+      "missing_signature",
+      "Request signature headers are required: X-Wallet-Address, X-Timestamp, X-Nonce, X-Signature"
+    );
+  }
+
+  if (!/^G[A-Z2-7]{55}$/.test(walletAddress)) {
+    return sendError(res, 401, "invalid_signature", "Invalid wallet address in signature headers");
+  }
+
+  const timestampSec = parseInt(timestampHeader, 10);
+  if (!Number.isFinite(timestampSec)) {
+    return sendError(res, 401, "invalid_signature", "X-Timestamp must be a Unix epoch in seconds");
+  }
+
+  const ageMs = Math.abs(Date.now() - timestampSec * 1000);
+  if (ageMs > MAX_SIGNATURE_AGE_MS) {
+    return sendError(
+      res,
+      401,
+      "signature_expired",
+      `Signature timestamp is outside the allowed window (${MAX_SIGNATURE_AGE_MS / 1000}s)`
+    );
+  }
+
+  if (!markNonceUsed(nonce)) {
+    return sendError(res, 401, "replay_detected", "Nonce has already been used");
+  }
+
+  const bodyHash = hashRequestBody(req.body);
+  const message = buildCanonicalMessage({
+    method: req.method,
+    path: req.originalUrl.split("?")[0],
+    timestamp: timestampSec,
+    nonce,
+    bodyHash,
+  });
+
+  if (!verifyWalletSignature(walletAddress, message, signature)) {
+    logger.warn("Request signature verification failed", {
+      path: req.originalUrl,
+      walletAddress,
+    });
+    return sendError(res, 401, "invalid_signature", "Request signature verification failed");
+  }
+
+  if (
+    req.body &&
+    typeof req.body === "object" &&
+    "walletAddress" in req.body &&
+    !safeEqual(req.body.walletAddress, walletAddress)
+  ) {
+    return sendError(
+      res,
+      401,
+      "wallet_mismatch",
+      "X-Wallet-Address does not match body.walletAddress"
+    );
+  }
+
+  req.signedWalletAddress = walletAddress;
+  next();
+}
+
+/** Reset nonce cache (tests only). */
+export function _resetNonceCache() {
+  usedNonces.clear();
+}

--- a/backend/src/routes/_shared.js
+++ b/backend/src/routes/_shared.js
@@ -14,12 +14,13 @@ export async function buildAndRecordTransaction({
   contractId,
   walletAddress,
   transactionType,
+  contractMethod,
   scvlArgs,
   auditAction,
   auditMetadata,
   transactionMetadata = {},
 }) {
-  // Record transaction in database for audit trail
+  const method = contractMethod ?? transactionType;
   const transactionId = recordTransaction(
     contractId,
     transactionType,
@@ -27,8 +28,7 @@ export async function buildAndRecordTransaction({
     transactionMetadata
   );
 
-  // Build the transaction XDR
-  const txXdr = await retryBuildTx(walletAddress, contractId, transactionType, scvlArgs);
+  const txXdr = await retryBuildTx(walletAddress, contractId, method, scvlArgs);
 
   // Log the audit event
   addAuditLog(contractId, auditAction, walletAddress, {

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,8 +1,8 @@
 import express from "express";
 import db from "../database/index.js";
 import logger from "../logger.js";
-import { validateContractIdMiddleware } from "../validation.js";
-import { sendError } from "../error-response.js";
+import { validateContractIdMiddleware, analyticsQuerySchema } from "../validation.js";
+import { sendError, sendValidationError } from "../error-response.js";
 
 // Simple in-memory cache with TTL
 const cache = new Map();
@@ -12,7 +12,19 @@ const router = express.Router();
 
 router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) => {
   const { contractId } = req.params;
-  const { start, end } = req.query;
+
+  const queryResult = analyticsQuerySchema.safeParse(req.query);
+  if (!queryResult.success) {
+    return sendValidationError(
+      res,
+      queryResult.error.issues.map((e) => ({
+        field: e.path.join(".") || "query",
+        message: e.message,
+      }))
+    );
+  }
+
+  const { start, end, collaboratorLimit = 10 } = queryResult.data;
 
   try {
     // Parse date range
@@ -98,9 +110,10 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
         WHERE t.contractId = ? AND t.status = 'confirmed'
           AND t.timestamp BETWEEN ? AND ?
         GROUP BY dp.collaboratorAddress
-        ORDER BY totalEarned DESC`
+        ORDER BY totalEarned DESC
+        LIMIT ?`
       )
-      .all(contractId, startDate.toISOString(), endDate.toISOString());
+      .all(contractId, startDate.toISOString(), endDate.toISOString(), collaboratorLimit);
 
     const data = {
       success: true,

--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -31,7 +31,7 @@ router.get("/history/:contractId", validateContractIdMiddleware, (req, res) => {
     const { contractId } = req.params;
     if (!validateContractId(contractId, res)) return;
 
-    const pagination = parsePagination(req.query, res, 50, 100);
+    const pagination = parsePagination(req.query, res);
     if (!pagination) return;
     const { limit, offset } = pagination;
 
@@ -170,7 +170,7 @@ router.get("/audit/:contractId", validateContractIdMiddleware, (req, res) => {
     const { contractId } = req.params;
     if (!validateContractId(contractId, res)) return;
 
-    const pagination = parsePagination(req.query, res, 100, 200);
+    const pagination = parsePagination(req.query, res);
     if (!pagination) return;
     const { limit, offset } = pagination;
 

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -1,16 +1,33 @@
 import { Router } from "express";
-import { addressToScVal, u32ToScVal, vecToScVal, isContractInitialized } from "../stellar.js";
-import { validate, initializeSchema, validateInitializePayloadSize } from "../validation.js";
+import {
+  addressToScVal,
+  u32ToScVal,
+  vecToScVal,
+  bytesN32HexToScVal,
+  isContractInitialized,
+} from "../stellar.js";
+import {
+  validate,
+  initializeSchema,
+  commitInitializeSchema,
+  revealInitializeSchema,
+  validateInitializePayloadSize,
+} from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
-import { sendError } from "../error-response.js";
 
 export const initializeRouter = Router();
 
-/**
- * POST /api/initialize
- * Body: { contractId, walletAddress, collaborators: string[], shares: number[] }
- * Returns: { xdr, transactionId } — unsigned transaction XDR for the frontend to sign & submit + tracking ID
- */
+async function ensureNotInitialized(contractId, res) {
+  const alreadyInitialized = await isContractInitialized(contractId);
+  if (alreadyInitialized) {
+    res.status(409).json({
+      error: "Contract is already initialized. Cannot re-initialize an existing contract.",
+    });
+    return false;
+  }
+  return true;
+}
+
 initializeRouter.post(
   "/",
   validateInitializePayloadSize,
@@ -18,59 +35,85 @@ initializeRouter.post(
   async (req, res, next) => {
     try {
       const { contractId, walletAddress, collaborators, shares } = req.body;
+      if (!(await ensureNotInitialized(contractId, res))) return;
 
-    if (!contractId || !walletAddress || !collaborators?.length || !shares?.length) {
-      return res.status(400).json({ error: "Missing required fields." });
-    }
-
-    if (Array.isArray(collaborators) && collaborators.length === 0) {
-      return res.status(400).json({ error: "Collaborators array must be non-empty" });
-    }
-
-    if (collaborators.length !== shares.length) {
-      return res
-        .status(400)
-        .json({ error: "Collaborators and shares arrays must be the same length" });
-    }
-    const total = shares.reduce((s, n) => s + n, 0);
-    if (total !== 10_000) {
-      return res.status(400).json({ error: "Shares must sum to 10000 basis points" });
-    }
-
-      // Check if contract is already initialized on-chain
-      const alreadyInitialized = await isContractInitialized(contractId);
-      if (alreadyInitialized) {
-        return res.status(409).json({
-          error: "Contract is already initialized. Cannot re-initialize an existing contract.",
-        });
-      }
-
-      // Build ScVal arguments for the contract call
       const collaboratorVec = vecToScVal(collaborators.map(addressToScVal));
       const sharesVec = vecToScVal(shares.map(u32ToScVal));
 
-      // Use shared handler to record transaction, build XDR, and log audit
       const { xdr, transactionId } = await buildAndRecordTransaction({
         contractId,
         walletAddress,
         transactionType: "initialize",
         scvlArgs: [collaboratorVec, sharesVec],
         auditAction: "contract_initialized",
-        auditMetadata: {
-          collaboratorCount: collaborators.length,
-          shares,
-        },
-        transactionMetadata: {
-          requestedAmount: null,
-          tokenId: null,
-        },
+        auditMetadata: { collaboratorCount: collaborators.length, shares },
+        transactionMetadata: { requestedAmount: null, tokenId: null },
       });
 
       res.json({ xdr, transactionId });
     } catch (err) {
-      if (err.status) {
-        return res.status(err.status).json({ error: err.message });
-      }
+      if (err.status) return res.status(err.status).json({ error: err.message });
+      next(err);
+    }
+  }
+);
+
+/** POST /api/v1/initialize/commit — commit-reveal phase 1 (#403) */
+initializeRouter.post("/commit", validate(commitInitializeSchema), async (req, res, next) => {
+  try {
+    const { contractId, walletAddress, collaboratorsHash, sharesHash, nonce } = req.body;
+    if (!(await ensureNotInitialized(contractId, res))) return;
+
+    const { xdr, transactionId } = await buildAndRecordTransaction({
+      contractId,
+      walletAddress,
+      transactionType: "initialize",
+      contractMethod: "commit_initialize",
+      scvlArgs: [
+        addressToScVal(walletAddress),
+        bytesN32HexToScVal(collaboratorsHash),
+        bytesN32HexToScVal(sharesHash),
+        bytesN32HexToScVal(nonce),
+      ],
+      auditAction: "initialize_committed",
+      auditMetadata: { collaboratorsHash, sharesHash },
+      transactionMetadata: { requestedAmount: null, tokenId: null },
+    });
+
+    res.json({ xdr, transactionId, phase: "commit" });
+  } catch (err) {
+    if (err.status) return res.status(err.status).json({ error: err.message });
+    next(err);
+  }
+});
+
+/** POST /api/v1/initialize/reveal — commit-reveal phase 2 (#403) */
+initializeRouter.post(
+  "/reveal",
+  validateInitializePayloadSize,
+  validate(revealInitializeSchema),
+  async (req, res, next) => {
+    try {
+      const { contractId, walletAddress, collaborators, shares, salt } = req.body;
+      if (!(await ensureNotInitialized(contractId, res))) return;
+
+      const collaboratorVec = vecToScVal(collaborators.map(addressToScVal));
+      const sharesVec = vecToScVal(shares.map(u32ToScVal));
+
+      const { xdr, transactionId } = await buildAndRecordTransaction({
+        contractId,
+        walletAddress,
+        transactionType: "initialize",
+        contractMethod: "reveal_initialize",
+        scvlArgs: [collaboratorVec, sharesVec, bytesN32HexToScVal(salt)],
+        auditAction: "initialize_revealed",
+        auditMetadata: { collaboratorCount: collaborators.length, shares },
+        transactionMetadata: { requestedAmount: null, tokenId: null },
+      });
+
+      res.json({ xdr, transactionId, phase: "reveal" });
+    } catch (err) {
+      if (err.status) return res.status(err.status).json({ error: err.message });
       next(err);
     }
   }

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -301,7 +301,7 @@ secondaryRoyaltyRouter.get("/sales/:contractId", (req, res, next) => {
     const { contractId } = req.params;
     if (!validateContractId(contractId, res)) return;
 
-    const pagination = parsePagination(req.query, res, 50, 100);
+    const pagination = parsePagination(req.query, res);
     if (!pagination) return;
     const { limit, offset } = pagination;
 
@@ -343,15 +343,17 @@ secondaryRoyaltyRouter.get(
   (req, res, next) => {
     try {
       const { contractId } = req.params;
-      const { limit = 50, offset = 0 } = req.query;
+      const pagination = parsePagination(req.query, res);
+      if (!pagination) return;
+      const { limit, offset } = pagination;
 
       const distributions = getSecondaryRoyaltyDistributions(
         contractId,
-        parseInt(limit),
-        parseInt(offset)
+        limit,
+        offset
       );
 
-      res.json({ distributions });
+      res.json({ distributions, pagination });
     } catch (err) {
       next(err);
     }

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -566,6 +566,14 @@ export function u32ToScVal(n) {
   return xdr.ScVal.scvU32(n);
 }
 
+export function bytesN32HexToScVal(hex) {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length !== 32) {
+    throw new Error("Expected 32-byte hex value");
+  }
+  return xdr.ScVal.scvBytes(buf);
+}
+
 export function i128ToScVal(n) {
   return nativeToScVal(BigInt(n), { type: "i128" });
 }

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -32,6 +32,22 @@ export const initializeSchema = z
     }
   });
 
+const bytes32Hex = z
+  .string()
+  .regex(/^[0-9a-fA-F]{64}$/, "must be a 32-byte hex string (64 hex chars)");
+
+export const commitInitializeSchema = z.object({
+  contractId: contractAddress,
+  walletAddress: stellarAddress,
+  collaboratorsHash: bytes32Hex,
+  sharesHash: bytes32Hex,
+  nonce: bytes32Hex,
+});
+
+export const revealInitializeSchema = initializeSchema.extend({
+  salt: bytes32Hex,
+});
+
 export const INITIALIZE_PAYLOAD_LIMIT_BYTES = 10 * 1024;
 export const INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES = 8 * 1024;
 
@@ -78,6 +94,43 @@ export const transactionConfirmSchema = z.object({
   blockTime: z.string().optional(),
   errorMessage: z.string().optional(),
   status: z.enum(["pending", "confirmed", "failed"]).optional(),
+});
+
+/** Pagination constraints (issue #394): limit 1–100 (default 10), offset >= 0 */
+export const PAGINATION_DEFAULT_LIMIT = 10;
+export const PAGINATION_MAX_LIMIT = 100;
+export const PAGINATION_MAX_OFFSET = 1_000_000;
+
+const paginationLimitSchema = z.coerce
+  .number()
+  .int("limit must be an integer")
+  .min(1, "limit must be at least 1")
+  .max(PAGINATION_MAX_LIMIT, `limit must not exceed ${PAGINATION_MAX_LIMIT}`)
+  .default(PAGINATION_DEFAULT_LIMIT);
+
+const paginationOffsetSchema = z.coerce
+  .number()
+  .int("offset must be an integer")
+  .min(0, "offset must be >= 0")
+  .max(PAGINATION_MAX_OFFSET, `offset must not exceed ${PAGINATION_MAX_OFFSET}`)
+  .default(0);
+
+export const paginationQuerySchema = z.object({
+  limit: paginationLimitSchema,
+  offset: paginationOffsetSchema,
+});
+
+/** Analytics query bounds (issue #394) */
+export const analyticsQuerySchema = z.object({
+  start: z.string().optional(),
+  end: z.string().optional(),
+  collaboratorLimit: z.coerce
+    .number()
+    .int("collaboratorLimit must be an integer")
+    .min(1, "collaboratorLimit must be at least 1")
+    .max(PAGINATION_MAX_LIMIT, `collaboratorLimit must not exceed ${PAGINATION_MAX_LIMIT}`)
+    .default(PAGINATION_DEFAULT_LIMIT)
+    .optional(),
 });
 
 export function validate(schema) {
@@ -156,23 +209,41 @@ export function validateStellarAddress(address, res) {
 }
 
 /**
+ * Express middleware that validates query-string pagination params via Zod.
+ */
+export function validatePaginationQuery(req, res, next) {
+  const result = paginationQuerySchema.safeParse(req.query);
+  if (!result.success) {
+    return sendValidationError(
+      res,
+      result.error.issues.map((e) => ({
+        field: e.path.join(".") || "query",
+        message: e.message,
+      }))
+    );
+  }
+  req.pagination = result.data;
+  next();
+}
+
+/**
  * Parse and validate limit/offset query params.
  * Returns { limit, offset } on success, or sends a 400 and returns null.
+ * Rejects out-of-range values with 400 (issue #394).
  * @param {object} query - req.query
  * @param {object} res   - express response
- * @param {number} defaultLimit
- * @param {number} maxLimit
  */
-export function parsePagination(query, res, defaultLimit = 50, maxLimit = 100) {
-  if (query.limit !== undefined && isNaN(parseInt(query.limit))) {
-    sendError(res, 400, "invalid_query_parameter", "limit must be a number");
+export function parsePagination(query, res) {
+  const result = paginationQuerySchema.safeParse(query);
+  if (!result.success) {
+    sendValidationError(
+      res,
+      result.error.issues.map((e) => ({
+        field: e.path.join(".") || "query",
+        message: e.message,
+      }))
+    );
     return null;
   }
-  if (query.offset !== undefined && isNaN(parseInt(query.offset))) {
-    sendError(res, 400, "invalid_query_parameter", "offset must be a number");
-    return null;
-  }
-  const limit = Math.min(Math.max(parseInt(query.limit) || defaultLimit, 1), maxLimit);
-  const offset = Math.max(parseInt(query.offset) || 0, 0);
-  return { limit, offset };
+  return result.data;
 }

--- a/backend/tests/initialize-commit-reveal.test.js
+++ b/backend/tests/initialize-commit-reveal.test.js
@@ -1,0 +1,89 @@
+/**
+ * Commit-reveal initialize route tests (#403).
+ */
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const HASH = "a".repeat(64);
+
+const retryBuildTx = jest.fn().mockResolvedValue("AAAAxdr");
+const isContractInitialized = jest.fn().mockResolvedValue(false);
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  retryBuildTx,
+  isContractInitialized,
+  addressToScVal: jest.fn((a) => a),
+  u32ToScVal: jest.fn((n) => n),
+  vecToScVal: jest.fn((v) => v),
+  bytesN32HexToScVal: jest.fn((h) => h),
+}));
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  recordTransaction: jest.fn(() => 1),
+  addAuditLog: jest.fn(),
+}));
+
+const { initializeRouter } = await import("../src/routes/initialize.js");
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/initialize", initializeRouter);
+  return app;
+}
+
+describe("initialize commit-reveal routes (#403)", () => {
+  beforeEach(() => {
+    retryBuildTx.mockClear();
+    isContractInitialized.mockResolvedValue(false);
+  });
+
+  test("POST /commit validates hex hashes", async () => {
+    const res = await request(createApp()).post("/api/v1/initialize/commit").send({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaboratorsHash: "not-hex",
+      sharesHash: HASH,
+      nonce: HASH,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /commit returns xdr on success", async () => {
+    const res = await request(createApp()).post("/api/v1/initialize/commit").send({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaboratorsHash: HASH,
+      sharesHash: HASH,
+      nonce: HASH,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.phase).toBe("commit");
+    expect(res.body.xdr).toBeDefined();
+  });
+
+  test("POST /reveal requires salt", async () => {
+    const res = await request(createApp()).post("/api/v1/initialize/reveal").send({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaborators: [WALLET],
+      shares: [10000],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /reveal returns xdr on success", async () => {
+    const res = await request(createApp()).post("/api/v1/initialize/reveal").send({
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      collaborators: [WALLET],
+      shares: [10000],
+      salt: HASH,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.phase).toBe("reveal");
+  });
+});

--- a/backend/tests/pagination.test.js
+++ b/backend/tests/pagination.test.js
@@ -1,0 +1,93 @@
+/**
+ * Pagination and analytics query validation tests (issue #394).
+ */
+import { describe, test, expect } from "@jest/globals";
+import {
+  paginationQuerySchema,
+  analyticsQuerySchema,
+  PAGINATION_DEFAULT_LIMIT,
+  PAGINATION_MAX_LIMIT,
+  PAGINATION_MAX_OFFSET,
+} from "../src/validation.js";
+
+describe("paginationQuerySchema (issue #394)", () => {
+  test("defaults: limit=10, offset=0 when omitted", () => {
+    const result = paginationQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(PAGINATION_DEFAULT_LIMIT);
+    expect(result.data.offset).toBe(0);
+  });
+
+  test("valid: limit=50, offset=100", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "50", offset: "100" });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ limit: 50, offset: 100 });
+  });
+
+  test("rejects limit=0", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "0" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects limit above max (101)", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "101" });
+    expect(result.success).toBe(false);
+    const msg = result.error.issues.map((i) => i.message).join(" ");
+    expect(msg).toMatch(/100/);
+  });
+
+  test("accepts limit at max boundary (100)", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "100" });
+    expect(result.success).toBe(true);
+    expect(result.data.limit).toBe(PAGINATION_MAX_LIMIT);
+  });
+
+  test("rejects negative offset", () => {
+    const result = paginationQuerySchema.safeParse({ offset: "-1" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer limit", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "abc" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects offset above max", () => {
+    const result = paginationQuerySchema.safeParse({
+      offset: String(PAGINATION_MAX_OFFSET + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects float limit (coerced then fails int check)", () => {
+    const result = paginationQuerySchema.safeParse({ limit: "10.5" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("analyticsQuerySchema (issue #394)", () => {
+  test("defaults collaboratorLimit when omitted", () => {
+    const result = analyticsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data.collaboratorLimit).toBe(10);
+  });
+
+  test("valid collaboratorLimit within bounds", () => {
+    const result = analyticsQuerySchema.safeParse({ collaboratorLimit: "25" });
+    expect(result.success).toBe(true);
+    expect(result.data.collaboratorLimit).toBe(25);
+  });
+
+  test("rejects collaboratorLimit above 100", () => {
+    const result = analyticsQuerySchema.safeParse({ collaboratorLimit: "500" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts optional start and end dates", () => {
+    const result = analyticsQuerySchema.safeParse({
+      start: "2024-01-01",
+      end: "2024-12-31",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/backend/tests/request-signing.test.js
+++ b/backend/tests/request-signing.test.js
@@ -1,0 +1,194 @@
+/**
+ * Request signing integration tests (issue #392).
+ */
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import StellarSdk from "@stellar/stellar-sdk";
+import {
+  signRequest,
+  verifyRequestSignatureMiddleware,
+  buildCanonicalMessage,
+  hashRequestBody,
+  verifyWalletSignature,
+  isRequestSigningRequired,
+  _resetNonceCache,
+} from "../src/request-signing.js";
+
+const { Keypair } = StellarSdk;
+const TEST_KEYPAIR = Keypair.random();
+const WALLET_SECRET = TEST_KEYPAIR.secret();
+const WALLET_PUBLIC = TEST_KEYPAIR.publicKey();
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(verifyRequestSignatureMiddleware);
+  app.post("/api/v1/initialize", (req, res) => {
+    res.json({ ok: true, wallet: req.signedWalletAddress ?? req.body.walletAddress });
+  });
+  return app;
+}
+
+describe("request-signing (issue #392)", () => {
+  const originalEnv = process.env.REQUEST_SIGNING_REQUIRED;
+
+  beforeEach(() => {
+    _resetNonceCache();
+    process.env.REQUEST_SIGNING_REQUIRED = "true";
+  });
+
+  afterEach(() => {
+    process.env.REQUEST_SIGNING_REQUIRED = originalEnv;
+    _resetNonceCache();
+  });
+
+  test("valid signature is accepted", async () => {
+    const app = createTestApp();
+    const body = {
+      contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      walletAddress: WALLET_PUBLIC,
+      collaborators: ["GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+      shares: [10000],
+    };
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/initialize",
+      body,
+      walletSecret: WALLET_SECRET,
+    });
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .set(headers)
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test("missing signature headers returns 401 when required", async () => {
+    const app = createTestApp();
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ walletAddress: WALLET_PUBLIC });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("missing_signature");
+  });
+
+  test("invalid signature returns 401", async () => {
+    const app = createTestApp();
+    const body = { walletAddress: WALLET_PUBLIC };
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/initialize",
+      body,
+      walletSecret: WALLET_SECRET,
+    });
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .set({ ...headers, "X-Signature": Buffer.from("invalid").toString("base64") })
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("invalid_signature");
+  });
+
+  test("expired timestamp returns 401", async () => {
+    const app = createTestApp();
+    const body = { walletAddress: WALLET_PUBLIC };
+    const expiredTs = Math.floor(Date.now() / 1000) - 600;
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/initialize",
+      body,
+      walletSecret: WALLET_SECRET,
+      timestamp: expiredTs,
+    });
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .set(headers)
+      .send(body);
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("signature_expired");
+  });
+
+  test("replay nonce returns 401", async () => {
+    const app = createTestApp();
+    const body = { walletAddress: WALLET_PUBLIC };
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/initialize",
+      body,
+      walletSecret: WALLET_SECRET,
+      nonce: "fixed-nonce-123",
+    });
+
+    const first = await request(app).post("/api/v1/initialize").set(headers).send(body);
+    expect(first.status).toBe(200);
+
+    const second = await request(app).post("/api/v1/initialize").set(headers).send(body);
+    expect(second.status).toBe(401);
+    expect(second.body.code).toBe("replay_detected");
+  });
+
+  test("wallet mismatch between header and body returns 401", async () => {
+    const app = createTestApp();
+    const body = {
+      walletAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    };
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/initialize",
+      body,
+      walletSecret: WALLET_SECRET,
+    });
+
+    const res = await request(app).post("/api/v1/initialize").set(headers).send(body);
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("wallet_mismatch");
+  });
+
+  test("unsigned requests allowed when signing not required", async () => {
+    process.env.REQUEST_SIGNING_REQUIRED = "false";
+    const app = createTestApp();
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ walletAddress: WALLET_PUBLIC });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("buildCanonicalMessage and verifyWalletSignature round-trip", () => {
+    const bodyHash = hashRequestBody({ foo: "bar" });
+    const message = buildCanonicalMessage({
+      method: "POST",
+      path: "/api/v1/distribute",
+      timestamp: 1700000000,
+      nonce: "abc",
+      bodyHash,
+    });
+    const { headers } = signRequest({
+      method: "POST",
+      path: "/api/v1/distribute",
+      body: { foo: "bar" },
+      walletSecret: WALLET_SECRET,
+      timestamp: 1700000000,
+      nonce: "abc",
+    });
+    expect(
+      verifyWalletSignature(WALLET_PUBLIC, message, headers["X-Signature"])
+    ).toBe(true);
+  });
+
+  test("isRequestSigningRequired reflects env", () => {
+    process.env.REQUEST_SIGNING_REQUIRED = "true";
+    expect(isRequestSigningRequired()).toBe(true);
+    process.env.REQUEST_SIGNING_REQUIRED = "false";
+    expect(isRequestSigningRequired()).toBe(false);
+  });
+});

--- a/frontend/e2e/theme.spec.ts
+++ b/frontend/e2e/theme.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Theme toggle (#390)", () => {
+  test("toggles dark mode and persists to localStorage", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("theme"));
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", /.+/);
+
+    const toggle = page.getByRole("button", { name: "Toggle theme" });
+    await expect(toggle).toBeVisible();
+
+    const before = await page.locator("html").getAttribute("data-theme");
+    await toggle.click();
+    const after = await page.locator("html").getAttribute("data-theme");
+    expect(after).not.toBe(before);
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", after!);
+
+    const stored = await page.evaluate(() => localStorage.getItem("theme"));
+    expect(stored).toBe(after);
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stellar Royalty Splitter</title>
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem("theme");
+          var dark = saved
+            ? saved === "dark"
+            : window.matchMedia("(prefers-color-scheme: dark)").matches;
+          document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+        } catch (_) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,8 +1,9 @@
 // Thin client that talks to the Express backend
 
 import { extractContractError } from "./lib/contract-errors";
+import { signWriteRequest } from "./lib/request-signing";
 
-const BASE = "/api";
+const BASE = "/api/v1";
 export const SESSION_EXPIRED_EVENT = "srs:session-expired";
 const SESSION_EXPIRED_MESSAGE =
   "Your session has expired. Please connect your wallet again.";
@@ -94,10 +95,30 @@ function readErrorBody(status: number, data: unknown): BackendApiError {
   );
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+async function post<T>(
+  path: string,
+  body: unknown,
+  walletAddress?: string,
+): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+  if (walletAddress && typeof body === "object" && body !== null) {
+    try {
+      const signingHeaders = await signWriteRequest({
+        method: "POST",
+        path: `${BASE}${path}`,
+        body,
+        walletAddress,
+      });
+      Object.assign(headers, signingHeaders);
+    } catch {
+      // Signing is optional when REQUEST_SIGNING_REQUIRED=false on the server.
+    }
+  }
+
   return request<T>(path, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
 }
@@ -166,13 +187,49 @@ export const api = {
     walletAddress: string;
     collaborators: string[];
     shares: number[];
-  }) => post<{ xdr: string; transactionId: number }>("/initialize", body),
+  }) =>
+    post<{ xdr: string; transactionId: number }>(
+      "/initialize",
+      body,
+      body.walletAddress,
+    ),
+
+  commitInitialize: (body: {
+    contractId: string;
+    walletAddress: string;
+    collaboratorsHash: string;
+    sharesHash: string;
+    nonce: string;
+  }) =>
+    post<{ xdr: string; transactionId: number; phase: string }>(
+      "/initialize/commit",
+      body,
+      body.walletAddress,
+    ),
+
+  revealInitialize: (body: {
+    contractId: string;
+    walletAddress: string;
+    collaborators: string[];
+    shares: number[];
+    salt: string;
+  }) =>
+    post<{ xdr: string; transactionId: number; phase: string }>(
+      "/initialize/reveal",
+      body,
+      body.walletAddress,
+    ),
 
   distribute: (body: {
     contractId: string;
     walletAddress: string;
     tokenId: string;
-  }) => post<{ xdr: string; transactionId: number }>("/distribute", body),
+  }) =>
+    post<{ xdr: string; transactionId: number }>(
+      "/distribute",
+      body,
+      body.walletAddress,
+    ),
 
   getContractBalance: (contractId: string, tokenId: string) =>
     get<{ balance: string }>(
@@ -205,10 +262,12 @@ export const api = {
       errorMessage?: string;
       transactionId?: number;
     },
+    walletAddress?: string,
   ) =>
     post<{ success: boolean; message: string }>(
       `/transaction/confirm/${txHash}`,
       body,
+      walletAddress,
     ),
 
   getAuditLog: (contractId: string, limit = 100, offset = 0) =>
@@ -224,7 +283,11 @@ export const api = {
       details?: Record<string, unknown>;
     },
   ) =>
-    post<{ success: boolean; message: string }>(`/audit/${contractId}`, body),
+    post<{ success: boolean; message: string }>(
+      `/audit/${contractId}`,
+      body,
+      body.user,
+    ),
 
   // Secondary Royalty APIs
   recordSecondarySale: (body: {
@@ -240,6 +303,7 @@ export const api = {
     post<{ xdr: string; transactionId: number; royaltyAmount: number }>(
       "/secondary-royalty",
       body,
+      body.walletAddress,
     ),
 
   setRoyaltyRate: (body: {
@@ -250,6 +314,7 @@ export const api = {
     post<{ xdr: string; transactionId: number }>(
       "/secondary-royalty/set-rate",
       body,
+      body.walletAddress,
     ),
 
   distributeSecondaryRoyalties: (body: {
@@ -262,7 +327,7 @@ export const api = {
       transactionId: number;
       numberOfSales: number;
       totalRoyalties: string;
-    }>("/secondary-royalty/distribute", body),
+    }>("/secondary-royalty/distribute", body, body.walletAddress),
 
   getRoyaltyStats: (contractId: string) =>
     get<RoyaltyStats>(`/secondary-royalty/stats/${contractId}`),
@@ -305,11 +370,6 @@ export const api = {
   // NEW: Fetch contract status
   getContractStatus: (contractId: string) =>
     get<{ initialized: boolean }>(`/contract/status/${contractId}`),
-
-  getContractBalance: (contractId: string, tokenId: string) =>
-    get<{ balance: string }>(
-      `/contract/balance/${contractId}?tokenId=${encodeURIComponent(tokenId)}`,
-    ),
 
   getContractVersion: (contractId: string) =>
     get<{ contractId: string; version: string }>(

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -1,10 +1,32 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { api } from "../api";
 import { signAndSubmitTransaction } from "../stellar";
 import { useNetwork } from "../context/NetworkContext";
 import FormStatus from "./FormStatus";
 import { useFormStatus } from "../hooks/useFormStatus";
+import {
+  bytesToHex,
+  generateInitNonce,
+  generateInitSalt,
+  hashCollaborators,
+  hashShares,
+  INIT_COMMIT_STORAGE_KEY,
+  type InitCommitState,
+} from "../lib/init-commitment";
 
+
+type InitPhase = "form" | "committed";
+
+function loadCommitState(contractId: string): InitCommitState | null {
+  try {
+    const raw = localStorage.getItem(INIT_COMMIT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as InitCommitState;
+    return parsed.contractId === contractId ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 interface Collaborator {
   address: string;
@@ -104,6 +126,16 @@ export default function InitializeForm({
   >({});
   const { status, setStatus } = useFormStatus();
   const [loading, setLoading] = useState(false);
+  const [phase, setPhase] = useState<InitPhase>("form");
+  const [pendingCommit, setPendingCommit] = useState<InitCommitState | null>(null);
+
+  useEffect(() => {
+    const saved = loadCommitState(contractId);
+    if (saved) {
+      setPendingCommit(saved);
+      setPhase("committed");
+    }
+  }, [contractId]);
 
   function update(i: number, field: keyof Collaborator, value: string) {
     setCollaborators((prev: Collaborator[]) =>
@@ -174,8 +206,11 @@ export default function InitializeForm({
   const hasInvalidPercentages = collaborators.some((c: Collaborator) => getPercentageError(c.basisPoints));
 
   async function submit() {
-    if (!contractId)
-      return setStatus("error", "Enter a contract ID first.");
+    if (phase === "committed") {
+      return reveal();
+    }
+
+    if (!contractId) return setStatus("error", "Enter a contract ID first.");
     const nextErrors = collaborators.reduce<
       Record<number, { address?: string; basisPoints?: string }>
     >((acc, c, i) => {
@@ -185,61 +220,109 @@ export default function InitializeForm({
           address: "Must be a valid Stellar address (G..., 56 chars)",
         };
       }
-
       const percentageError = getPercentageError(c.basisPoints);
       if (percentageError) {
-        acc[i] = {
-          ...acc[i],
-          basisPoints: percentageError,
-        };
+        acc[i] = { ...acc[i], basisPoints: percentageError };
       }
-
       return acc;
     }, {});
     if (Object.keys(nextErrors).length > 0) {
       setErrors((prev) => ({ ...prev, ...nextErrors }));
       return setStatus("error", "Please fix all field errors before submitting.");
     }
-    if (Math.round(total * 100) !== 10_000)
+    if (Math.round(total * 100) !== 10_000) {
       return setStatus("error", `Percentages must sum to 100% (currently ${total.toFixed(2)}%).`);
-
+    }
     const addresses = collaborators.map((c: Collaborator) => c.address);
-    const hasDuplicates = new Set(addresses).size !== addresses.length;
-    if (hasDuplicates) {
+    if (new Set(addresses).size !== addresses.length) {
       return setStatus("error", "Duplicate addresses are not allowed.");
     }
 
     setLoading(true);
-    setStatus("info", "Building transaction…");
+    setStatus("info", "Step 1/2: Committing initialization hashes…");
+    try {
+      const shares = collaborators.map((c: Collaborator) =>
+        Math.round(parseFloat(c.basisPoints) * 100),
+      );
+      const salt = generateInitSalt();
+      const nonce = generateInitNonce();
+      const collaboratorsHash = await hashCollaborators(addresses, salt);
+      const sharesHash = await hashShares(shares, salt);
+      const res = await api.commitInitialize({
+        contractId,
+        walletAddress,
+        collaboratorsHash: bytesToHex(collaboratorsHash),
+        sharesHash: bytesToHex(sharesHash),
+        nonce: bytesToHex(nonce),
+      });
+      setStatus("info", "Signing commit transaction with Freighter...");
+      const commitHash = await signAndSubmitTransaction(res.xdr, network);
+      await api.confirmTransaction(
+        commitHash,
+        { status: "confirmed", blockTime: new Date().toISOString() },
+        walletAddress,
+      );
+      const commitState: InitCommitState = {
+        contractId,
+        saltHex: bytesToHex(salt),
+        nonceHex: bytesToHex(nonce),
+        collaboratorsHashHex: bytesToHex(collaboratorsHash),
+        sharesHashHex: bytesToHex(sharesHash),
+        committedAt: new Date().toISOString(),
+      };
+      localStorage.setItem(INIT_COMMIT_STORAGE_KEY, JSON.stringify(commitState));
+      setPendingCommit(commitState);
+      setPhase("committed");
+      setStatus(
+        "ok",
+        `Commit confirmed (${commitHash.slice(0, 8)}…). Wait at least 1 ledger, then reveal.`,
+      );
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : "Unknown error";
+      setStatus("error", errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function reveal() {
+    if (!pendingCommit) {
+      return setStatus("error", "No pending commit found. Commit first.");
+    }
+
+    setLoading(true);
+    setStatus("info", "Step 2/2: Revealing collaborators and initializing…");
 
     try {
-      const res = await api.initialize({
+      const addresses = collaborators.map((c: Collaborator) => c.address);
+      const shares = collaborators.map((c: Collaborator) =>
+        Math.round(parseFloat(c.basisPoints) * 100),
+      );
+
+      const res = await api.revealInitialize({
         contractId,
         walletAddress,
         collaborators: addresses,
-        shares: collaborators.map((c: Collaborator) => Math.round(parseFloat(c.basisPoints) * 100)),
+        shares,
+        salt: pendingCommit.saltHex,
       });
 
-      setStatus("info", "Signing transaction with Freighter...");
+      setStatus("info", "Signing reveal transaction with Freighter...");
       const hash = await signAndSubmitTransaction(res.xdr, network);
+      await api.confirmTransaction(
+        hash,
+        { status: "confirmed", blockTime: new Date().toISOString() },
+        walletAddress,
+      );
 
-      setStatus("info", "Waiting for confirmation...");
-      await api.confirmTransaction(hash, {
-        status: "confirmed",
-        blockTime: new Date().toISOString(),
-      });
-
+      localStorage.removeItem(INIT_COMMIT_STORAGE_KEY);
+      setPendingCommit(null);
+      setPhase("form");
       setStatus("ok", `Initialized. Tx: ${hash}`);
       onSuccess();
-
     } catch (e: unknown) {
-      // Handle 409 Conflict error specifically
       const errorMessage = e instanceof Error ? e.message : "Unknown error";
-      if (errorMessage.includes('409') || errorMessage.includes('already initialized')) {
-        setStatus("error", "⚠️ This contract is already initialized. You cannot re-initialize an existing contract.");
-      } else {
-        setStatus("error", errorMessage);
-      }
+      setStatus("error", errorMessage);
     } finally {
       setLoading(false);
     }
@@ -248,6 +331,13 @@ export default function InitializeForm({
   return (
     <div className="card">
       <span className="badge">Initialize</span>
+
+      {phase === "committed" && (
+        <div className="status info" role="status">
+          Commit pending — wait at least 1 ledger (~5s), then reveal with the same
+          collaborator data.
+        </div>
+      )}
 
       {collaborators.map((c: Collaborator, i: number) => (
         <div key={i}>
@@ -337,7 +427,11 @@ export default function InitializeForm({
           onClick={submit}
           disabled={loading || hasErrors || hasEmptyFields || hasInvalidPercentages}
         >
-          {loading ? "Submitting…" : "Initialize contract"}
+          {loading
+            ? "Submitting…"
+            : phase === "committed"
+              ? "Reveal & initialize"
+              : "Commit initialization"}
         </button>
       </div>
 

--- a/frontend/src/components/Settings.css
+++ b/frontend/src/components/Settings.css
@@ -337,3 +337,29 @@
     font-size: 0.9rem;
   }
 }
+
+/* Dark mode (#390) */
+[data-theme="dark"] .settings-header h1,
+[data-theme="dark"] .setting-label label,
+[data-theme="dark"] .settings-section h2 {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .settings-subtitle,
+[data-theme="dark"] .setting-description,
+[data-theme="dark"] .about-item p {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .settings-section,
+[data-theme="dark"] .setting-item,
+[data-theme="dark"] .about-item {
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] .save-status {
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}

--- a/frontend/src/components/TransactionHistory.css
+++ b/frontend/src/components/TransactionHistory.css
@@ -374,7 +374,32 @@
   letter-spacing: 0.5px;
 }
 
+[data-theme="dark"] .transaction-history {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .history-header h2,
+[data-theme="dark"] .tx-table th,
+[data-theme="dark"] .tx-payouts-table th {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .tx-table td,
+[data-theme="dark"] .tx-payouts-table td,
+[data-theme="dark"] .tx-meta {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .tx-table tr:hover {
+  background: var(--bg-tertiary);
+}
+
 .tx-payouts-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 13px;
+}
   padding: 8px 12px;
   border-top: 1px solid #e5e7eb;
   color: #4b5563;

--- a/frontend/src/lib/init-commitment.ts
+++ b/frontend/src/lib/init-commitment.ts
@@ -1,0 +1,74 @@
+/** Commit-reveal hashing for initialize (#403) — must match on-chain contract. */
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return new Uint8Array(digest);
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+export function generateInitSalt(): Uint8Array {
+  const salt = new Uint8Array(32);
+  crypto.getRandomValues(salt);
+  return salt;
+}
+
+export function generateInitNonce(): Uint8Array {
+  const nonce = new Uint8Array(32);
+  crypto.getRandomValues(nonce);
+  return nonce;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const normalized = hex.replace(/^0x/i, "");
+  const out = new Uint8Array(normalized.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export async function hashCollaborators(
+  collaborators: string[],
+  salt: Uint8Array,
+): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const chunks = [salt, ...collaborators.map((c) => enc.encode(c))];
+  return sha256(concatBytes(chunks));
+}
+
+export async function hashShares(shares: number[], salt: Uint8Array): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [salt];
+  for (const share of shares) {
+    const buf = new Uint8Array(4);
+    new DataView(buf.buffer).setUint32(0, share, false);
+    chunks.push(buf);
+  }
+  return sha256(concatBytes(chunks));
+}
+
+export const INIT_COMMIT_STORAGE_KEY = "srs_init_commit";
+
+export interface InitCommitState {
+  contractId: string;
+  saltHex: string;
+  nonceHex: string;
+  collaboratorsHashHex: string;
+  sharesHashHex: string;
+  committedAt: string;
+}

--- a/frontend/src/lib/request-signing.ts
+++ b/frontend/src/lib/request-signing.ts
@@ -1,0 +1,130 @@
+/**
+ * Client-side HTTP request signing (issue #392).
+ * Signs write requests with the connected wallet via Freighter or SDK Keypair.
+ */
+import { Keypair } from "@stellar/stellar-sdk";
+
+const SIGNING_PATH_PREFIX = "/api/v1";
+
+async function sha256Hex(text: string): Promise<string> {
+  const data = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function buildCanonicalMessage({
+  method,
+  path,
+  timestamp,
+  nonce,
+  bodyHash,
+}: {
+  method: string;
+  path: string;
+  timestamp: number;
+  nonce: string;
+  bodyHash: string;
+}): string {
+  return `${method.toUpperCase()}\n${path}\n${timestamp}\n${nonce}\n${bodyHash}`;
+}
+
+export async function hashRequestBody(body: unknown): Promise<string> {
+  const serialized =
+    body === undefined || body === null ? "" : JSON.stringify(body);
+  return sha256Hex(serialized);
+}
+
+/**
+ * Sign a request payload. Uses Freighter signMessage when available;
+ * falls back to throwing if no signing method is available.
+ */
+export async function signWriteRequest({
+  method,
+  path,
+  body,
+  walletAddress,
+}: {
+  method: string;
+  path: string;
+  body: unknown;
+  walletAddress: string;
+}): Promise<Record<string, string>> {
+  const apiPath = path.startsWith(SIGNING_PATH_PREFIX)
+    ? path
+    : `${SIGNING_PATH_PREFIX}${path.startsWith("/") ? path : `/${path}`}`;
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = crypto.randomUUID();
+  const bodyHash = await hashRequestBody(body);
+  const message = buildCanonicalMessage({
+    method,
+    path: apiPath,
+    timestamp,
+    nonce,
+    bodyHash,
+  });
+
+  let signature: string;
+
+  // @ts-expect-error Freighter global
+  if (typeof window !== "undefined" && window.freighter?.signMessage) {
+    // @ts-expect-error Freighter global
+    const signed = await window.freighter.signMessage(message, {
+      address: walletAddress,
+    });
+    signature =
+      typeof signed === "string"
+        ? signed
+        : (signed?.signedMessage ?? signed?.signature ?? "");
+    if (!signature) {
+      throw new Error("Freighter did not return a signature");
+    }
+  } else {
+    throw new Error(
+      "Wallet message signing is required. Connect Freighter with signMessage support.",
+    );
+  }
+
+  return {
+    "X-Wallet-Address": walletAddress,
+    "X-Timestamp": String(timestamp),
+    "X-Nonce": nonce,
+    "X-Signature": signature,
+  };
+}
+
+/** Test helper — sign with a known secret key. */
+export async function signWriteRequestWithSecret({
+  method,
+  path,
+  body,
+  walletSecret,
+}: {
+  method: string;
+  path: string;
+  body: unknown;
+  walletSecret: string;
+}): Promise<Record<string, string>> {
+  const apiPath = path.startsWith(SIGNING_PATH_PREFIX)
+    ? path
+    : `${SIGNING_PATH_PREFIX}${path.startsWith("/") ? path : `/${path}`}`;
+  const keypair = Keypair.fromSecret(walletSecret);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = crypto.randomUUID();
+  const bodyHash = await hashRequestBody(body);
+  const message = buildCanonicalMessage({
+    method,
+    path: apiPath,
+    timestamp,
+    nonce,
+    bodyHash,
+  });
+  const sig = keypair.sign(Buffer.from(message, "utf8"));
+  return {
+    "X-Wallet-Address": keypair.publicKey(),
+    "X-Timestamp": String(timestamp),
+    "X-Nonce": nonce,
+    "X-Signature": sig.toString("base64"),
+  };
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,6 +5,8 @@ use soroban_sdk::{symbol_short, Address, Env, String};
 /// Static auth failure messages (function context + role).
 pub mod msg {
     pub const INITIALIZE_ADMIN: &str = "initialize: admin authorization required";
+    pub const COMMIT_INITIALIZE_ADMIN: &str = "commit_initialize: admin authorization required";
+    pub const REVEAL_INITIALIZE_ADMIN: &str = "reveal_initialize: admin authorization required";
     pub const SET_ROYALTY_RATE_ADMIN: &str = "set_royalty_rate: admin authorization required";
     pub const PAUSE_ADMIN: &str = "pause: admin authorization required";
     pub const UNPAUSE_ADMIN: &str = "unpause: admin authorization required";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ pub mod auth;
 mod storage;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
-    Map, String, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN,
+    Env, Map, String, Vec,
 };
 
 #[contracttype]
@@ -46,6 +46,11 @@ pub enum StorageKey {
     PendingAdmin,
     AdminList,
     AdminThreshold,
+    InitCH,
+    InitSH,
+    InitCS,
+    InitCM,
+    InitNC,
     // Persistent storage
     Collaborators,
     ShareMap,
@@ -61,6 +66,8 @@ pub const RATE_HISTORY_CAP: u32 = 20;
 pub type DataKey = StorageKey;
 
 pub use storage::MIN_TTL;
+
+pub const REVEAL_DELAY_LEDGERS: u32 = 1;
 
 /// On-chain contract version in [semantic versioning](https://semver.org/) format
 /// (`MAJOR.MINOR.PATCH`, e.g. `"0.1.0"`).
@@ -78,31 +85,35 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[repr(u32)]
 pub enum ContractError {
     Underfunded = 1,
-    AlreadyInitialized,
-    EmptyCollaborators,
-    TooManyRecipients,
-    LengthMismatch,
-    InvalidShareTotal,
-    ZeroShare,
-    DuplicateRecipient,
-    InvalidBasisPoints,
-    NotInitialized,
-    NoCollaborators,
-    NoShareMap,
-    ArithmeticOverflow,
-    RoyaltyRateZero,
-    RoyaltyRateTooHigh,
-    ContractPaused,
-    AmountNotPositive,
-    InsufficientBalance,
-    EmptyRecipients,
-    AmountTooSmall,
-    PoolExceedsBalance,
-    NoSecondaryRoyalties,
-    NoSecondaryToken,
-    CollaboratorNotFound,
-    InvalidUpdatedShareTotal,
-    SalePriceNotPositive,
+    AlreadyInitialized = 2,
+    EmptyCollaborators = 3,
+    TooManyRecipients = 4,
+    LengthMismatch = 5,
+    InvalidShareTotal = 6,
+    ZeroShare = 7,
+    DuplicateRecipient = 8,
+    InvalidBasisPoints = 9,
+    NotInitialized = 10,
+    NoCollaborators = 11,
+    NoShareMap = 12,
+    ArithmeticOverflow = 13,
+    RoyaltyRateZero = 14,
+    RoyaltyRateTooHigh = 15,
+    ContractPaused = 16,
+    AmountNotPositive = 17,
+    InsufficientBalance = 18,
+    EmptyRecipients = 19,
+    AmountTooSmall = 20,
+    PoolExceedsBalance = 21,
+    NoSecondaryRoyalties = 22,
+    NoSecondaryToken = 23,
+    CollaboratorNotFound = 24,
+    InvalidUpdatedShareTotal = 25,
+    SalePriceNotPositive = 26,
+    NoPendingCommit = 27,
+    InvalidReveal = 28,
+    RevealTooEarly = 29,
+    CommitmentExists = 30,
 }
 
 #[contract]
@@ -156,83 +167,150 @@ impl RoyaltySplitter {
         result as i128
     }
 
-    /// Initialize the contract with collaborators and their revenue shares.
-    ///
-    /// Can only be called once. The first address in `collaborators` becomes
-    /// the admin and must authorize this transaction.
-    ///
-    /// # Arguments
-    /// * `collaborators` - Recipient wallet addresses; first is admin (max 10).
-    /// * `shares` - Basis-point allocations per collaborator (must sum to 10,000).
-    ///
-    /// # Authorization
-    /// Requires signature from `collaborators[0]` (the admin).
-    ///
-    /// # Panics
-    /// On invalid collaborators/shares, duplicate addresses, or re-initialization.
     pub fn initialize(env: Env, collaborators: Vec<Address>, shares: Vec<u32>) {
         storage::extend_instance_ttl(&env);
+        Self::apply_initialize(&env, collaborators, shares, auth::msg::INITIALIZE_ADMIN);
+    }
 
+    pub fn commit_initialize(
+        env: Env,
+        committer: Address,
+        collaborators_hash: BytesN<32>,
+        shares_hash: BytesN<32>,
+        nonce: BytesN<32>,
+    ) {
+        storage::extend_instance_ttl(&env);
         if env.storage().instance().has(&StorageKey::Admin) {
             Self::fail(&env, ContractError::AlreadyInitialized);
         }
+        if env.storage().instance().has(&StorageKey::InitCH) {
+            Self::fail(&env, ContractError::CommitmentExists);
+        }
+        auth::require_admin(&env, &committer, auth::msg::COMMIT_INITIALIZE_ADMIN);
+        let ledger = env.ledger().sequence();
+        storage::instance_set(&env, &StorageKey::InitCH, &collaborators_hash);
+        storage::instance_set(&env, &StorageKey::InitSH, &shares_hash);
+        storage::instance_set(&env, &StorageKey::InitCS, &ledger);
+        storage::instance_set(&env, &StorageKey::InitCM, &committer);
+        storage::instance_set(&env, &StorageKey::InitNC, &nonce);
+        env.events().publish((symbol_short!("royalty"), symbol_short!("commt")), committer);
+    }
 
+    pub fn reveal_initialize(
+        env: Env,
+        collaborators: Vec<Address>,
+        shares: Vec<u32>,
+        salt: BytesN<32>,
+    ) {
+        storage::extend_instance_ttl(&env);
+        if env.storage().instance().has(&StorageKey::Admin) {
+            Self::fail(&env, ContractError::AlreadyInitialized);
+        }
+        let stored_collab_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::InitCH)
+            .unwrap_or_else(|| Self::fail(&env, ContractError::NoPendingCommit));
+        let stored_shares_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::InitSH)
+            .unwrap_or_else(|| Self::fail(&env, ContractError::NoPendingCommit));
+        let commit_ledger: u32 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::InitCS)
+            .unwrap_or_else(|| Self::fail(&env, ContractError::NoPendingCommit));
+        let committer: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::InitCM)
+            .unwrap_or_else(|| Self::fail(&env, ContractError::NoPendingCommit));
+        if env.ledger().sequence() < commit_ledger + REVEAL_DELAY_LEDGERS {
+            Self::fail(&env, ContractError::RevealTooEarly);
+        }
+        if Self::hash_collaborators(&env, &collaborators, &salt) != stored_collab_hash
+            || Self::hash_shares(&env, &shares, &salt) != stored_shares_hash
+        {
+            Self::clear_init_commit(&env);
+            Self::fail(&env, ContractError::InvalidReveal);
+        }
+        auth::require_admin(&env, &committer, auth::msg::REVEAL_INITIALIZE_ADMIN);
+        if collaborators.get(0).unwrap() != committer {
+            Self::clear_init_commit(&env);
+            Self::fail(&env, ContractError::InvalidReveal);
+        }
+        Self::clear_init_commit(&env);
+        Self::apply_initialize(&env, collaborators, shares, auth::msg::REVEAL_INITIALIZE_ADMIN);
+    }
+
+    fn clear_init_commit(env: &Env) {
+        env.storage().instance().remove(&StorageKey::InitCH);
+        env.storage().instance().remove(&StorageKey::InitSH);
+        env.storage().instance().remove(&StorageKey::InitCS);
+        env.storage().instance().remove(&StorageKey::InitCM);
+        env.storage().instance().remove(&StorageKey::InitNC);
+    }
+
+    fn hash_collaborators(env: &Env, collaborators: &Vec<Address>, salt: &BytesN<32>) -> BytesN<32> {
+        let mut bytes = Bytes::new(env);
+        bytes.extend_from_slice(salt.as_ref());
+        for i in 0..collaborators.len() {
+            let addr = collaborators.get(i).unwrap();
+            bytes.append(&String::from_str(env, &addr.to_string()).to_bytes());
+        }
+        env.crypto().sha256(&bytes)
+    }
+
+    fn hash_shares(env: &Env, shares: &Vec<u32>, salt: &BytesN<32>) -> BytesN<32> {
+        let mut bytes = Bytes::new(env);
+        bytes.extend_from_slice(salt.as_ref());
+        for i in 0..shares.len() {
+            let share = shares.get(i).unwrap();
+            bytes.append(&Bytes::from_slice(env, &share.to_be_bytes()));
+        }
+        env.crypto().sha256(&bytes)
+    }
+
+    fn apply_initialize(env: &Env, collaborators: Vec<Address>, shares: Vec<u32>, auth_msg: &str) {
+        if env.storage().instance().has(&StorageKey::Admin) {
+            Self::fail(env, ContractError::AlreadyInitialized);
+        }
         if collaborators.is_empty() {
-            Self::fail(&env, ContractError::EmptyCollaborators);
+            Self::fail(env, ContractError::EmptyCollaborators);
         }
-
         if collaborators.len() > 10 {
-            Self::fail(&env, ContractError::TooManyRecipients);
+            Self::fail(env, ContractError::TooManyRecipients);
         }
-
-        // The first collaborator is the admin and must sign the init tx,
-        // preventing any third party from front-running initialization.
-        auth::require_admin(
-            &env,
-            &collaborators.get(0).unwrap(),
-            auth::msg::INITIALIZE_ADMIN,
-        );
-
+        auth::require_admin(env, &collaborators.get(0).unwrap(), auth_msg);
         if collaborators.len() != shares.len() {
-            Self::fail(&env, ContractError::LengthMismatch);
+            Self::fail(env, ContractError::LengthMismatch);
         }
-
         let mut total: u32 = 0;
         for share in shares.iter() {
-            total = Self::checked_add_share_total(&env, total, share);
+            total = Self::checked_add_share_total(env, total, share);
         }
-
         if total != 10_000 {
-            Self::fail(&env, ContractError::InvalidShareTotal);
+            Self::fail(env, ContractError::InvalidShareTotal);
         }
-
-        let mut share_map: Map<Address, u32> = Map::new(&env);
-
+        let mut share_map: Map<Address, u32> = Map::new(env);
         for i in 0..collaborators.len() {
             let addr = collaborators.get(i).unwrap();
             let share = shares.get(i).unwrap();
-
             if share == 0 {
-                Self::fail(&env, ContractError::ZeroShare);
+                Self::fail(env, ContractError::ZeroShare);
             }
-
             if share_map.contains_key(addr.clone()) {
-                Self::fail(&env, ContractError::DuplicateRecipient);
+                Self::fail(env, ContractError::DuplicateRecipient);
             }
-
             share_map.set(addr, share);
         }
-
         let admin = collaborators.get(0).unwrap();
-
-        storage::instance_set(&env, &StorageKey::Admin, &admin);
-        // Collaborators and ShareMap go to persistent storage (#322)
-        storage::persistent_set(&env, &StorageKey::Collaborators, &collaborators);
-        storage::persistent_set(&env, &StorageKey::ShareMap, &share_map);
-
-        let version = String::from_str(&env, VERSION);
-        storage::instance_set(&env, &StorageKey::ContractVersion, &version);
-
+        storage::instance_set(env, &StorageKey::Admin, &admin);
+        storage::persistent_set(env, &StorageKey::Collaborators, &collaborators);
+        storage::persistent_set(env, &StorageKey::ShareMap, &share_map);
+        let version = String::from_str(env, VERSION);
+        storage::instance_set(env, &StorageKey::ContractVersion, &version);
         env.events().publish(
             (symbol_short!("royalty"), symbol_short!("init")),
             (collaborators, shares),


### PR DESCRIPTION
## Summary

Closes #390, #392, #394, #403

This PR bundles four related improvements across the stack:

- **#394** — Pagination and analytics query validation with Zod (`limit` 1–100, default 10; `offset` ≥ 0), explicit 400 errors, aligned secondary-royalty routes, analytics `collaboratorLimit` cap, and dedicated rate limiting for history/audit/analytics endpoints.
- **#392** — Ed25519 HTTP request signing for write operations (`POST`/`PUT`/`DELETE`) with nonce replay protection and a 5-minute timestamp window. Backwards compatible via `REQUEST_SIGNING_REQUIRED=false` (default).
- **#390** — Dark mode polish: FOUC prevention in `index.html`, CSS variable coverage for Settings and Transaction History, and Playwright E2E test for theme toggle persistence.
- **#403** — Commit-reveal initialization: `commit_initialize` / `reveal_initialize` on contract, `/initialize/commit` and `/initialize/reveal` API routes, and a two-step Initialize UI (commit → wait 1 ledger → reveal).

## Changes by area

### Backend
- `validation.js` — `paginationQuerySchema`, `analyticsQuerySchema`, commit/reveal schemas
- `request-signing.js` — signature middleware + canonical message format
- `initialize.js` — commit/reveal routes; `_shared.js` supports `contractMethod` override
- `index.js` — signing middleware, CORS headers, analytics rate limiter
- `API.md` + `.env.example` updated

### Frontend
- `api.ts` — `/api/v1` base path, signed write requests
- `request-signing.ts`, `init-commitment.ts` — client utilities
- `InitializeForm.tsx` — 2-step commit-reveal flow
- `theme.spec.ts` — E2E theme toggle test

### Contract
- `commit_initialize`, `reveal_initialize`, shared `apply_initialize`
- `ContractError` explicit discriminants; new commit-reveal storage keys

## Test plan

- [x] `backend/tests/pagination.test.js` (13 cases)
- [x] `backend/tests/request-signing.test.js` (9 cases)
- [x] `backend/tests/initialize-commit-reveal.test.js` (4 cases)
- [ ] Full backend suite: `cd backend && npm test`
- [ ] Frontend E2E: `cd frontend && npm run test:e2e`
- [ ] Contract build: `cargo build` (see note below)

## Deployment notes

- Set `REQUEST_SIGNING_REQUIRED=true` in production after verifying Freighter `signMessage` support.
- Commit-reveal requires **new contract WASM** deploy before mainnet use.
- **Known blocker:** `cargo build` currently fails with Soroban `LengthExceedsMax` on `#[contractimpl]` (pre-existing spec size limit). Contract changes are included but WASM rebuild needs a follow-up fix.