### PR TITLE
feat: add restartable, mobile-friendly onboarding tour

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ export default function App() {
   );
   const [initialLoading, setInitialLoading] = useState(true);
   const [sessionToast, setSessionToast] = useState<string | null>(null);
+  const [tourTrigger, setTourTrigger] = useState(0);
 
   function handleWalletConnect(address: string) {
     setWalletAddress(address);
@@ -335,6 +336,7 @@ export default function App() {
         onPageChange={handlePageChange}
         walletAddress={walletAddress}
         onDisconnect={handleDisconnect}
+        onStartTour={() => setTourTrigger((n) => n + 1)}
       />
 
       <div className="app-content">
@@ -428,7 +430,11 @@ export default function App() {
         <div className="app-main">{renderPage()}</div>
       </div>
 
-      <OnboardingWalkthrough />
+      <OnboardingWalkthrough
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        restartSignal={tourTrigger}
+      />
     </div>
   );
 }

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -105,6 +105,30 @@
   flex-shrink: 0;
 }
 
+/* Onboarding tour restart — issue #419 */
+.tour-restart-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  min-height: 38px;
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-inverse);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(5px);
+  transition: all var(--transition-base);
+  white-space: nowrap;
+}
+
+.tour-restart-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
 /* Network toggle — issue #231 */
 .network-toggle {
   display: flex;
@@ -331,7 +355,8 @@
   }
 
   .network-toggle,
-  .wallet-status {
+  .wallet-status,
+  .tour-restart-btn {
     font-size: 0.78rem;
     padding: 0.4rem 0.7rem;
   }
@@ -352,7 +377,8 @@
   }
 
   .network-toggle,
-  .wallet-status {
+  .wallet-status,
+  .tour-restart-btn {
     font-size: 0.75rem;
     padding: 0.35rem 0.6rem;
   }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -8,6 +8,7 @@ interface NavigationProps {
   onPageChange: (page: string) => void;
   walletAddress: string | null;
   onDisconnect: () => void;
+  onStartTour: () => void;
 }
 
 export const Navigation: React.FC<NavigationProps> = ({
@@ -15,6 +16,7 @@ export const Navigation: React.FC<NavigationProps> = ({
   onPageChange,
   walletAddress,
   onDisconnect,
+  onStartTour,
 }) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -77,6 +79,7 @@ export const Navigation: React.FC<NavigationProps> = ({
                 className={`nav-link ${currentPage === item.id ? "active" : ""}`}
                 onClick={() => handleNavClick(item.id)}
                 aria-current={currentPage === item.id ? "page" : undefined}
+                data-tour-id={item.id}
               >
                 <span className="nav-icon">{item.icon}</span>
                 <span className="nav-label">{item.label}</span>
@@ -86,6 +89,16 @@ export const Navigation: React.FC<NavigationProps> = ({
         </ul>
 
         <div className="nav-wallet">
+          {/* Onboarding tour restart — issue #419 */}
+          <button
+            className="tour-restart-btn"
+            onClick={onStartTour}
+            aria-label="Start the onboarding tour"
+            title="Start the onboarding tour"
+          >
+            🎯 Start Tour
+          </button>
+
           {/* Network toggle — issue #231 */}
           <button
             className={`network-toggle network-toggle--${network}`}

--- a/frontend/src/components/OnboardingWalkthrough.css
+++ b/frontend/src/components/OnboardingWalkthrough.css
@@ -89,15 +89,24 @@
   transition: width 0.3s ease-out;
 }
 
+.onboarding-tooltip--centered {
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%);
+}
+
 .onboarding-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
 .onboarding-btn-skip,
+.onboarding-btn-previous,
 .onboarding-btn-next {
   flex: 1;
-  padding: 0.5rem;
+  min-height: 44px;
+  padding: 0.6rem 0.75rem;
   border: none;
   border-radius: 6px;
   font-size: 0.875rem;
@@ -106,13 +115,15 @@
   transition: opacity 0.15s;
 }
 
-.onboarding-btn-skip {
+.onboarding-btn-skip,
+.onboarding-btn-previous {
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border-color);
 }
 
-.onboarding-btn-skip:hover {
+.onboarding-btn-skip:hover,
+.onboarding-btn-previous:hover {
   opacity: 0.8;
 }
 
@@ -127,11 +138,25 @@
 
 @media (max-width: 768px) {
   .onboarding-tooltip {
-    max-width: 280px;
-    padding: 0.875rem;
+    max-width: calc(100vw - 2rem);
+    width: calc(100vw - 2rem);
+    padding: 1rem;
+    box-sizing: border-box;
   }
 
   .onboarding-overlay {
     background: rgba(0, 0, 0, 0.5);
+  }
+
+  .onboarding-actions {
+    gap: 0.6rem;
+  }
+
+  .onboarding-btn-skip,
+  .onboarding-btn-previous,
+  .onboarding-btn-next {
+    flex: 1 1 100%;
+    min-height: 48px;
+    font-size: 0.95rem;
   }
 }

--- a/frontend/src/components/OnboardingWalkthrough.test.tsx
+++ b/frontend/src/components/OnboardingWalkthrough.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OnboardingWalkthrough } from "./OnboardingWalkthrough";
+
+const STORAGE_KEY = "srs_onboarding_completed";
+
+describe("OnboardingWalkthrough", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("shows on first mount when not previously completed", () => {
+    render(<OnboardingWalkthrough />);
+    expect(screen.getByText("Initialize Your Contract")).toBeInTheDocument();
+  });
+
+  test("does not show when already completed", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    render(<OnboardingWalkthrough />);
+    expect(screen.queryByText("Initialize Your Contract")).not.toBeInTheDocument();
+  });
+
+  test("skip sets localStorage and hides the tour", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingWalkthrough onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Skip/i }));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+    expect(onComplete).toHaveBeenCalled();
+    expect(screen.queryByText("Initialize Your Contract")).not.toBeInTheDocument();
+  });
+
+  test("Previous is unavailable on the first step, and Next advances steps", () => {
+    render(<OnboardingWalkthrough />);
+
+    expect(screen.queryByRole("button", { name: /Previous/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Next/i }));
+    expect(screen.getByText("Add Collaborators")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Previous/i }));
+    expect(screen.getByText("Initialize Your Contract")).toBeInTheDocument();
+  });
+
+  test("bumping restartSignal reopens the tour from step 1, even after completion", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    const { rerender } = render(<OnboardingWalkthrough restartSignal={0} />);
+    expect(screen.queryByText("Initialize Your Contract")).not.toBeInTheDocument();
+
+    rerender(<OnboardingWalkthrough restartSignal={1} />);
+    expect(screen.getByText("Initialize Your Contract")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/OnboardingWalkthrough.tsx
+++ b/frontend/src/components/OnboardingWalkthrough.tsx
@@ -7,32 +7,46 @@ interface OnboardingStep {
   description: string;
   targetElement: string;
   position: "top" | "bottom" | "left" | "right";
+  /** App page (App.tsx currentPage value) this step's target lives on, if any. */
+  page?: string;
 }
 
 const STEPS: OnboardingStep[] = [
   {
-    id: "connect-wallet",
-    title: "Connect Your Wallet",
+    id: "initialize-overview",
+    title: "Initialize Your Contract",
     description:
-      "Start by connecting your Stellar wallet using Freighter. This allows you to sign transactions.",
-    targetElement: ".wallet-status",
+      "Start here. Initializing defines who your collaborators are and how royalties are split between them.",
+    targetElement: '[data-tour-id="initialize"]',
     position: "bottom",
+    page: "initialize",
   },
   {
-    id: "set-contract",
-    title: "Enter Contract ID",
+    id: "add-collaborators",
+    title: "Add Collaborators",
     description:
-      "Paste your smart contract ID (starts with 'C') in the sidebar. This is the contract you want to manage.",
-    targetElement: ".contract-input",
+      "Enter each collaborator's wallet address, then use 'Add collaborator' to add more rows.",
+    targetElement: ".btn-add",
     position: "bottom",
+    page: "initialize",
+  },
+  {
+    id: "confirm-shares",
+    title: "Confirm Share Allocation",
+    description:
+      "The share calculator tracks your total allocation — it must equal 100% before you can submit.",
+    targetElement: ".share-calculator",
+    position: "left",
+    page: "initialize",
   },
   {
     id: "distribute",
     title: "Distribute Funds",
     description:
-      "Once set up, you can distribute royalties to your collaborators. Select a token and amount, then confirm with Freighter.",
-    targetElement: '[aria-current="page"]',
-    position: "right",
+      "Once initialized, head to Distribute to send royalty payouts to your collaborators.",
+    targetElement: '[data-tour-id="distribute"]',
+    position: "bottom",
+    page: "distribute",
   },
 ];
 
@@ -40,16 +54,30 @@ const STORAGE_KEY = "srs_onboarding_completed";
 
 interface OnboardingWalkthroughProps {
   onComplete?: () => void;
+  /** Current App page, used to auto-navigate as the tour advances across pages. */
+  currentPage?: string;
+  /** Navigate the host app to a different page (e.g. App's handlePageChange). */
+  onPageChange?: (page: string) => void;
+  /** Bump this number (e.g. from a "Start Tour" button) to force the tour open from step 1. */
+  restartSignal?: number;
 }
 
 export const OnboardingWalkthrough: React.FC<OnboardingWalkthroughProps> = ({
   onComplete,
+  currentPage,
+  onPageChange,
+  restartSignal,
 }) => {
   const [currentStep, setCurrentStep] = useState(0);
   const [isVisible, setIsVisible] = useState(false);
-  const [position, setPosition] = useState<{ top: number; left: number }>({
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    centered: boolean;
+  }>({
     top: 0,
     left: 0,
+    centered: false,
   });
 
   useEffect(() => {
@@ -59,50 +87,82 @@ export const OnboardingWalkthrough: React.FC<OnboardingWalkthroughProps> = ({
     }
   }, []);
 
+  // Restart the tour on demand (e.g. "Start Tour" button in Navigation),
+  // regardless of prior completion state.
+  useEffect(() => {
+    if (restartSignal === undefined || restartSignal === 0) return;
+    setCurrentStep(0);
+    setIsVisible(true);
+  }, [restartSignal]);
+
+  // Navigate the host app to the page a step's target lives on before we
+  // try to measure that target's position.
+  useEffect(() => {
+    if (!isVisible) return;
+    const step = STEPS[currentStep];
+    if (step.page && step.page !== currentPage) {
+      onPageChange?.(step.page);
+    }
+  }, [isVisible, currentStep, currentPage, onPageChange]);
+
   useEffect(() => {
     if (!isVisible) return;
 
     const step = STEPS[currentStep];
+    if (step.page && step.page !== currentPage) {
+      // Still waiting for the page navigation above to take effect.
+      return;
+    }
+
     const targetElement = document.querySelector(step.targetElement);
 
-    if (targetElement) {
-      const rect = targetElement.getBoundingClientRect();
-      const scrollTop =
-        window.pageYOffset || document.documentElement.scrollTop;
-      const scrollLeft =
-        window.pageXOffset || document.documentElement.scrollLeft;
-
-      let top = rect.top + scrollTop;
-      let left = rect.left + scrollLeft;
-
-      switch (step.position) {
-        case "bottom":
-          top = rect.bottom + scrollTop + 10;
-          left = rect.left + scrollLeft;
-          break;
-        case "top":
-          top = rect.top + scrollTop - 10;
-          left = rect.left + scrollLeft;
-          break;
-        case "left":
-          top = rect.top + scrollTop;
-          left = rect.left + scrollLeft - 10;
-          break;
-        case "right":
-          top = rect.top + scrollTop;
-          left = rect.right + scrollLeft + 10;
-          break;
-      }
-
-      setPosition({ top, left });
+    if (!targetElement) {
+      setPosition({ top: 0, left: 0, centered: true });
+      return;
     }
-  }, [isVisible, currentStep]);
+
+    const rect = targetElement.getBoundingClientRect();
+    const scrollTop =
+      window.pageYOffset || document.documentElement.scrollTop;
+    const scrollLeft =
+      window.pageXOffset || document.documentElement.scrollLeft;
+
+    let top = rect.top + scrollTop;
+    let left = rect.left + scrollLeft;
+
+    switch (step.position) {
+      case "bottom":
+        top = rect.bottom + scrollTop + 10;
+        left = rect.left + scrollLeft;
+        break;
+      case "top":
+        top = rect.top + scrollTop - 10;
+        left = rect.left + scrollLeft;
+        break;
+      case "left":
+        top = rect.top + scrollTop;
+        left = rect.left + scrollLeft - 10;
+        break;
+      case "right":
+        top = rect.top + scrollTop;
+        left = rect.right + scrollLeft + 10;
+        break;
+    }
+
+    setPosition({ top, left, centered: false });
+  }, [isVisible, currentStep, currentPage]);
 
   function nextStep() {
     if (currentStep < STEPS.length - 1) {
       setCurrentStep(currentStep + 1);
     } else {
       completeWalkthrough();
+    }
+  }
+
+  function previousStep() {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
     }
   }
 
@@ -121,17 +181,22 @@ export const OnboardingWalkthrough: React.FC<OnboardingWalkthroughProps> = ({
   }
 
   const step = STEPS[currentStep];
+  const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === STEPS.length - 1;
 
   return (
     <>
       <div className="onboarding-overlay" onClick={skipWalkthrough} />
       <div
-        className="onboarding-tooltip"
-        style={{
-          top: `${position.top}px`,
-          left: `${position.left}px`,
-        }}
+        className={`onboarding-tooltip ${position.centered ? "onboarding-tooltip--centered" : ""}`}
+        style={
+          position.centered
+            ? undefined
+            : {
+                top: `${position.top}px`,
+                left: `${position.left}px`,
+              }
+        }
       >
         <div className="onboarding-header">
           <h3>{step.title}</h3>
@@ -165,6 +230,15 @@ export const OnboardingWalkthrough: React.FC<OnboardingWalkthroughProps> = ({
           >
             Skip
           </button>
+          {!isFirstStep && (
+            <button
+              className="onboarding-btn-previous"
+              onClick={previousStep}
+              type="button"
+            >
+              Previous
+            </button>
+          )}
           <button
             className="onboarding-btn-next"
             onClick={nextStep}


### PR DESCRIPTION
## Summary
- Adds a "Start Tour" button to the nav to replay the onboarding walkthrough at any time, regardless of completion state
- Replaces the old wallet/contract-id-focused steps with a flow that matches the actual product: initialize overview -> add collaborators -> confirm shares -> distribute, auto-navigating the app to each step's page
- Adds a Previous control (only Skip/Next existed before) and larger touch targets / a near-full-width layout on mobile

## Test plan
- [x] `frontend/src/components/OnboardingWalkthrough.test.tsx` covers: first-mount visibility, completed-state suppression, Skip persistence, Next/Previous navigation, and forced restart via the new `restartSignal` prop
- [x] `npx tsc --noEmit` — no new type errors introduced
- [ ] Manual click-through in a browser (couldn't run `vitest` in this sandbox — see note below)

Note: this sandbox's `vitest` run is broken by a pre-existing `jsdom`/`html-encoding-sniffer` packaging bug unrelated to this change (confirmed by running an existing, untouched test file, which fails identically). Verified via `tsc` and manual code review instead.

Closes #419