### PR TITLE
feat: wallet connection retry with exponential backoff

### DIFF
--- a/frontend/e2e/wallet-retry.spec.ts
+++ b/frontend/e2e/wallet-retry.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E for the wallet connection retry flow (#412).
+ *
+ * Freighter is mocked so its first access attempt fails (simulating an RPC
+ * timeout) and a later attempt succeeds. The UI should surface a
+ * "Reconnecting…" state and then reach the connected state without the user
+ * having to click again.
+ */
+test.describe("Wallet Connection Retry", () => {
+  test("retries a failed connection and eventually connects", async ({ page }) => {
+    await page.goto("/");
+
+    // Mock Freighter: fail the first requestAccess, then succeed.
+    await page.evaluate(() => {
+      let calls = 0;
+      (window as any).freighter = {
+        requestAccess: async () => {
+          calls += 1;
+          if (calls < 2) {
+            throw new Error("rpc timeout");
+          }
+          return { address: "GTEST123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" };
+        },
+      };
+    });
+
+    await page.getByRole("button", { name: /connect/i }).click();
+
+    // Reconnecting feedback shows during the backoff window.
+    await expect(page.getByText(/reconnecting/i)).toBeVisible();
+
+    // After the retry succeeds the connected address is displayed.
+    await expect(page.getByText(/GTEST/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("surfaces an error after retries are exhausted", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      (window as any).freighter = {
+        requestAccess: async () => {
+          throw new Error("rpc timeout");
+        },
+      };
+    });
+
+    await page.getByRole("button", { name: /connect/i }).click();
+
+    await expect(page.getByText(/could not connect/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/frontend/src/components/WalletConnect.test.tsx
+++ b/frontend/src/components/WalletConnect.test.tsx
@@ -44,6 +44,50 @@ describe("WalletConnect", () => {
     expect(localStorage.getItem("freighter_connected")).toBeNull();
   });
 
+  test("retries a transient failure, shows Reconnecting…, then connects and persists (#412)", async () => {
+    const onConnect = vi.fn();
+    let resolveSecond: (v: { address: string }) => void = () => {};
+    const second = new Promise<{ address: string }>((r) => {
+      resolveSecond = r;
+    });
+    const requestAccess = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockReturnValueOnce(second);
+    (window as any).freighter = { requestAccess };
+
+    render(
+      <WalletConnect walletAddress={null} onConnect={onConnect} retryBaseDelayMs={5} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Connect Freighter/i }));
+
+    // Reconnecting state appears after the first failure schedules a retry
+    // (shown both on the button and in the status line).
+    expect((await screen.findAllByText(/Reconnecting/i)).length).toBeGreaterThan(0);
+
+    resolveSecond({ address: VALID_WALLET });
+
+    await waitFor(() => expect(onConnect).toHaveBeenCalledWith(VALID_WALLET));
+    expect(requestAccess).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem("lastWalletAddress")).toBe(VALID_WALLET);
+    expect(localStorage.getItem("freighter_connected")).toBe("true");
+  });
+
+  test("shows an error after exhausting all retries (#412)", async () => {
+    const onConnect = vi.fn();
+    const requestAccess = vi.fn().mockRejectedValue(new Error("rpc timeout"));
+    (window as any).freighter = { requestAccess };
+
+    render(
+      <WalletConnect walletAddress={null} onConnect={onConnect} retryBaseDelayMs={1} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Connect Freighter/i }));
+
+    expect(await screen.findByText(/Could not connect after 4 attempts/i)).toBeInTheDocument();
+    expect(requestAccess).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+
   test("copies the connected wallet address to clipboard", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     (navigator as any).clipboard = { writeText };

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -1,9 +1,16 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import {
+  retryWithBackoff,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_RETRIES,
+} from "../lib/retryWithBackoff";
 
 interface Props {
   walletAddress: string | null;
   onConnect: (address: string) => void;
   onDisconnect?: () => void;
+  /** Base backoff delay; overridable so tests don't wait whole seconds. */
+  retryBaseDelayMs?: number;
 }
 
 // Freighter injects window.freighter at runtime — no official type package available,
@@ -23,12 +30,24 @@ declare global {
   }
 }
 
-export default function WalletConnect({ walletAddress, onConnect, onDisconnect }: Props) {
+export default function WalletConnect({
+  walletAddress,
+  onConnect,
+  onDisconnect,
+  retryBaseDelayMs = DEFAULT_BASE_DELAY_MS,
+}: Props) {
   const [error, setError] = useState("");
   const [freighterAvailable, setFreighterAvailable] = useState(
     () => Boolean(window.freighter),
   );
   const [copied, setCopied] = useState(false);
+  // #412: connection-attempt state for retry feedback.
+  const [connecting, setConnecting] = useState(false);
+  const [retryAttempt, setRetryAttempt] = useState(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight retry loop on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   useEffect(() => {
     function checkFreighterAvailability() {
@@ -53,6 +72,21 @@ export default function WalletConnect({ walletAddress, onConnect, onDisconnect }
     });
   }, [freighterAvailable, onConnect]);
 
+  async function requestFreighterAddress(): Promise<string> {
+    let addr = "";
+    if (window.freighter?.requestAccess) {
+      addr = (await window.freighter.requestAccess()).address;
+    } else if (window.freighter?.getAddress) {
+      addr = (await window.freighter.getAddress()).address;
+    } else if (window.freighter?.getPublicKey) {
+      addr = await window.freighter.getPublicKey();
+    }
+    if (!addr) {
+      throw new Error("No address returned from Freighter.");
+    }
+    return addr;
+  }
+
   async function connect() {
     setError("");
 
@@ -61,29 +95,44 @@ export default function WalletConnect({ walletAddress, onConnect, onDisconnect }
       return;
     }
 
+    // #412: retry transient connection failures (RPC timeouts, network
+    // hiccups) with exponential backoff instead of failing immediately.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setConnecting(true);
+    setRetryAttempt(0);
+
     try {
-      let addr = "";
-      if (window.freighter.requestAccess) {
-        addr = (await window.freighter.requestAccess()).address;
-      } else if (window.freighter.getAddress) {
-        addr = (await window.freighter.getAddress()).address;
-      } else if (window.freighter.getPublicKey) {
-        addr = await window.freighter.getPublicKey();
-      }
+      const addr = await retryWithBackoff(requestFreighterAddress, {
+        baseDelayMs: retryBaseDelayMs,
+        signal: controller.signal,
+        onRetry: (attempt) => setRetryAttempt(attempt),
+      });
 
-      if (!addr) {
-        throw new Error("No address returned from Freighter.");
-      }
-
+      // Persist last known wallet state so the app can restore it (#412).
+      localStorage.setItem("lastWalletAddress", addr);
+      localStorage.setItem("freighter_connected", "true");
       onConnect(addr);
-    } catch {
-      setError("Connection rejected. Please approve the request in Freighter.");
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return; // unmounted/disconnected
+      setError(
+        `Could not connect after ${DEFAULT_RETRIES + 1} attempts. Check Freighter and your connection, then try again.`,
+      );
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      setConnecting(false);
+      setRetryAttempt(0);
     }
   }
 
   function disconnect() {
+    abortRef.current?.abort();
+    abortRef.current = null;
     setError("");
     setCopied(false);
+    setConnecting(false);
+    setRetryAttempt(0);
     localStorage.removeItem("lastWalletAddress");
     localStorage.removeItem("freighter_connected");
     onDisconnect?.();
@@ -118,13 +167,24 @@ export default function WalletConnect({ walletAddress, onConnect, onDisconnect }
           <button
             className="btn-primary"
             onClick={connect}
-            disabled={!freighterAvailable}
+            disabled={!freighterAvailable || connecting}
+            aria-busy={connecting}
             aria-describedby={!freighterAvailable ? "freighter-install-prompt" : undefined}
           >
-            Connect Freighter
+            {connecting
+              ? retryAttempt > 0
+                ? `Reconnecting… (attempt ${retryAttempt + 1})`
+                : "Connecting…"
+              : "Connect Freighter"}
           </button>
         )}
       </div>
+
+      {connecting && retryAttempt > 0 && (
+        <div className="status" role="status" aria-live="polite">
+          Reconnecting… (attempt {retryAttempt + 1} of {DEFAULT_RETRIES + 1})
+        </div>
+      )}
 
       {!freighterAvailable && !walletAddress && (
         <div className="status error" id="freighter-install-prompt" role="status">

--- a/frontend/src/lib/retryWithBackoff.test.ts
+++ b/frontend/src/lib/retryWithBackoff.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  retryWithBackoff,
+  backoffDelay,
+  DEFAULT_BASE_DELAY_MS,
+} from "./retryWithBackoff";
+
+describe("backoffDelay", () => {
+  test("grows exponentially without jitter", () => {
+    expect(backoffDelay(1, 1000, 2, false)).toBe(1000);
+    expect(backoffDelay(2, 1000, 2, false)).toBe(2000);
+    expect(backoffDelay(3, 1000, 2, false)).toBe(4000);
+  });
+
+  test("equal jitter keeps the delay within [raw/2, raw]", () => {
+    expect(backoffDelay(3, 1000, 2, true, () => 0)).toBe(2000); // raw/2
+    expect(backoffDelay(3, 1000, 2, true, () => 1)).toBe(4000); // raw
+    expect(backoffDelay(3, 1000, 2, true, () => 0.5)).toBe(3000); // midpoint
+  });
+});
+
+describe("retryWithBackoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("resolves on the first attempt without any delay", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    await expect(retryWithBackoff(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries and resolves after transient failures", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockResolvedValueOnce("GADDRESS");
+    const onRetry = vi.fn();
+
+    const run = retryWithBackoff(fn, { jitter: false, onRetry });
+    await vi.advanceTimersByTimeAsync(1000 + 2000);
+
+    await expect(run).resolves.toBe("GADDRESS");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  test("uses 1s, 2s, 4s exponential delays (3 retries)", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("down"));
+    const onRetry = vi.fn();
+
+    const run = retryWithBackoff(fn, { jitter: false, onRetry }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(1000 + 2000 + 4000);
+
+    const err = await run;
+    expect((err as Error).message).toBe("down");
+    // 1 initial + 3 retries = 4 attempts.
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(onRetry.mock.calls.map((c) => c[1])).toEqual([1000, 2000, 4000]);
+  });
+
+  test("rejects with the last error once retries are exhausted", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValue(new Error("final"));
+
+    const run = retryWithBackoff(fn, { jitter: false }).catch((e) => e);
+    await vi.advanceTimersByTimeAsync(1000 + 2000 + 4000);
+
+    const err = await run;
+    expect((err as Error).message).toBe("final");
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  test("stops retrying when aborted and rejects with AbortError", async () => {
+    const controller = new AbortController();
+    const fn = vi.fn().mockRejectedValue(new Error("down"));
+
+    const run = retryWithBackoff(fn, {
+      jitter: false,
+      signal: controller.signal,
+    }).catch((e) => e);
+
+    // First attempt fails, loop is sleeping before retry 1.
+    await vi.advanceTimersByTimeAsync(0);
+    const callsBeforeAbort = fn.mock.calls.length;
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const err = await run;
+    expect((err as Error).name).toBe("AbortError");
+    expect(fn.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
+  test("honours a custom base delay", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("x")).mockResolvedValue("ok");
+    const onRetry = vi.fn();
+
+    const run = retryWithBackoff(fn, { baseDelayMs: 50, jitter: false, onRetry });
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(run).resolves.toBe("ok");
+    expect(onRetry.mock.calls[0][1]).toBe(50);
+    expect(DEFAULT_BASE_DELAY_MS).toBe(1000);
+  });
+});

--- a/frontend/src/lib/retryWithBackoff.ts
+++ b/frontend/src/lib/retryWithBackoff.ts
@@ -1,0 +1,114 @@
+/**
+ * Retry with exponential backoff + jitter (#412)
+ *
+ * Wraps a flaky async operation (e.g. a Freighter wallet connection that fails
+ * on an RPC hiccup) and retries it a bounded number of times with exponentially
+ * growing delays. Jitter spreads retries out so concurrent clients don't
+ * synchronise. Kept framework-agnostic so it can be unit-tested with fake
+ * timers and reused beyond the wallet flow.
+ *
+ * Defaults: 3 retries with ~1s, ~2s, ~4s delays (4 attempts total).
+ */
+
+export const DEFAULT_RETRIES = 3;
+export const DEFAULT_BASE_DELAY_MS = 1_000;
+export const DEFAULT_FACTOR = 2;
+
+export interface RetryOptions {
+  /** Max retries after the initial attempt. Default 3. */
+  retries?: number;
+  /** Delay before the first retry. Default 1000ms. */
+  baseDelayMs?: number;
+  /** Exponential growth factor. Default 2. */
+  factor?: number;
+  /** Apply jitter to each delay. Default true. */
+  jitter?: boolean;
+  /** Cancels the retry loop (e.g. component unmount / manual disconnect). */
+  signal?: AbortSignal;
+  /** Called before each retry sleep, for "Reconnecting…" UI. attempt is 1-based. */
+  onRetry?: (attempt: number, delayMs: number, error: unknown) => void;
+  /** Injectable RNG for deterministic tests. Default Math.random. */
+  random?: () => number;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/**
+ * Computes the delay before retry `attempt` (1-based). With jitter, uses
+ * "equal jitter": half the exponential delay plus a random share of the other
+ * half — so the value stays in [raw/2, raw] and never collapses to zero.
+ */
+export function backoffDelay(
+  attempt: number,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  factor = DEFAULT_FACTOR,
+  jitter = true,
+  random: () => number = Math.random,
+): number {
+  const raw = baseDelayMs * factor ** (attempt - 1);
+  if (!jitter) return raw;
+  return Math.round(raw / 2 + random() * (raw / 2));
+}
+
+/** Promise delay that rejects with an AbortError when the signal fires. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort);
+  });
+}
+
+/**
+ * Runs `fn`, retrying on rejection up to `retries` times with exponential
+ * backoff. Resolves with the first success; rejects with the last error once
+ * retries are exhausted, or with an AbortError if the signal fires.
+ */
+export async function retryWithBackoff<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    retries = DEFAULT_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    factor = DEFAULT_FACTOR,
+    jitter = true,
+    signal,
+    onRetry,
+    random = Math.random,
+  } = options;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      lastError = error;
+      if (signal?.aborted || isAbortError(error)) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      if (attempt === retries) break; // out of retries
+      const delayMs = backoffDelay(attempt + 1, baseDelayMs, factor, jitter, random);
+      onRetry?.(attempt + 1, delayMs, error);
+      await sleep(delayMs, signal);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
`WalletConnect` failed immediately on a transient Freighter/RPC error, showing a confusing "connection rejected" message. It now retries with exponential backoff before giving up, with clear UI feedback.

Closes #412

## What's included
- **`retryWithBackoff`** (`lib/retryWithBackoff.ts`) — generic helper: **3 retries** with **~1s / 2s / 4s** delays (equal jitter), `AbortSignal` cancellation, and an `onRetry` hook. Resolves on first success; rejects with the last error when exhausted.
- **`WalletConnect`** — wraps the Freighter access call in the retry loop:
  - shows a **"Reconnecting… (attempt n of 4)"** state during retries
  - **aborts** the loop on unmount and on manual disconnect (no retry-after-disconnect)
  - **persists** the connected address + `freighter_connected` flag to `localStorage` on success (cleared on disconnect)

## Acceptance criteria
- [x] Retries up to 3 times on failure
- [x] Exponential backoff (1s, 2s, 4s)
- [x] "Reconnecting…" UI state during retry
- [x] Retry logic tested in 4+ scenarios (8 unit + 2 component)
- [x] Last wallet state persisted to localStorage
- [x] E2E test for the retry flow added
- [x] Capped at 3 retries; localStorage cleared on manual disconnect

## Tests
- **8 unit scenarios** for `retryWithBackoff`: first-try success, retry-then-success, exhaustion, exact 1s/2s/4s delays, abort mid-retry, custom base delay, jitter bounds.
- **WalletConnect component**: retry→connect with persistence, and exhaustion error.
- **Playwright e2e** (`e2e/wallet-retry.spec.ts`): mocked Freighter fails then succeeds → reconnecting → connected; and exhaustion → error.

## Notes / adaptations
- The issue references `WalletConnect.jsx` and a `WalletContext`, but the repo uses **`WalletConnect.tsx`** and has **no WalletContext**. I exposed the retry via the component (the natural place here) rather than inventing a context.
- The component takes an optional `retryBaseDelayMs` prop (defaults to 1000ms) so tests don't wait whole seconds.
- **Pre-existing, unrelated:** `DistributeForm.test.tsx` (4 tests) fails on `main` because it renders without `TransactionProvider` — untouched here and fixed separately in #446. All other tests (incl. my new ones) pass: **50 + my additions green**.