### PR TITLE
feat: transaction confirmation polling with WebSocket fallback

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -123,8 +123,8 @@ async function post<T>(
   });
 }
 
-async function get<T>(path: string): Promise<T> {
-  return request<T>(path);
+async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
+  return request<T>(path, signal ? { signal } : undefined);
 }
 
 export interface TransactionRecord {
@@ -249,9 +249,10 @@ export const api = {
       pagination: { limit: number; offset: number; total: number };
     }>(`/history/${contractId}?limit=${limit}&offset=${offset}`),
 
-  getTransactionDetails: (txHash: string) =>
+  getTransactionDetails: (txHash: string, signal?: AbortSignal) =>
     get<{ success: boolean; data: TransactionDetails }>(
       `/transaction/${txHash}`,
+      signal,
     ),
 
   confirmTransaction: (

--- a/frontend/src/components/DistributeForm.test.tsx
+++ b/frontend/src/components/DistributeForm.test.tsx
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import DistributeForm from "./DistributeForm";
+import { TransactionProvider } from "../context/TransactionContext";
 import { api } from "../api";
+
+// DistributeForm reads transaction phase from TransactionContext, so every
+// render needs the provider.
+function renderForm(ui: ReactElement) {
+  return render(<TransactionProvider>{ui}</TransactionProvider>);
+}
 
 vi.mock("../context/NetworkContext", () => ({
   useNetwork: () => ({
@@ -16,6 +24,9 @@ vi.mock("../api", () => ({
     getContractBalance: vi.fn().mockResolvedValue({ balance: "0" }),
     distribute: vi.fn().mockResolvedValue({ xdr: "dummy-xdr", transactionId: 1 }),
     confirmTransaction: vi.fn().mockResolvedValue({ success: true, message: "ok" }),
+    getTransactionDetails: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: { status: "confirmed" } }),
   },
 }));
 
@@ -39,7 +50,7 @@ describe("DistributeForm", () => {
       JSON.stringify({ tokenId: "C" + "A".repeat(55), amount: "15" }),
     );
 
-    render(
+    renderForm(
       <DistributeForm contractId="test-contract" walletAddress="test-wallet" onSuccess={vi.fn()} />,
     );
 
@@ -55,7 +66,7 @@ describe("DistributeForm", () => {
 
     (api.getCollaborators as unknown as vi.Mock).mockResolvedValue(mockCollaborators);
 
-    render(
+    renderForm(
       <DistributeForm contractId="test-contract" walletAddress="test-wallet" onSuccess={vi.fn()} />,
     );
 
@@ -74,7 +85,7 @@ describe("DistributeForm", () => {
   });
 
   test("shows a contract-address validation error when the token address is malformed", async () => {
-    render(
+    renderForm(
       <DistributeForm contractId="test-contract" walletAddress="test-wallet" onSuccess={vi.fn()} />,
     );
 
@@ -89,7 +100,7 @@ describe("DistributeForm", () => {
     (api.getCollaborators as unknown as vi.Mock).mockResolvedValue([]);
     (api.getContractBalance as unknown as vi.Mock).mockResolvedValue({ balance: "5" });
 
-    render(
+    renderForm(
       <DistributeForm contractId="test-contract" walletAddress="test-wallet" onSuccess={vi.fn()} />,
     );
 
@@ -106,5 +117,36 @@ describe("DistributeForm", () => {
     );
     expect(await screen.findByText(/Amount exceeds available balance/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Distribute funds/i })).toBeDisabled();
+  });
+
+  test("polls for confirmation after submit and reports success (#414)", async () => {
+    (api.getContractBalance as unknown as vi.Mock).mockResolvedValue({ balance: "100" });
+    // The first poll already reports confirmed (the 5s loop itself is covered
+    // by transactionPolling.test.ts), so this stays fast and deterministic.
+    (api.getTransactionDetails as unknown as vi.Mock).mockResolvedValue({
+      success: true,
+      data: { status: "confirmed" },
+    });
+    const onSuccess = vi.fn();
+
+    renderForm(
+      <DistributeForm contractId="test-contract" walletAddress="test-wallet" onSuccess={onSuccess} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Token contract address/i), {
+      target: { value: "C" + "A".repeat(55) },
+    });
+    await waitFor(() => expect(api.getContractBalance).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText(/Amount/i), { target: { value: "10" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Distribute funds/i }));
+
+    // Settlement is kicked off and polling drives the confirmed state.
+    await waitFor(() => expect(api.confirmTransaction).toHaveBeenCalled());
+    await waitFor(() => expect(api.getTransactionDetails).toHaveBeenCalled(), {
+      timeout: 8000,
+    });
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled(), { timeout: 8000 });
+    expect(await screen.findByText(/Distributed successfully/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -4,6 +4,7 @@ import { getContractAddressError, isValidContractAddress } from "../lib/stellar-
 import { signAndSubmitTransaction } from "../stellar";
 import { useNetwork } from "../context/NetworkContext";
 import { useTransaction, useIsTransactionInFlight } from "../context/TransactionContext";
+import { useTransactionPolling } from "../hooks/useTransactionPolling";
 import FormStatus from "./FormStatus";
 import TransactionStatusBadge from "./TransactionStatusBadge";
 import { useFormStatus } from "../hooks/useFormStatus";
@@ -60,6 +61,8 @@ export default function DistributeForm({
   const { network } = useNetwork();
   const { current: txEntry, beginTransaction, updatePhase, reset: resetTx } = useTransaction();
   const isInFlight = useIsTransactionInFlight();
+  // #414: real-time confirmation polling (5s interval, 60s timeout, aborts on unmount).
+  const { poll: pollTransaction } = useTransactionPolling();
 
   const [tokenId, setTokenId] = useState("");
   const [amount, setAmount] = useState("");
@@ -208,23 +211,53 @@ export default function DistributeForm({
 
       const hash = await signAndSubmitTransaction(res.xdr, network);
 
-      // #391: Phase 3 — confirming, with countdown
+      // #391/#414: Phase 3 — confirming, with countdown + real-time polling.
       updatePhase("confirming", { txHash: hash });
 
-      await api.confirmTransaction(hash, {
-        status: "confirmed",
-        blockTime: new Date().toISOString(),
-        transactionId: res.transactionId,
-      });
+      // Kick off server-side settlement (Horizon polling + webhooks). We don't
+      // block on it — the polling loop below reflects status in real time and
+      // enforces the 60s client-side timeout independently.
+      void api
+        .confirmTransaction(hash, {
+          status: "confirmed",
+          blockTime: new Date().toISOString(),
+          transactionId: res.transactionId,
+        })
+        .catch(() => {
+          // Settlement errors surface through the polled status / timeout.
+        });
 
-      // #391: Phase 4 — confirmed
-      updatePhase("confirmed");
+      // #414: poll GET /transaction/:hash every 5s until terminal or 60s.
+      const outcome = await pollTransaction(hash);
 
-      setStatus("ok", "Distributed successfully.");
-      localStorage.removeItem(draftKey);
-      setTokenId("");
-      setAmount("");
-      onSuccess();
+      // Component unmounted mid-poll — nothing to update.
+      if (outcome === "aborted") return;
+
+      if (outcome === "confirmed") {
+        // #391: Phase 4 — confirmed
+        updatePhase("confirmed");
+        setStatus("ok", "Distributed successfully.");
+        localStorage.removeItem(draftKey);
+        setTokenId("");
+        setAmount("");
+        onSuccess();
+        return;
+      }
+
+      if (outcome === "timeout") {
+        updatePhase("timeout", {
+          error: "Confirmation timed out. The transaction may still settle.",
+        });
+        setStatus(
+          "error",
+          "Confirmation timed out. Check the transaction status shortly.",
+        );
+        return;
+      }
+
+      // outcome === "failed"
+      updatePhase("failed", { error: "Transaction failed to confirm." });
+      setStatus("error", "Transaction failed to confirm.");
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Unknown error";
       const isTimeout =

--- a/frontend/src/hooks/useTransactionPolling.test.tsx
+++ b/frontend/src/hooks/useTransactionPolling.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTransactionPolling } from "./useTransactionPolling";
+import { api } from "../api";
+
+vi.mock("../api", () => ({
+  api: { getTransactionDetails: vi.fn() },
+}));
+
+const mockedGet = api.getTransactionDetails as unknown as ReturnType<typeof vi.fn>;
+
+describe("useTransactionPolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("polls the status endpoint until confirmed and reports the outcome", async () => {
+    mockedGet
+      .mockResolvedValueOnce({ data: { status: "pending" } })
+      .mockResolvedValueOnce({ data: { status: "confirmed" } });
+
+    const { result } = renderHook(() => useTransactionPolling());
+
+    let outcome: string | undefined;
+    await act(async () => {
+      const run = result.current.poll("abc123");
+      await vi.advanceTimersByTimeAsync(5_000);
+      outcome = await run;
+    });
+
+    expect(outcome).toBe("confirmed");
+    expect(result.current.outcome).toBe("confirmed");
+    expect(result.current.status).toBe("confirmed");
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+    expect(mockedGet).toHaveBeenLastCalledWith("abc123", expect.any(AbortSignal));
+  });
+
+  test("aborts in-flight polling on unmount", async () => {
+    mockedGet.mockResolvedValue({ data: { status: "pending" } });
+
+    const { result, unmount } = renderHook(() => useTransactionPolling());
+
+    let run: Promise<string> | undefined;
+    await act(async () => {
+      run = result.current.poll("abc123") as Promise<string>;
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    const callsBeforeUnmount = mockedGet.mock.calls.length;
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    await expect(run).resolves.toBe("aborted");
+    // No further polls after the component unmounted.
+    expect(mockedGet.mock.calls.length).toBe(callsBeforeUnmount);
+  });
+});

--- a/frontend/src/hooks/useTransactionPolling.ts
+++ b/frontend/src/hooks/useTransactionPolling.ts
@@ -1,0 +1,114 @@
+/**
+ * useTransactionPolling (#414)
+ *
+ * React wrapper around {@link pollTransactionStatus} that drives real-time
+ * transaction confirmation in the UI. It owns an AbortController so polling is
+ * cancelled automatically on unmount, exposes the latest observed status for
+ * rendering, and optionally races a WebSocket subscription as a faster
+ * fallback when a socket URL is configured.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import {
+  pollTransactionStatus,
+  type PollOutcome,
+  type PolledStatus,
+  type TxStatus,
+} from "../lib/transactionPolling";
+import { subscribeTransactionStatus } from "../lib/transactionStatusSocket";
+
+export interface UseTransactionPollingOptions {
+  /** Optional ws(s):// endpoint enabling the real-time fallback. */
+  wsUrl?: string;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface UseTransactionPollingResult {
+  /** Most recent status observed, or null before polling starts. */
+  status: PolledStatus | null;
+  /** Terminal outcome of the last run, or null while in flight. */
+  outcome: PollOutcome | null;
+  isPolling: boolean;
+  /** Begin polling a transaction hash; resolves with the terminal outcome. */
+  poll: (txHash: string) => Promise<PollOutcome>;
+  /** Abort any in-flight polling. */
+  cancel: () => void;
+}
+
+export function useTransactionPolling(
+  options: UseTransactionPollingOptions = {},
+): UseTransactionPollingResult {
+  const { wsUrl, intervalMs, timeoutMs } = options;
+  const controllerRef = useRef<AbortController | null>(null);
+  const [status, setStatus] = useState<PolledStatus | null>(null);
+  const [outcome, setOutcome] = useState<PollOutcome | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+
+  const cancel = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+  }, []);
+
+  // Cancel polling if the component unmounts mid-flight.
+  useEffect(() => cancel, [cancel]);
+
+  const poll = useCallback(
+    async (txHash: string): Promise<PollOutcome> => {
+      // Supersede any previous run.
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      setStatus(null);
+      setOutcome(null);
+      setIsPolling(true);
+
+      const applyStatus = (next: PolledStatus) => setStatus(next);
+
+      const pollRun = pollTransactionStatus({
+        fetchStatus: async (signal) => {
+          const res = await api.getTransactionDetails(txHash, signal);
+          return res.data.status as TxStatus;
+        },
+        signal: controller.signal,
+        intervalMs,
+        timeoutMs,
+        onUpdate: applyStatus,
+      });
+
+      const runners: Array<Promise<PollOutcome>> = [pollRun];
+
+      // Optional WebSocket fallback: resolve early on a terminal push.
+      if (wsUrl) {
+        runners.push(
+          subscribeTransactionStatus({
+            url: wsUrl,
+            txHash,
+            signal: controller.signal,
+            onStatus: applyStatus,
+          })
+            // The socket only resolves on a terminal status.
+            .then((s): PollOutcome => (s === "failed" ? "failed" : "confirmed"))
+            // If the socket fails, let polling decide the outcome.
+            .catch(() => pollRun),
+        );
+      }
+
+      try {
+        const result = await Promise.race(runners);
+        setOutcome(result);
+        return result;
+      } finally {
+        setIsPolling(false);
+        if (controllerRef.current === controller) {
+          controller.abort(); // stop the loser of the race
+          controllerRef.current = null;
+        }
+      }
+    },
+    [wsUrl, intervalMs, timeoutMs],
+  );
+
+  return { status, outcome, isPolling, poll, cancel };
+}

--- a/frontend/src/lib/transactionPolling.test.ts
+++ b/frontend/src/lib/transactionPolling.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  pollTransactionStatus,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_POLL_TIMEOUT_MS,
+} from "./transactionPolling";
+
+describe("pollTransactionStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("resolves 'confirmed' once the status confirms and stops polling", async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockResolvedValueOnce("pending")
+      .mockResolvedValueOnce("pending")
+      .mockResolvedValueOnce("confirmed");
+    const onUpdate = vi.fn();
+
+    const run = pollTransactionStatus({ fetchStatus, onUpdate });
+    // Two 5s intervals separate the three reads.
+    await vi.advanceTimersByTimeAsync(2 * DEFAULT_POLL_INTERVAL_MS);
+
+    await expect(run).resolves.toBe("confirmed");
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+    // No further polling after confirmation.
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL_MS);
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+    expect(onUpdate).toHaveBeenLastCalledWith("confirmed");
+  });
+
+  test("resolves 'failed' when the backend reports a failed transaction", async () => {
+    const fetchStatus = vi.fn().mockResolvedValue("failed");
+
+    const run = pollTransactionStatus({ fetchStatus });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(run).resolves.toBe("failed");
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+  });
+
+  test("resolves 'timeout' after 60s when the status stays pending", async () => {
+    const fetchStatus = vi.fn().mockResolvedValue("pending");
+
+    const run = pollTransactionStatus({ fetchStatus });
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_TIMEOUT_MS);
+
+    await expect(run).resolves.toBe("timeout");
+    // ~12 polls over 60s at a 5s interval; never indefinitely.
+    expect(fetchStatus.mock.calls.length).toBeLessThanOrEqual(
+      DEFAULT_POLL_TIMEOUT_MS / DEFAULT_POLL_INTERVAL_MS + 1,
+    );
+  });
+
+  test("stops polling when the signal is aborted", async () => {
+    const controller = new AbortController();
+    const fetchStatus = vi.fn().mockResolvedValue("pending");
+
+    const run = pollTransactionStatus({
+      fetchStatus,
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL_MS);
+    const callsBeforeAbort = fetchStatus.mock.calls.length;
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(3 * DEFAULT_POLL_INTERVAL_MS);
+
+    await expect(run).resolves.toBe("aborted");
+    // No additional polls fire after abort.
+    expect(fetchStatus.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
+  test("applies exponential backoff after failures, then recovers", async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce("confirmed");
+    const onError = vi.fn();
+
+    const run = pollTransactionStatus({ fetchStatus, onError });
+
+    // First read is immediate and fails.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    // Backoff after one failure is 5s (interval * 2^0); only then the 2nd read.
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL_MS);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenLastCalledWith(expect.any(Error), 2);
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+
+    // Backoff after two failures is 10s (interval * 2^1) before the 3rd read.
+    await vi.advanceTimersByTimeAsync(2 * DEFAULT_POLL_INTERVAL_MS);
+
+    await expect(run).resolves.toBe("confirmed");
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+  });
+
+  test("keeps polling on 'not_found' until the row is written", async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockResolvedValueOnce("not_found")
+      .mockResolvedValueOnce("confirmed");
+    const onUpdate = vi.fn();
+
+    const run = pollTransactionStatus({ fetchStatus, onUpdate });
+    await vi.advanceTimersByTimeAsync(DEFAULT_POLL_INTERVAL_MS);
+
+    await expect(run).resolves.toBe("confirmed");
+    expect(onUpdate).toHaveBeenNthCalledWith(1, "not_found");
+    expect(onUpdate).toHaveBeenNthCalledWith(2, "confirmed");
+  });
+});

--- a/frontend/src/lib/transactionPolling.ts
+++ b/frontend/src/lib/transactionPolling.ts
@@ -1,0 +1,129 @@
+/**
+ * Transaction confirmation polling (#414)
+ *
+ * A framework-agnostic loop that polls a backend transaction-status endpoint
+ * until the transaction settles (confirmed / failed), the caller aborts, or a
+ * timeout is reached. Kept free of React so it can be unit-tested with fake
+ * timers and reused by the WebSocket fallback.
+ *
+ * Behaviour required by the issue:
+ * - Poll every 5s by default.
+ * - Stop on confirmation or after a 60s timeout.
+ * - Cancel cleanly via an AbortSignal (the hook aborts on unmount).
+ * - Exponential backoff after consecutive failures so a flaky backend is not
+ *   hammered with retries.
+ */
+
+/** Status values the backend reports for a transaction. */
+export type TxStatus = "pending" | "confirmed" | "failed";
+
+/** A status read may also come back as "not_found" before the row is written. */
+export type PolledStatus = TxStatus | "not_found";
+
+/** Terminal result of a polling run. */
+export type PollOutcome = "confirmed" | "failed" | "timeout" | "aborted";
+
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+export const DEFAULT_POLL_TIMEOUT_MS = 60_000;
+export const DEFAULT_MAX_BACKOFF_MS = 30_000;
+
+export interface PollTransactionStatusOptions {
+  /** Reads the current status. Receives a signal so the request can be aborted. */
+  fetchStatus: (signal: AbortSignal) => Promise<PolledStatus>;
+  /** Aborts the run (e.g. component unmount). */
+  signal?: AbortSignal;
+  /** Base interval between polls. Default 5000ms. */
+  intervalMs?: number;
+  /** Maximum total time before giving up. Default 60000ms. */
+  timeoutMs?: number;
+  /** Cap on the backoff delay between failed polls. Default 30000ms. */
+  maxBackoffMs?: number;
+  /** Called after every successful status read, for real-time UI updates. */
+  onUpdate?: (status: PolledStatus) => void;
+  /** Called when a poll request throws (network/backend error). */
+  onError?: (error: unknown, consecutiveFailures: number) => void;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/** Promise-based delay that rejects with an AbortError when the signal fires. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort);
+  });
+}
+
+/**
+ * Polls `fetchStatus` until the transaction reaches a terminal state, the
+ * caller aborts, or the timeout elapses. Resolves with the outcome rather than
+ * throwing, so callers can switch on the result.
+ */
+export async function pollTransactionStatus(
+  options: PollTransactionStatusOptions,
+): Promise<PollOutcome> {
+  const {
+    fetchStatus,
+    signal,
+    intervalMs = DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs = DEFAULT_POLL_TIMEOUT_MS,
+    maxBackoffMs = DEFAULT_MAX_BACKOFF_MS,
+    onUpdate,
+    onError,
+  } = options;
+
+  // A real signal for fetchStatus even when the caller passed none.
+  const effectiveSignal = signal ?? new AbortController().signal;
+  const start = Date.now();
+  let consecutiveFailures = 0;
+
+  while (true) {
+    if (signal?.aborted) return "aborted";
+    if (Date.now() - start >= timeoutMs) return "timeout";
+
+    try {
+      const status = await fetchStatus(effectiveSignal);
+      consecutiveFailures = 0;
+      onUpdate?.(status);
+      if (status === "confirmed") return "confirmed";
+      if (status === "failed") return "failed";
+      // "pending" / "not_found" → keep polling.
+    } catch (error) {
+      if (signal?.aborted || isAbortError(error)) return "aborted";
+      consecutiveFailures += 1;
+      onError?.(error, consecutiveFailures);
+    }
+
+    // Exponential backoff while the backend is failing; steady interval
+    // otherwise. Never sleep past the overall timeout deadline.
+    const backoff =
+      consecutiveFailures > 0
+        ? Math.min(intervalMs * 2 ** (consecutiveFailures - 1), maxBackoffMs)
+        : intervalMs;
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) return "timeout";
+
+    try {
+      await delay(Math.min(backoff, remaining), signal);
+    } catch {
+      return "aborted";
+    }
+  }
+}

--- a/frontend/src/lib/transactionStatusSocket.ts
+++ b/frontend/src/lib/transactionStatusSocket.ts
@@ -1,0 +1,99 @@
+/**
+ * Optional WebSocket fallback for transaction confirmation (#414)
+ *
+ * When a WebSocket URL is configured, this subscribes to real-time transaction
+ * status messages so the UI can react the moment the backend surfaces a
+ * webhook event, without waiting for the next poll tick. It is strictly a
+ * fallback: if the socket never connects or errors, the polling loop continues
+ * to drive the UI, so the feature degrades gracefully.
+ *
+ * Expected message shape (JSON):
+ *   { "txHash": "<hash>", "status": "confirmed" | "failed" | "pending" }
+ */
+import type { TxStatus } from "./transactionPolling";
+
+export interface SubscribeOptions {
+  /** ws:// or wss:// endpoint. */
+  url: string;
+  /** Only resolve for messages matching this hash. */
+  txHash: string;
+  /** Aborts the subscription (closes the socket). */
+  signal?: AbortSignal;
+  /** Called for every matching status message. */
+  onStatus?: (status: TxStatus) => void;
+}
+
+/**
+ * Resolves with the first terminal status ("confirmed" | "failed") received for
+ * the given hash, or rejects if the socket closes/errors before that. Callers
+ * race this against {@link pollTransactionStatus}.
+ */
+export function subscribeTransactionStatus(
+  options: SubscribeOptions,
+): Promise<TxStatus> {
+  const { url, txHash, signal, onStatus } = options;
+
+  return new Promise<TxStatus>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    if (typeof WebSocket === "undefined") {
+      reject(new Error("WebSocket is not available in this environment"));
+      return;
+    }
+
+    const socket = new WebSocket(url);
+
+    const cleanup = () => {
+      signal?.removeEventListener("abort", onAbort);
+      // readyState 0 = CONNECTING, 1 = OPEN
+      if (socket.readyState <= WebSocket.OPEN) socket.close();
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort);
+
+    socket.addEventListener("open", () => {
+      // Some backends expect a subscribe frame naming the hash of interest.
+      try {
+        socket.send(JSON.stringify({ type: "subscribe", txHash }));
+      } catch {
+        // Non-fatal: server may push without an explicit subscribe.
+      }
+    });
+
+    socket.addEventListener("message", (event) => {
+      try {
+        const data = JSON.parse(String(event.data)) as {
+          txHash?: string;
+          status?: TxStatus;
+        };
+        if (data.txHash && data.txHash !== txHash) return;
+        if (data.status === "pending") {
+          onStatus?.("pending");
+          return;
+        }
+        if (data.status === "confirmed" || data.status === "failed") {
+          onStatus?.(data.status);
+          cleanup();
+          resolve(data.status);
+        }
+      } catch {
+        // Ignore malformed frames; polling remains the source of truth.
+      }
+    });
+
+    socket.addEventListener("error", () => {
+      cleanup();
+      reject(new Error("Transaction status socket error"));
+    });
+
+    socket.addEventListener("close", () => {
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("Transaction status socket closed"));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
`DistributeForm` previously marked a distribution **confirmed optimistically** right after a single `confirmTransaction` call, so the UI didn't reflect the transaction's real settlement state. This adds real-time confirmation polling.

Closes #414

## What's included
- **`pollTransactionStatus`** (`lib/transactionPolling.ts`) — framework-agnostic polling loop:
  - polls the status endpoint **every 5s**
  - **stops on `confirmed`/`failed`**
  - **gives up after a 60s timeout**
  - **cancels via `AbortSignal`**
  - **exponential backoff** on consecutive failures (don't spam the backend)
- **`useTransactionPolling`** (`hooks/useTransactionPolling.ts`) — React hook that owns an `AbortController` and **aborts polling on unmount**; exposes live `status` / `outcome`; optionally races a WebSocket subscription as a faster fallback.
- **`subscribeTransactionStatus`** (`lib/transactionStatusSocket.ts`) — **optional** ws(s) subscriber. If a socket URL is configured it short-circuits polling on a terminal push; if it never connects, polling stays the source of truth (graceful degradation).
- **`DistributeForm`** — kicks off server-side settlement, then polls for the real status and surfaces **confirmed / timeout / failed**. The existing badge already renders the **estimated confirmation time** countdown during the confirming phase.
- **`api.getTransactionDetails`** now accepts an optional `AbortSignal`.

## Acceptance criteria
- [x] Transaction status polled every 5 seconds
- [x] Estimated confirmation time displayed (existing badge countdown, shown during `confirming`)
- [x] Status updates in real-time without page refresh
- [x] Polling stops on confirmation or 60s timeout
- [x] 4+ polling scenario tests (6 here)
- [x] WebSocket fallback configured (optional)
- [x] `AbortController` cancels polling on unmount
- [x] Exponential backoff if polling fails

## Tests
- **6 polling-loop scenarios**: confirm-after-N-polls, failed, 60s timeout, abort cancels, exponential backoff + recovery, `not_found` keeps polling.
- **2 hook tests**: poll-to-confirm (asserts the `AbortSignal` is threaded to the request), abort-on-unmount.
- **DistributeForm**: submit → poll → `Distributed successfully` integration test.

```
Test Files  9 passed (9)
     Tests  53 passed (53)
```

## Notes / judgment calls
- The previous flow `await`ed `confirmTransaction` (which itself blocks on server-side Horizon polling). I now **kick that off without blocking** and let the client poll `GET /transaction/:hash`, so the 60s client-side timeout and real-time updates are independent of the server call.
- The existing `DistributeForm.test.tsx` rendered the component **without** `TransactionProvider` and was failing at baseline; since this PR touches the component I wrapped those renders in the provider, turning the suite green.
- `tsc`: no new type errors introduced (pre-existing baseline errors in unrelated files are untouched).