### PR TITLE
test: add integration tests for initialize endpoint edge cases

### DIFF
--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -16,6 +16,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   addressToScVal: jest.fn((a) => a),
   u32ToScVal: jest.fn((n) => n),
   vecToScVal: jest.fn((v) => v),
+  bytesN32HexToScVal: jest.fn((h) => h),
   server: {},
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
@@ -132,6 +133,75 @@ describe("POST /api/v1/initialize", () => {
     const res = await request(app).post("/api/v1/initialize").send({ contractId: CONTRACT });
 
     expect(res.status).toBe(400);
+  });
+
+  test("happy path with 1 collaborator (minimum) — returns xdr and transactionId", async () => {
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("unsigned-xdr-string");
+    recordTransaction.mockReturnValue("tx-123");
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validBody,
+        collaborators: [COLLAB1],
+        shares: [10000],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ xdr: "unsigned-xdr-string", transactionId: "tx-123" });
+  });
+
+  test("happy path with 20 collaborators (maximum) — returns xdr and transactionId", async () => {
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("unsigned-xdr-string");
+    recordTransaction.mockReturnValue("tx-123");
+
+    const collaborators = Array.from({ length: 20 }, (_, i) => {
+      const char = String.fromCharCode(65 + (i % 26));
+      return `G${char.repeat(55)}`;
+    });
+    const shares = Array.from({ length: 20 }, () => 500);
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validBody,
+        collaborators,
+        shares,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ xdr: "unsigned-xdr-string", transactionId: "tx-123" });
+  });
+
+  test("400 when collaborators array contains invalid addresses", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validBody,
+        collaborators: [COLLAB1, "invalid-stellar-address"],
+        shares: [5000, 5000],
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  test("duplicate addresses in collaborators — succeeds at API validation layer", async () => {
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("unsigned-xdr-string");
+    recordTransaction.mockReturnValue("tx-123");
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({
+        ...validBody,
+        collaborators: [COLLAB1, COLLAB1],
+        shares: [5000, 5000],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ xdr: "unsigned-xdr-string", transactionId: "tx-123" });
   });
 
   test("413 when initialize request body is too large", async () => {


### PR DESCRIPTION
closes #362 

#### Description
This pull request introduces comprehensive integration tests for the initialize endpoint (`POST /api/v1/initialize`) covering all requested edge cases, boundary conditions, and error scenarios.

Additionally, this PR fixes a syntax error when running the tests by ensuring the mock of `../src/stellar.js` includes the `bytesN32HexToScVal` helper function, which was added to the initialize route under the commit-reveal enhancement.

#### Scope of Work
- **1 Collaborator (Minimum):** Added a happy path test confirming that initializing with exactly 1 collaborator and 10,000 shares works correctly and returns 200 (XDR and transaction ID).
- **20 Collaborators (Maximum):** Added a happy path test confirming that initializing with exactly 20 collaborators and 500 shares each (summing to 10,000 basis points) works correctly and returns 200.
- **Shares sum validation (9999 / 10001):** Verified that the schema correctly rejects sums of 9999 and 10001 basis points, returning a 400 error.
- **Duplicate Addresses:** Added a test checking that duplicate collaborator addresses are permitted at the API validation layer, since uniqueness constraints are handled on-chain and not at the API router level.
- **Invalid Addresses:** Added a test confirming that providing malformed Stellar addresses (not matching the `G...` format) rejects the request with a 400 validation error.

#### Verification
All `initialize` tests pass successfully:
