### PR TITLE
test: proptest, snapshot tests, k6 load tests, backend integration suite (#408, #409, #410, #411)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "20.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "20.0.0", features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/backend/tests/contract-integration.test.js
+++ b/backend/tests/contract-integration.test.js
@@ -1,0 +1,327 @@
+/**
+ * Issue #411 — Backend contract integration test suite.
+ *
+ * Covers the full initialize → distribute → verify flow using mocked
+ * stellar.js and database/index.js dependencies, following the same ESM +
+ * jest.unstable_mockModule pattern used throughout this test suite.
+ *
+ * Scenarios:
+ *   1.  Full initialize flow — mocked contract call succeeds.
+ *   2.  Full distribute flow — XDR returned on success.
+ *   3.  Distribute validates contract initialization check.
+ *   4.  Distribute error on Stellar RPC failure.
+ *   5.  Distribute idempotency — same Idempotency-Key not re-processed.
+ *   6.  Initialize with invalid collaborators — mismatched arrays → 400.
+ *   7.  Contract state verified — distribute called after initialize.
+ *   8.  Distribute fails when contract not initialized (409 guard via initialize, not distribute).
+ *       Note: The distribute route does not itself check initialization; the
+ *       contract enforces that on-chain. The backend guard lives on the
+ *       initialize route (409 if already initialized). This test verifies
+ *       that the initialize guard fires correctly so the two endpoints
+ *       work in the right order.
+ */
+
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import request from "supertest";
+
+// ── Mocks — must be declared before any dynamic import of the routes ──────────
+
+const retryBuildTx        = jest.fn();
+const isContractInitialized = jest.fn();
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  retryBuildTx,
+  isContractInitialized,
+  addressToScVal:   jest.fn((a) => a),
+  u32ToScVal:       jest.fn((n) => n),
+  vecToScVal:       jest.fn((v) => v),
+  server:           {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+const recordTransaction = jest.fn(() => "tx-ci-001");
+const addAuditLog       = jest.fn();
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  recordTransaction,
+  addAuditLog,
+  initializeDatabase:  jest.fn(),
+  getMigrationVersion: jest.fn(() => 1),
+}));
+
+// Import the shared test app (mounts all routers) AFTER the mocks are in place.
+const { default: app } = await import("./app.js");
+
+// Import the idempotency cache-clear helper for teardown.
+const { clearCache } = await import("../src/idempotency.js");
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN    = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB1  = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB2  = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+const COLLAB3  = "GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+
+const validInitBody = {
+  contractId:    CONTRACT,
+  walletAddress: WALLET,
+  collaborators: [COLLAB1, COLLAB2],
+  shares:        [5000, 5000],
+};
+
+const validDistBody = {
+  contractId:    CONTRACT,
+  walletAddress: WALLET,
+  tokenId:       TOKEN,
+};
+
+// ── Suite setup ───────────────────────────────────────────────────────────────
+
+describe("Contract integration — initialize → distribute flow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearCache();
+  });
+
+  afterEach(() => {
+    clearCache();
+  });
+
+  // ── Scenario 1: Full initialize flow ───────────────────────────────────────
+
+  test("scenario 1 — initialize succeeds and returns xdr + transactionId", async () => {
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("init-xdr-payload");
+    recordTransaction.mockReturnValue("tx-init-001");
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send(validInitBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      xdr:           "init-xdr-payload",
+      transactionId: "tx-init-001",
+    });
+    expect(isContractInitialized).toHaveBeenCalledWith(CONTRACT);
+    expect(retryBuildTx).toHaveBeenCalledTimes(1);
+    expect(recordTransaction).toHaveBeenCalledTimes(1);
+    expect(addAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Scenario 2: Full distribute flow ───────────────────────────────────────
+
+  test("scenario 2 — distribute succeeds and returns xdr + transactionId", async () => {
+    retryBuildTx.mockResolvedValue("dist-xdr-payload");
+    recordTransaction.mockReturnValue("tx-dist-001");
+
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send(validDistBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      xdr:           "dist-xdr-payload",
+      transactionId: "tx-dist-001",
+    });
+    expect(retryBuildTx).toHaveBeenCalledTimes(1);
+    expect(recordTransaction).toHaveBeenCalledWith(
+      CONTRACT,
+      "distribute",
+      WALLET,
+      expect.objectContaining({ tokenId: TOKEN })
+    );
+  });
+
+  // ── Scenario 3: Distribute validates contract initialization check ──────────
+  // The distribute route itself does not call isContractInitialized — that
+  // check is on the initialize route (409 if already initialized). This
+  // scenario confirms that distribute proceeds regardless of initialization
+  // status and lets the smart contract enforce on-chain ordering.
+
+  test("scenario 3 — distribute does not call isContractInitialized", async () => {
+    retryBuildTx.mockResolvedValue("dist-xdr");
+    recordTransaction.mockReturnValue("tx-dist-002");
+
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send(validDistBody);
+
+    expect(res.status).toBe(200);
+    // distribute route must NOT check contract initialization state — that is
+    // the smart contract's responsibility, not the backend's.
+    expect(isContractInitialized).not.toHaveBeenCalled();
+  });
+
+  // ── Scenario 4: Distribute error on Stellar RPC failure ────────────────────
+
+  test("scenario 4 — 503 when Stellar RPC is unavailable during distribute", async () => {
+    retryBuildTx.mockRejectedValue({
+      status:  503,
+      message: "Stellar RPC is currently unavailable. Please try again later.",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/distribute")
+      .send(validDistBody);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/unavailable/i);
+    // Transaction must NOT be recorded on RPC failure.
+    expect(recordTransaction).not.toHaveBeenCalled();
+  });
+
+  // ── Scenario 5: Distribute idempotency ─────────────────────────────────────
+
+  test("scenario 5 — duplicate Idempotency-Key returns cached response without re-processing", async () => {
+    retryBuildTx.mockResolvedValue("dist-xdr-idempotent");
+    recordTransaction.mockReturnValue("tx-idem-001");
+
+    const KEY = "integration-idem-key-001";
+
+    // First request.
+    const res1 = await request(app)
+      .post("/api/v1/distribute")
+      .set("Idempotency-Key", KEY)
+      .send(validDistBody);
+
+    expect(res1.status).toBe(200);
+    expect(res1.body).toMatchObject({
+      xdr:           "dist-xdr-idempotent",
+      transactionId: "tx-idem-001",
+    });
+    expect(retryBuildTx).toHaveBeenCalledTimes(1);
+    expect(recordTransaction).toHaveBeenCalledTimes(1);
+
+    // Swap out mocks so we can detect if they are called again.
+    retryBuildTx.mockResolvedValue("dist-xdr-second-call");
+    recordTransaction.mockReturnValue("tx-idem-002");
+
+    // Second request with the same idempotency key.
+    const res2 = await request(app)
+      .post("/api/v1/distribute")
+      .set("Idempotency-Key", KEY)
+      .send(validDistBody);
+
+    expect(res2.status).toBe(200);
+    // Must return the FIRST response, not re-process.
+    expect(res2.body).toMatchObject({
+      xdr:           "dist-xdr-idempotent",
+      transactionId: "tx-idem-001",
+    });
+    // Should NOT have been called a second time.
+    expect(retryBuildTx).toHaveBeenCalledTimes(1);
+    expect(recordTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Scenario 6: Initialize with invalid collaborators ──────────────────────
+
+  test("scenario 6 — 400 when collaborators and shares arrays have mismatched lengths", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validInitBody,
+        collaborators: [COLLAB1, COLLAB2, COLLAB3],
+        shares:        [5000, 5000], // length mismatch
+      });
+
+    expect(res.status).toBe(400);
+    // Validation must short-circuit before any RPC call.
+    expect(isContractInitialized).not.toHaveBeenCalled();
+    expect(retryBuildTx).not.toHaveBeenCalled();
+  });
+
+  // ── Scenario 7: Contract state verified — distribute called after initialize
+
+  test("scenario 7 — full initialize then distribute flow records both transactions", async () => {
+    // Step 1: initialize.
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValueOnce("init-xdr");
+    recordTransaction.mockReturnValueOnce("tx-flow-init");
+
+    const initRes = await request(app)
+      .post("/api/v1/initialize")
+      .send(validInitBody);
+
+    expect(initRes.status).toBe(200);
+    expect(initRes.body.transactionId).toBe("tx-flow-init");
+
+    // Step 2: distribute (simulating post-init state).
+    retryBuildTx.mockResolvedValueOnce("dist-xdr");
+    recordTransaction.mockReturnValueOnce("tx-flow-dist");
+
+    const distRes = await request(app)
+      .post("/api/v1/distribute")
+      .send(validDistBody);
+
+    expect(distRes.status).toBe(200);
+    expect(distRes.body.transactionId).toBe("tx-flow-dist");
+
+    // Both endpoints recorded their transactions.
+    expect(recordTransaction).toHaveBeenCalledTimes(2);
+    // addAuditLog should have been called at least once (for initialize).
+    expect(addAuditLog).toHaveBeenCalled();
+  });
+
+  // ── Scenario 8: Distribute fails when contract not initialized ──────────────
+  // The backend's guard against double-initialization lives on the initialize
+  // route (409 Conflict). This test confirms that if initialize is called when
+  // the contract is ALREADY initialized, the backend blocks it and the
+  // distribute endpoint (which has no such guard) is never reached.
+
+  test("scenario 8 — 409 when initialize called on an already-initialized contract", async () => {
+    isContractInitialized.mockResolvedValue(true); // contract already initialized
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send(validInitBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already initialized/i);
+    // Must not proceed to build the transaction.
+    expect(retryBuildTx).not.toHaveBeenCalled();
+    expect(recordTransaction).not.toHaveBeenCalled();
+  });
+
+  // ── Bonus: Initialize audit log contains correct metadata ─────────────────
+
+  test("bonus — initialize audit log records collaborator count and shares", async () => {
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("init-xdr-audit");
+    recordTransaction.mockReturnValue("tx-audit-init");
+
+    await request(app)
+      .post("/api/v1/initialize")
+      .send(validInitBody);
+
+    expect(addAuditLog).toHaveBeenCalledWith(
+      CONTRACT,
+      "contract_initialized",
+      WALLET,
+      expect.objectContaining({
+        collaboratorCount: 2,
+        shares:            [5000, 5000],
+      })
+    );
+  });
+
+  // ── Bonus: Distribute audit log contains tokenId ──────────────────────────
+
+  test("bonus — distribute audit log records tokenId", async () => {
+    retryBuildTx.mockResolvedValue("dist-xdr-audit");
+    recordTransaction.mockReturnValue("tx-audit-dist");
+
+    await request(app)
+      .post("/api/v1/distribute")
+      .send(validDistBody);
+
+    expect(addAuditLog).toHaveBeenCalledWith(
+      CONTRACT,
+      "distribution_initiated",
+      WALLET,
+      expect.objectContaining({ transactionId: "tx-audit-dist" })
+    );
+  });
+});

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5221,3 +5221,304 @@ fn test_events_emitted_before_state_changes() {
     let events = env.events().all();
     assert!(events.len() > 0);
 }
+
+// ── Issue #410: Additional snapshot tests for storage state transitions ────────
+
+/// Issue #410 — After admin_transfer, PendingAdmin is set in instance storage.
+#[test]
+fn test_snapshot_pending_admin_set_after_admin_transfer() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    client.admin_transfer(&new_admin);
+
+    env.as_contract(&contract_id, || {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::PendingAdmin)
+            .expect("PendingAdmin should be set after admin_transfer");
+        assert_eq!(pending, new_admin);
+        // Admin must not have changed yet.
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("Admin should still be set");
+        assert_eq!(current_admin, admin);
+    });
+}
+
+/// Issue #410 — After accept_admin, Admin changes to new_admin and PendingAdmin is cleared.
+#[test]
+fn test_snapshot_admin_changes_and_pending_cleared_after_accept_admin() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    client.admin_transfer(&new_admin);
+    client.accept_admin();
+
+    env.as_contract(&contract_id, || {
+        // Admin must now be new_admin.
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("Admin should be stored after accept_admin");
+        assert_eq!(stored_admin, new_admin);
+        // PendingAdmin must be cleared.
+        assert!(
+            !env.storage().instance().has(&StorageKey::PendingAdmin),
+            "PendingAdmin should be cleared after accept_admin"
+        );
+    });
+}
+
+/// Issue #410 — After pause, Paused=true is stored in instance storage.
+#[test]
+fn test_snapshot_paused_true_after_pause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    client.pause();
+
+    env.as_contract(&contract_id, || {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .expect("Paused should be stored after pause");
+        assert!(paused, "Paused should be true after pause()");
+    });
+}
+
+/// Issue #410 — After unpause, Paused is false or cleared in instance storage.
+#[test]
+fn test_snapshot_paused_cleared_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    client.pause();
+    client.unpause();
+
+    env.as_contract(&contract_id, || {
+        // Either the key is absent, or the value is false.
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "Paused should be false or absent after unpause()");
+    });
+}
+
+/// Issue #410 — After set_royalty_rate, RoyaltyRate is stored and RoyaltyRateHistory is updated.
+#[test]
+fn test_snapshot_royalty_rate_stored_and_history_updated() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    let new_rate: u32 = 500;
+    client.set_royalty_rate(&new_rate);
+
+    env.as_contract(&contract_id, || {
+        let stored_rate: u32 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::RoyaltyRate)
+            .expect("RoyaltyRate should be stored after set_royalty_rate");
+        assert_eq!(stored_rate, new_rate);
+
+        // RoyaltyRateHistory in persistent storage must be non-empty.
+        let history_exists = env.storage().persistent().has(&StorageKey::RoyaltyRateHistory);
+        assert!(history_exists, "RoyaltyRateHistory should exist after set_royalty_rate");
+    });
+}
+
+/// Issue #410 — After two distributes, DistributeHistory counter equals 2.
+#[test]
+fn test_snapshot_distribute_history_has_both_records_after_two_distributes() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 5_000_u32, 5_000_u32],
+    );
+
+    mint(&env, &token, &contract_id, 10_000);
+    env.ledger().with_mut(|l| l.timestamp = 1_700_000_001);
+    client.distribute(&token);
+
+    mint(&env, &token, &contract_id, 20_000);
+    env.ledger().with_mut(|l| l.timestamp = 1_700_000_002);
+    client.distribute(&token);
+
+    env.as_contract(&contract_id, || {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::DistributeHistory)
+            .expect("DistributeHistory should be stored after two distributes");
+        assert_eq!(count, 2, "DistributeHistory should be 2 after two distributes");
+    });
+}
+
+/// Issue #410 — Collaborators count is exactly 3 after initialize with 3 collaborators.
+#[test]
+fn test_snapshot_collaborators_count_after_initialize_with_three() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, a.clone(), b.clone(), c.clone()],
+        &vec![&env, 4_000_u32, 3_000_u32, 3_000_u32],
+    );
+
+    env.as_contract(&contract_id, || {
+        let stored: SorobanVec<Address> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::Collaborators)
+            .expect("Collaborators should be stored");
+        assert_eq!(stored.len(), 3, "Collaborators count should be 3");
+    });
+}
+
+/// Issue #410 — ShareMap has exact values after initialize.
+#[test]
+fn test_snapshot_share_map_exact_values_after_initialize() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.initialize(
+        &vec![&env, a.clone(), b.clone(), c.clone()],
+        &vec![&env, 4_000_u32, 3_500_u32, 2_500_u32],
+    );
+
+    env.as_contract(&contract_id, || {
+        let stored: Map<Address, u32> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ShareMap)
+            .expect("ShareMap should be stored");
+        assert_eq!(stored.get(a).unwrap(), 4_000, "a's share should be 4000");
+        assert_eq!(stored.get(b).unwrap(), 3_500, "b's share should be 3500");
+        assert_eq!(stored.get(c).unwrap(), 2_500, "c's share should be 2500");
+    });
+}
+
+/// Issue #410 — ContractVersion is stored on initialize and matches VERSION constant.
+#[test]
+fn test_snapshot_contract_version_stored_on_initialize() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    client.initialize(
+        &vec![&env, admin.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    env.as_contract(&contract_id, || {
+        let stored_version: String = env
+            .storage()
+            .instance()
+            .get(&StorageKey::ContractVersion)
+            .expect("ContractVersion should be stored after initialize");
+        assert_eq!(
+            stored_version,
+            String::from_str(&env, VERSION),
+            "ContractVersion should match the VERSION constant"
+        );
+    });
+}
+
+/// Issue #410 — LastDistribution timestamp matches ledger timestamp after distribute.
+#[test]
+fn test_snapshot_last_distribution_timestamp_after_distribute() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let (contract_id, client) = setup(&env);
+
+    let admin = Address::generate(&env);
+    let b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = make_token(&env, &token_admin);
+
+    client.initialize(
+        &vec![&env, admin.clone(), b.clone()],
+        &vec![&env, 6_000_u32, 4_000_u32],
+    );
+
+    let expected_ts: u64 = 1_750_000_000;
+    mint(&env, &token, &contract_id, 50_000);
+    env.ledger().with_mut(|l| l.timestamp = expected_ts);
+    client.distribute(&token);
+
+    env.as_contract(&contract_id, || {
+        let last_ts: u64 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::LastDistribution)
+            .expect("LastDistribution should be stored after distribute");
+        assert_eq!(
+            last_ts, expected_ts,
+            "LastDistribution timestamp should equal ledger timestamp"
+        );
+    });
+}

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,83 @@
+# Load Tests — Stellar Royalty Splitter
+
+This directory contains [k6](https://k6.io) load-test scripts for the Node.js backend.
+
+## Prerequisites
+
+Install k6 (macOS / Linux):
+
+```bash
+# macOS (Homebrew)
+brew install k6
+
+# Linux (Debian/Ubuntu)
+sudo gpg --no-default-keyring \
+  --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] \
+  https://dl.k6.io/deb stable main" | \
+  sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+```
+
+See [k6 installation docs](https://k6.io/docs/get-started/installation/) for other platforms.
+
+## Running the distribute load test
+
+1. Start the backend server in a separate terminal:
+
+   ```bash
+   cd backend
+   npm start
+   # or: node src/index.js
+   ```
+
+2. Run the load test against `http://localhost:3000` (default):
+
+   ```bash
+   k6 run tests/load/distribute-load.js
+   ```
+
+3. Override the target URL:
+
+   ```bash
+   BASE_URL=http://localhost:4000 k6 run tests/load/distribute-load.js
+   ```
+
+4. Run against a staging environment:
+
+   ```bash
+   BASE_URL=https://api.staging.example.com \
+     k6 run tests/load/distribute-load.js
+   ```
+
+## Test parameters
+
+| Parameter  | Value   | Description                         |
+|------------|---------|-------------------------------------|
+| VUs        | 100     | Concurrent virtual users            |
+| Duration   | 30 s    | Total test duration                 |
+| p95 target | < 200ms | 95th-percentile response time limit |
+| p99 target | < 500ms | 99th-percentile response time limit |
+| Error rate | < 1%    | Maximum acceptable 5xx rate         |
+
+## Interpreting results
+
+k6 prints a summary table at the end of the run.  The test **passes** only when
+all configured thresholds are met (marked with `✓`).  Any `✗` indicates a
+threshold violation.
+
+Key metrics to watch:
+
+- `http_req_duration` — end-to-end request latency (p50, p90, p95, p99, max)
+- `http_req_failed` — fraction of requests that failed at the HTTP layer
+- `distribute_errors` — custom rate for 5xx responses from the distribute endpoint
+- `distribute_response_time` — custom trend mirror of `http_req_duration` for
+  the distribute endpoint specifically
+
+## Ramp scenario
+
+An alternative ramping configuration is included in `distribute-load.js` as a
+commented-out `options` block.  Uncomment it (and comment out the constant-VU
+block) to run a ramp-up / hold / ramp-down scenario instead.

--- a/tests/load/distribute-load.js
+++ b/tests/load/distribute-load.js
@@ -1,0 +1,161 @@
+/**
+ * Issue #409 — k6 load test for POST /api/v1/distribute
+ *
+ * Simulates 100 concurrent users sending distribute requests over 30 seconds.
+ * Passes only if:
+ *   - p95 response time < 200 ms
+ *   - p99 response time < 500 ms
+ *   - error rate < 1 %
+ *   - HTTP 200 rate > 99 %
+ *
+ * Run with:
+ *   k6 run tests/load/distribute-load.js
+ *
+ * Override the target URL at runtime:
+ *   BASE_URL=http://localhost:4000 k6 run tests/load/distribute-load.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+// ── Custom metrics ─────────────────────────────────────────────────────────────
+
+const errorRate = new Rate("distribute_errors");
+const p95Trend  = new Trend("distribute_response_time");
+
+// ── Test configuration ─────────────────────────────────────────────────────────
+
+export const options = {
+  // 100 virtual users for 30 seconds
+  vus: 100,
+  duration: "30s",
+
+  thresholds: {
+    // p95 must be under 200 ms
+    http_req_duration: ["p(95)<200", "p(99)<500"],
+    // Custom error rate must stay below 1 %
+    distribute_errors: ["rate<0.01"],
+    // At least 99 % of requests must return HTTP 200
+    http_req_failed: ["rate<0.01"],
+  },
+};
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+// Valid-shaped Stellar addresses (56-char base-32 encoded strings).
+// These do not resolve to real contracts; the backend builds unsigned XDR
+// without on-chain verification, so the addresses just need to pass
+// the format validation layer.
+const CONTRACT_ID  = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET_ADDR  = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN_IDS    = [
+  "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  "CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+  "CEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
+  "CFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+];
+
+const HEADERS = {
+  "Content-Type": "application/json",
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/**
+ * Pick a token from the pool using the VU number so each virtual user
+ * targets a slightly different token, distributing load more realistically.
+ */
+function pickToken() {
+  return TOKEN_IDS[(__VU - 1) % TOKEN_IDS.length];
+}
+
+/**
+ * Generate a simple idempotency key per VU + iteration so we don't
+ * accidentally trigger cached responses from the server's idempotency layer.
+ */
+function idempotencyKey() {
+  return `load-vu${__VU}-iter${__ITER}`;
+}
+
+// ── Main scenario ──────────────────────────────────────────────────────────────
+
+export default function distributeLoad() {
+  const url  = `${BASE_URL}/api/v1/distribute`;
+  const body = JSON.stringify({
+    contractId:    CONTRACT_ID,
+    walletAddress: WALLET_ADDR,
+    tokenId:       pickToken(),
+  });
+  const params = {
+    headers: {
+      ...HEADERS,
+      "Idempotency-Key": idempotencyKey(),
+    },
+    tags: { name: "distribute" },
+  };
+
+  const res = http.post(url, body, params);
+
+  // Record response time in custom trend.
+  p95Trend.add(res.timings.duration);
+
+  // Determine if this was an error (anything other than 200 or 400).
+  // 400 responses are valid test outcomes when validation fires; they are fast
+  // by design. Treat 5xx as errors for the rate threshold.
+  const isError = res.status >= 500;
+  errorRate.add(isError);
+
+  check(res, {
+    "status is 200 or 400": (r) => r.status === 200 || r.status === 400,
+    "response time < 500ms": (r) => r.timings.duration < 500,
+    "has JSON body": (r) => {
+      try {
+        JSON.parse(r.body);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  // Brief think-time between requests so we don't saturate the local loopback.
+  sleep(0.1);
+}
+
+// ── Setup / teardown hooks (optional smoke check) ─────────────────────────────
+
+export function setup() {
+  // Verify the server is reachable before the load run starts.
+  const healthUrl = `${BASE_URL}/api/v1/health`;
+  const res = http.get(healthUrl, { tags: { name: "health-check" } });
+  if (res.status !== 200) {
+    console.warn(
+      `[setup] Health check returned ${res.status}. ` +
+      `Server may not be ready — proceeding anyway.`
+    );
+  }
+}
+
+// ── Ramp scenario (alternative — uncomment to use instead of constant VUs) ────
+//
+// export const options = {
+//   scenarios: {
+//     distribute_ramp: {
+//       executor: "ramping-vus",
+//       startVUs: 0,
+//       stages: [
+//         { duration: "10s", target: 100 },  // ramp up to 100 VUs
+//         { duration: "20s", target: 100 },  // hold at 100 VUs
+//         { duration: "5s",  target: 0   },  // ramp down
+//       ],
+//     },
+//   },
+//   thresholds: {
+//     http_req_duration: ["p(95)<200", "p(99)<500"],
+//     distribute_errors: ["rate<0.01"],
+//     http_req_failed:   ["rate<0.01"],
+//   },
+// };

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -1,0 +1,732 @@
+//! Issue #408 — Property-based (proptest) fuzz tests for the royalty splitter contract.
+//!
+//! These tests use proptest to generate randomized inputs and verify invariants
+//! that must hold for ALL valid inputs:
+//!
+//!   1. Total distributed == amount sent in (no fund loss or creation).
+//!   2. Every recipient receives a non-negative payout.
+//!   3. Distributing 1 lamport with any single-recipient split always works.
+//!   4. Share values are stored correctly after initialize.
+//!   5. Large amounts up to i64::MAX / 2 do not overflow.
+//!
+//! Proptest generates the *data* (counts, amounts, share weights) and we create
+//! real Soroban environments and addresses inside each test body, because Soroban
+//! types are not `Arbitrary`.
+
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec as SorobanVec,
+};
+use stellar_royalty_splitter::RoyaltySplitterClient;
+
+// ── Shared helpers ─────────────────────────────────────────────────────────────
+
+fn prop_setup(env: &Env) -> (Address, RoyaltySplitterClient) {
+    let contract_id = env.register_contract(None, stellar_royalty_splitter::RoyaltySplitter);
+    let client = RoyaltySplitterClient::new(env, &contract_id);
+    (contract_id, client)
+}
+
+fn prop_make_token(env: &Env, admin: &Address) -> Address {
+    env.register_stellar_asset_contract(admin.clone())
+}
+
+fn prop_mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+/// Build a share list that sums exactly to 10_000.
+/// `weights` is a non-empty slice of positive u32 values; each is normalised so
+/// the proportional slice of 10_000 is returned.  The last element absorbs
+/// rounding remainders so the sum is always exactly 10_000.
+fn weights_to_shares(weights: &[u32]) -> std::vec::Vec<u32> {
+    assert!(!weights.is_empty());
+    let total_weight: u64 = weights.iter().map(|&w| w as u64).sum();
+    let mut shares: std::vec::Vec<u32> = std::vec::Vec::new();
+    let mut assigned: u32 = 0;
+    let n = weights.len();
+    for (i, &w) in weights.iter().enumerate() {
+        if i == n - 1 {
+            // Last element absorbs any rounding remainder.
+            shares.push(10_000 - assigned);
+        } else {
+            let share = ((w as u64 * 10_000) / total_weight) as u32;
+            let share = share.max(1); // at least 1 basis point
+            shares.push(share);
+            assigned += share;
+        }
+    }
+    // Guard against degenerate rounding producing a zero last element.
+    if let Some(last) = shares.last_mut() {
+        if *last == 0 {
+            *last = 1;
+            // Reclaim 1 from the largest share to keep the sum at 10_000.
+            if let Some(max) = shares[..n - 1].iter_mut().max() {
+                *max -= 1;
+            }
+        }
+    }
+    shares
+}
+
+// ── Strategies ─────────────────────────────────────────────────────────────────
+
+/// Strategy: 1–8 collaborators with random positive weight each.
+fn collaborator_weights_strategy() -> impl Strategy<Value = std::vec::Vec<u32>> {
+    (1usize..=8usize).prop_flat_map(|n| prop::collection::vec(1u32..=1000u32, n..=n))
+}
+
+// ── Core invariant tests ────────────────────────────────────────────────────────
+
+proptest! {
+    // ── #1  No-dust: all funds land with recipients ──────────────────────────
+    #[test]
+    fn prop_distribute_preserves_total(
+        weights in collaborator_weights_strategy(),
+        amount in 1i128..=1_000_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+
+        let mut addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs {
+            soroban_addrs.push_back(addr.clone());
+        }
+        for &s in &shares {
+            soroban_shares.push_back(s);
+        }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        prop_assert_eq!(
+            total_paid,
+            amount,
+            "Invariant violated: distributed={amount}, paid={total_paid}, n={n}"
+        );
+    }
+
+    // ── #2  All payouts are non-negative ─────────────────────────────────────
+    #[test]
+    fn prop_all_payouts_non_negative(
+        weights in collaborator_weights_strategy(),
+        amount in 1i128..=100_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        for addr in &addrs {
+            let bal = TokenClient::new(&env, &token).balance(addr);
+            prop_assert!(bal >= 0, "Negative payout to {:?}: {}", addr, bal);
+        }
+    }
+
+    // ── #3  Single recipient always receives everything ───────────────────────
+    #[test]
+    fn prop_single_recipient_receives_all(
+        amount in 1i128..=9_007_199_254_740_992i128, // up to i64::MAX / 2 for safety
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let recipient = Address::generate(&env);
+
+        let soroban_addrs = SorobanVec::from_array(&env, [recipient.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [10_000_u32]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let bal = TokenClient::new(&env, &token).balance(&recipient);
+        prop_assert_eq!(
+            bal, amount,
+            "Single recipient must receive everything: sent={amount}, got={bal}"
+        );
+    }
+
+    // ── #4  Equal split: both recipients receive floor(amount/2) or ceil ─────
+    #[test]
+    fn prop_equal_two_way_split(
+        amount in 2i128..=10_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [5_000_u32, 5_000_u32]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let bal_a = TokenClient::new(&env, &token).balance(&a);
+        let bal_b = TokenClient::new(&env, &token).balance(&b);
+        let total = bal_a + bal_b;
+
+        // Sum must equal amount (no dust lost or created).
+        prop_assert_eq!(total, amount, "50/50 split lost dust: sent={amount}, got={total}");
+        // Each share must be within 1 of the other (floor/ceil rounding is acceptable).
+        prop_assert!(
+            (bal_a - bal_b).abs() <= 1,
+            "50/50 split too uneven: a={bal_a}, b={bal_b}"
+        );
+    }
+
+    // ── #5  Share map stored correctly for any collaborator count ────────────
+    #[test]
+    fn prop_share_map_stored_correctly(
+        weights in collaborator_weights_strategy(),
+    ) {
+        use stellar_royalty_splitter::StorageKey;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+
+        env.as_contract(&contract_id, || {
+            let stored: soroban_sdk::Map<Address, u32> = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::ShareMap)
+                .expect("ShareMap should be set after initialize");
+
+            let stored_sum: u32 = addrs.iter().map(|addr| stored.get(addr.clone()).unwrap_or(0)).sum();
+            // In the test we only check what we set matches what we get back.
+            assert_eq!(stored.len() as usize, n);
+            assert_eq!(stored_sum, 10_000, "stored share sum must be 10_000");
+        });
+    }
+
+    // ── #6  Collaborators list stored correctly ───────────────────────────────
+    #[test]
+    fn prop_collaborators_stored_in_order(
+        n in 1usize..=8usize,
+    ) {
+        use stellar_royalty_splitter::StorageKey;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        // Build equal shares summing to 10_000.
+        let base = 10_000u32 / n as u32;
+        let remainder = 10_000u32 - base * n as u32;
+        let mut shares: std::vec::Vec<u32> = vec![base; n];
+        shares[n - 1] += remainder;
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+
+        env.as_contract(&contract_id, || {
+            let stored: SorobanVec<Address> = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::Collaborators)
+                .expect("Collaborators should be stored");
+
+            assert_eq!(stored.len() as usize, n);
+            for (i, addr) in addrs.iter().enumerate() {
+                assert_eq!(stored.get(i as u32).unwrap(), *addr);
+            }
+        });
+    }
+
+    // ── #7  1-lamport distribute works (minimum amount) ──────────────────────
+    #[test]
+    fn prop_minimum_amount_single_recipient(
+        n in 1usize..=8usize,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let base = 10_000u32 / n as u32;
+        let remainder = 10_000u32 - base * n as u32;
+        let mut shares: std::vec::Vec<u32> = vec![base; n];
+        shares[n - 1] += remainder;
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+        let amount = n as i128; // 1 per recipient so no recipient gets 0
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        prop_assert_eq!(total_paid, amount);
+    }
+
+    // ── #8  Large amount: i64::MAX / 4 does not overflow ─────────────────────
+    #[test]
+    fn prop_large_amount_no_overflow(
+        weights in collaborator_weights_strategy(),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+        // Use a large but safe amount: i64::MAX / 4 to stay well within i128 arithmetic.
+        let amount: i128 = i64::MAX as i128 / 4;
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        prop_assert_eq!(total_paid, amount, "Large-amount distribute lost dust");
+    }
+
+    // ── #9  Multiple sequential distributes accumulate balances correctly ─────
+    #[test]
+    fn prop_two_sequential_distributes_accumulate(
+        weights in collaborator_weights_strategy(),
+        amount1 in 1i128..=1_000_000_000i128,
+        amount2 in 1i128..=1_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+
+        prop_mint(&env, &token, &contract_id, amount1);
+        client.distribute(&token);
+
+        prop_mint(&env, &token, &contract_id, amount2);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        let total_sent = amount1 + amount2;
+        prop_assert_eq!(
+            total_paid,
+            total_sent,
+            "Two sequential distributes: sent={total_sent}, paid={total_paid}"
+        );
+    }
+
+    // ── #10  DistributeHistory counter increments correctly ──────────────────
+    #[test]
+    fn prop_distribute_history_count(
+        n_distributes in 1u32..=5u32,
+        amount in 1i128..=100_000_000i128,
+    ) {
+        use stellar_royalty_splitter::StorageKey;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [5_000_u32, 5_000_u32]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+
+        for _ in 0..n_distributes {
+            prop_mint(&env, &token, &contract_id, amount);
+            client.distribute(&token);
+        }
+
+        env.as_contract(&contract_id, || {
+            let count: u64 = env
+                .storage()
+                .instance()
+                .get(&StorageKey::DistributeHistory)
+                .expect("DistributeHistory should be stored");
+            assert_eq!(count, n_distributes as u64);
+        });
+    }
+
+    // ── #11  Weighted 80/20 split preserves total ─────────────────────────────
+    #[test]
+    fn prop_weighted_split_preserves_total(
+        amount in 100i128..=10_000_000_000i128,
+        // major_share: 5000..9000 out of 10000 for the first recipient
+        major_share in 5000u32..=9000u32,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let minor_share = 10_000 - major_share;
+
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [major_share, minor_share]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let bal_a = TokenClient::new(&env, &token).balance(&a);
+        let bal_b = TokenClient::new(&env, &token).balance(&b);
+        let total = bal_a + bal_b;
+
+        prop_assert_eq!(total, amount, "Weighted split lost dust: sent={amount}, got={total}");
+        // Major share recipient must receive strictly more.
+        prop_assert!(
+            bal_a >= bal_b,
+            "Major share ({major_share}) recipient should receive at least as much as minor ({minor_share})"
+        );
+    }
+
+    // ── #12  Max collaborators (8) with varying amounts ───────────────────────
+    #[test]
+    fn prop_max_collaborators(
+        amount in 8i128..=1_000_000_000_000i128,
+        // 7 weights; 8th is computed to sum to 10_000
+        w in prop::collection::vec(1u32..=200u32, 7..=7),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&w);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        prop_assert_eq!(total_paid, amount);
+    }
+
+    // ── #13  Royalty rate does not affect primary distribute total ────────────
+    #[test]
+    fn prop_royalty_rate_does_not_affect_primary_distribute(
+        weights in collaborator_weights_strategy(),
+        amount in 1i128..=1_000_000_000i128,
+        rate in 0u32..=9999u32,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        client.set_royalty_rate(&rate);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        // The royalty rate applies to *secondary* pools; the primary distribute
+        // should still pay out everything to collaborators.
+        prop_assert_eq!(
+            total_paid,
+            amount,
+            "Setting royalty rate changed primary distribute payout: rate={rate}, sent={amount}, got={total_paid}"
+        );
+    }
+
+    // ── #14  LastDistribution timestamp is always updated after distribute ────
+    #[test]
+    fn prop_last_distribution_timestamp_updated(
+        ts in 1_000_000_u64..=10_000_000_000_u64,
+        amount in 1i128..=1_000_000_000i128,
+    ) {
+        use stellar_royalty_splitter::StorageKey;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [5_000_u32, 5_000_u32]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        env.ledger().with_mut(|l| l.timestamp = ts);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        env.as_contract(&contract_id, || {
+            let last_ts: u64 = env
+                .storage()
+                .instance()
+                .get(&StorageKey::LastDistribution)
+                .expect("LastDistribution must be set after distribute");
+            assert_eq!(last_ts, ts);
+        });
+    }
+
+    // ── #15  Extreme upper-bound amount: 10^14 stroops (100 billion XLM) ─────
+    #[test]
+    fn prop_extreme_upper_bound_amount(
+        weights in collaborator_weights_strategy(),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+        let amount: i128 = 100_000_000_000_000_i128; // 10^14 stroops
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let total_paid: i128 = addrs
+            .iter()
+            .map(|addr| TokenClient::new(&env, &token).balance(addr))
+            .sum();
+
+        prop_assert_eq!(total_paid, amount, "Extreme-amount distribute lost dust");
+    }
+
+    // ── #16  Three-way 1/3 split never loses more than n-1 stroops ───────────
+    #[test]
+    fn prop_three_way_split_minimal_dust_loss(
+        amount in 3i128..=10_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let c = Address::generate(&env);
+        // 3334 + 3333 + 3333 = 10000
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone(), c.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [3_334_u32, 3_333_u32, 3_333_u32]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let bal_a = TokenClient::new(&env, &token).balance(&a);
+        let bal_b = TokenClient::new(&env, &token).balance(&b);
+        let bal_c = TokenClient::new(&env, &token).balance(&c);
+        let total = bal_a + bal_b + bal_c;
+
+        // All funds accounted for (no dust lost).
+        prop_assert_eq!(total, amount, "3-way split: sent={amount}, got={total}");
+    }
+
+    // ── #17  Distribute with amount = 10_000 gives each 1/10000-share exactly 1
+    #[test]
+    fn prop_amount_equals_denominator(
+        major_share in 1u32..=9999u32,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let minor_share = 10_000 - major_share;
+        let soroban_addrs = SorobanVec::from_array(&env, [a.clone(), b.clone()]);
+        let soroban_shares = SorobanVec::from_array(&env, [major_share, minor_share]);
+
+        let token_admin = Address::generate(&env);
+        let token = prop_make_token(&env, &token_admin);
+
+        // Distribute exactly 10_000 stroops so each basis point = 1 stroop.
+        let amount: i128 = 10_000;
+        client.initialize(&soroban_addrs, &soroban_shares);
+        prop_mint(&env, &token, &contract_id, amount);
+        client.distribute(&token);
+
+        let bal_a = TokenClient::new(&env, &token).balance(&a);
+        let bal_b = TokenClient::new(&env, &token).balance(&b);
+
+        prop_assert_eq!(bal_a, major_share as i128);
+        prop_assert_eq!(bal_b, minor_share as i128);
+    }
+
+    // ── #18  Share sum invariant: stored shares always sum to 10_000 ──────────
+    #[test]
+    fn prop_stored_shares_always_sum_to_10000(
+        weights in collaborator_weights_strategy(),
+    ) {
+        use stellar_royalty_splitter::StorageKey;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let (contract_id, client) = prop_setup(&env);
+
+        let shares = weights_to_shares(&weights);
+        let n = shares.len();
+        let addrs: std::vec::Vec<Address> = (0..n).map(|_| Address::generate(&env)).collect();
+
+        let mut soroban_addrs: SorobanVec<Address> = SorobanVec::new(&env);
+        let mut soroban_shares: SorobanVec<u32> = SorobanVec::new(&env);
+        for addr in &addrs { soroban_addrs.push_back(addr.clone()); }
+        for &s in &shares { soroban_shares.push_back(s); }
+
+        client.initialize(&soroban_addrs, &soroban_shares);
+
+        env.as_contract(&contract_id, || {
+            let stored_map: soroban_sdk::Map<Address, u32> = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::ShareMap)
+                .expect("ShareMap must be stored");
+            let sum: u32 = addrs.iter().map(|addr| stored_map.get(addr.clone()).unwrap_or(0)).sum();
+            assert_eq!(sum, 10_000, "Stored shares must sum to 10_000, got {sum}");
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Four assigned testing issues resolved in a single batch:
- **#408**: Add the `proptest` framework for property-based contract tests
- **#409**: Add k6 load testing script for the distribute endpoint
- **#410**: Add 10+ storage snapshot tests covering more state transitions
- **#411**: Add backend+contract integration test suite (10 scenarios)

closes #408
closes #409
closes #410
closes #411

## Changes

- **#408 — `test(contract): add proptest property-based tests`**: Added `proptest = "1"` to `[dev-dependencies]` in `Cargo.toml`. Created `tests/property_tests.rs` with 18 property-based tests driven by the `proptest!` macro: no-dust invariant (sum of all payouts = amount sent), non-negative payouts, single-recipient totals, 50/50 split tolerance, share map storage verification, collaborator ordering, 1-lamport minimum, large-amount no-overflow (i64::MAX/4), sequential distribute accumulation, DistributeHistory counter, 80/20 weighted splits, max-8 collaborators, royalty-rate isolation, timestamp update, extreme 10^14 amounts, 3-way split, amount-equals-denominator edge case, and stored-shares-sum invariant. `weights_to_shares()` normalizes arbitrary weight vectors to exact 10,000 so every generated scenario is valid.

- **#409 — `test(load): add k6 load testing script`**: Created `tests/load/distribute-load.js` (100 VUs, 30s, p95<200ms / p99<500ms thresholds, custom Trend/Rate metrics, health-check setup hook, 4-token round-robin) and `tests/load/README.md` with install instructions, run commands, and metric reference.

- **#410 — `test(contract): add 10 storage snapshot tests`**: Appended 10 snapshot tests to `tests/integration_test.rs` using the existing `env.as_contract` / `env.storage().instance().get()` pattern: admin_transfer sets PendingAdmin; accept_admin changes Admin + clears PendingAdmin; pause stores Paused=true; unpause clears Paused; set_royalty_rate stores rate + history entry; two distributes produce two DistributeHistory records; 3-collaborator count check; exact ShareMap values; ContractVersion on initialize; LastDistribution timestamp after distribute.

- **#411 — `test(backend): add backend+contract integration test suite`**: Created `backend/tests/contract-integration.test.js` with 10 integration scenarios using `jest.unstable_mockModule` ESM mocks — same pattern as existing test files. Covers: full initialize and distribute flows, Stellar RPC failure (503), idempotency (duplicate key), mismatched collaborators/shares (400), sequential initialize→distribute transaction recording, already-initialized conflict (409), and audit-log content checks.

## Test plan

- **Proptest** (Rust): `cargo test --test property_tests -- --test-threads=1`
- **Snapshot tests** (Rust): `cargo test --test integration_test test_snapshot_`
- **Load test** (k6): `k6 run tests/load/distribute-load.js --env BASE_URL=http://localhost:3001` (see `tests/load/README.md`)
- **Backend integration** (Jest): `cd backend && npm test -- contract-integration`

> Not built/tested locally against the live contract; relying on CI for full validation.

---

_Note: this contribution was authored with AI assistance (Claude Code)._

Co-Authored-By: Claude <noreply@anthropic.com>