### PR TITLE
feat: add nonce-based request deduplication for initialize

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -74,11 +74,32 @@ Invalid or missing signatures return `401`.
 
 Build an unsigned `initialize` transaction XDR.
 
-**Body:** `{ contractId, walletAddress, collaborators, shares }`
+**Body:** `{ contractId, walletAddress, collaborators, shares, nonce? }`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `nonce` | string (optional) | UUID v4. When provided, permanently deduplicates this request per contract (#421) — see below. |
 
 **Response:** `{ xdr, transactionId }`
 
 Initialize requests are rejected before contract processing when the request body is too large or when the serialized `collaborators` array exceeds the initialize payload guard.
+
+**Request deduplication by nonce (#421):**
+
+`nonce` is distinct from the `Idempotency-Key` header used on `/distribute`:
+
+- **`Idempotency-Key`** (see Distribute below) caches the *response* for a TTL window (default 24h) and *replays* it on a repeated request with the same key.
+- **`nonce`** is *permanently* recorded per `(contractId, nonce)` pair. A second request reusing the same nonce for the same contract is rejected outright — it is never re-processed and the original response is never replayed. This lets a client distinguish an intentional retry (reuse a nonce on purpose to confirm rejection) from an accidental duplicate submission, without relying on a cache TTL.
+
+If `(contractId, nonce)` has already been seen, the request is rejected before any transaction is built or recorded:
+
+**Response:** `409 Conflict`
+
+```json
+{ "error": "A request with this nonce has already been processed for this contract." }
+```
+
+The same `nonce` value may be reused across *different* contracts — the uniqueness constraint is scoped to `(contractId, nonce)`, not `nonce` alone. Generate a nonce on the frontend with `crypto.randomUUID()` (see `frontend/src/lib/request-nonce.ts`).
 
 **Oversized payload response:** `413 Payload Too Large`
 

--- a/backend/src/database/core.js
+++ b/backend/src/database/core.js
@@ -59,6 +59,20 @@ export function initializeDatabase() {
       sql: `/* initial schema — already applied via CREATE TABLE IF NOT EXISTS */`,
     },
     {
+      // Issue #421: permanent per-contract nonce dedup for /api/v1/initialize.
+      version: 6,
+      sql: `
+        CREATE TABLE IF NOT EXISTS request_nonces (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          contractId TEXT NOT NULL,
+          nonce TEXT NOT NULL,
+          createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(contractId, nonce)
+        );
+        CREATE INDEX IF NOT EXISTS idx_request_nonces_contractId ON request_nonces(contractId);
+      `,
+    },
+    {
       version: 5,
       sql: `
         -- Issue #401: Dead-letter queue for failed webhook deliveries

--- a/backend/src/database/index.js
+++ b/backend/src/database/index.js
@@ -42,6 +42,9 @@ export {
 // Audit logging
 export { getAuditLog, addAuditLog } from "./audit.js";
 
+// Request nonce dedup (#421)
+export { recordNonceIfNew } from "./request-nonces.js";
+
 // Secondary royalties
 export {
   recordSecondarySale,

--- a/backend/src/database/request-nonces.js
+++ b/backend/src/database/request-nonces.js
@@ -1,0 +1,30 @@
+/**
+ * Permanent per-contract request nonce dedup (#421).
+ *
+ * Distinct from idempotency.js: that mechanism caches and replays a
+ * response for 24h. This permanently rejects (409, no replay) any second
+ * use of the same (contractId, nonce) pair, so it also distinguishes an
+ * intentional retry (client reuses a nonce on purpose) from an accidental
+ * duplicate submission.
+ */
+
+import { db, countWrite } from "./core.js";
+
+/**
+ * Record a nonce for a contract if it hasn't been seen before.
+ * Returns true if newly recorded, false if (contractId, nonce) already exists.
+ */
+export function recordNonceIfNew(contractId, nonce) {
+  const stmt = db.prepare(`
+    INSERT INTO request_nonces (contractId, nonce)
+    VALUES (?, ?)
+    ON CONFLICT(contractId, nonce) DO NOTHING
+  `);
+
+  const result = stmt.run(contractId, nonce);
+  if (result.changes > 0) {
+    countWrite();
+    return true;
+  }
+  return false;
+}

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -15,6 +15,8 @@ import {
 } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
 import { createRequestLogger } from "../logger.js";
+import { recordNonceIfNew } from "../database/index.js";
+import { sendError } from "../error-response.js";
 
 export const initializeRouter = Router();
 
@@ -37,8 +39,18 @@ initializeRouter.post(
   async (req, res, next) => {
     const log = createRequestLogger(req);
     try {
-      const { contractId, walletAddress, collaborators, shares } = req.body;
+      const { contractId, walletAddress, collaborators, shares, nonce } = req.body;
       if (!(await ensureNotInitialized(contractId, res, log))) return;
+
+      if (nonce && !recordNonceIfNew(contractId, nonce)) {
+        log.warn("duplicate initialize nonce rejected", { contractId, nonce });
+        return sendError(
+          res,
+          409,
+          "duplicate_nonce",
+          "A request with this nonce has already been processed for this contract."
+        );
+      }
 
       log.info("initialize requested", {
         contractId,

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -17,6 +17,8 @@ export const initializeSchema = z
     walletAddress: stellarAddress,
     collaborators: z.array(stellarAddress).min(1, "Collaborators array must be non-empty").max(20),
     shares: z.array(basisPoints).min(1).max(20),
+    // Issue #421: optional UUID for permanent per-contract request dedup.
+    nonce: z.string().uuid("nonce must be a valid UUID").optional(),
   })
   .refine((d) => d.collaborators.length === d.shares.length, {
     message: "collaborators and shares must be the same length",

--- a/backend/tests/collaborators.test.js
+++ b/backend/tests/collaborators.test.js
@@ -56,6 +56,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction: jest.fn(() => "tx-789"),
   addAuditLog: jest.fn(),
+  recordNonceIfNew: jest.fn(() => true),
   initializeDatabase: jest.fn(),
   getMigrationVersion: jest.fn(() => 1),
 }));

--- a/backend/tests/contract-integration.test.js
+++ b/backend/tests/contract-integration.test.js
@@ -45,6 +45,7 @@ const addAuditLog       = jest.fn();
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog,
+  recordNonceIfNew: jest.fn(() => true),
   initializeDatabase:  jest.fn(),
   getMigrationVersion: jest.fn(() => 1),
 }));

--- a/backend/tests/distribute-idempotency.test.js
+++ b/backend/tests/distribute-idempotency.test.js
@@ -18,6 +18,7 @@ const recordTransaction = jest.fn(() => "tx-456");
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog: jest.fn(),
+  recordNonceIfNew: jest.fn(() => true),
   initializeDatabase: jest.fn(),
   getMigrationVersion: jest.fn(() => 1),
 }));

--- a/backend/tests/distribute.integration.test.js
+++ b/backend/tests/distribute.integration.test.js
@@ -21,6 +21,7 @@ const addAuditLog = jest.fn();
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog,
+  recordNonceIfNew: jest.fn(() => true),
   initializeDatabase: jest.fn(),
   getMigrationVersion: jest.fn(() => 1),
 }));

--- a/backend/tests/initialize-commit-reveal.test.js
+++ b/backend/tests/initialize-commit-reveal.test.js
@@ -24,6 +24,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction: jest.fn(() => 1),
   addAuditLog: jest.fn(),
+  recordNonceIfNew: jest.fn(() => true),
 }));
 
 const { initializeRouter } = await import("../src/routes/initialize.js");

--- a/backend/tests/initialize-nonce.test.js
+++ b/backend/tests/initialize-nonce.test.js
@@ -1,0 +1,127 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+
+// Capture mock functions at factory time so we hold the same instances the route uses
+const retryBuildTx = jest.fn();
+const isContractInitialized = jest.fn();
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  retryBuildTx,
+  isContractInitialized,
+  addressToScVal: jest.fn((a) => a),
+  u32ToScVal: jest.fn((n) => n),
+  vecToScVal: jest.fn((v) => v),
+  bytesN32HexToScVal: jest.fn((h) => h),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+const recordTransaction = jest.fn(() => "tx-123");
+const addAuditLog = jest.fn();
+
+// better-sqlite3 is globally stubbed to no-ops for tests (see
+// __mocks__/better-sqlite3.js), so request-nonces.js's real DB-backed
+// recordNonceIfNew can't be exercised here. Simulate the same
+// (contractId, nonce) uniqueness semantics with an in-memory Set instead —
+// consistent with how the other database functions are mocked in
+// initialize.test.js.
+const seenNonces = new Set();
+const recordNonceIfNew = jest.fn((contractId, nonce) => {
+  const key = `${contractId}:${nonce}`;
+  if (seenNonces.has(key)) return false;
+  seenNonces.add(key);
+  return true;
+});
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  recordTransaction,
+  addAuditLog,
+  recordNonceIfNew,
+  initializeDatabase: jest.fn(),
+  getMigrationVersion: jest.fn(() => 1),
+}));
+
+const { initializeRouter } = await import("../src/routes/initialize.js");
+
+const app = express();
+app.use(express.json({ limit: "10kb" }));
+app.use("/api/v1/initialize", initializeRouter);
+app.use((err, _req, res, _next) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Payload too large" });
+  }
+  res.status(500).json({ error: err.message ?? "Internal server error" });
+});
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const CONTRACT_2 = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const WALLET = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const COLLAB1 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB2 = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+const NONCE = "11111111-1111-4111-8111-111111111111";
+
+const validBody = {
+  contractId: CONTRACT,
+  walletAddress: WALLET,
+  collaborators: [COLLAB1, COLLAB2],
+  shares: [5000, 5000],
+};
+
+describe("POST /api/v1/initialize — nonce dedup (#421)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    seenNonces.clear();
+    isContractInitialized.mockResolvedValue(false);
+    retryBuildTx.mockResolvedValue("unsigned-xdr-string");
+    recordTransaction.mockReturnValue("tx-123");
+  });
+
+  test("request without a nonce behaves as before", async () => {
+    const res = await request(app).post("/api/v1/initialize").send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ xdr: "unsigned-xdr-string", transactionId: "tx-123" });
+  });
+
+  test("first request with a nonce succeeds", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, nonce: NONCE });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("second request with the same nonce and contractId returns 409 and builds no new transaction", async () => {
+    await request(app).post("/api/v1/initialize").send({ ...validBody, nonce: NONCE });
+    retryBuildTx.mockClear();
+    recordTransaction.mockClear();
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, nonce: NONCE });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already been processed/i);
+    expect(retryBuildTx).not.toHaveBeenCalled();
+    expect(recordTransaction).not.toHaveBeenCalled();
+  });
+
+  test("the same nonce is reusable for a different contractId", async () => {
+    await request(app).post("/api/v1/initialize").send({ ...validBody, nonce: NONCE });
+
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, contractId: CONTRACT_2, nonce: NONCE });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("invalid (non-UUID) nonce is rejected with 400", async () => {
+    const res = await request(app)
+      .post("/api/v1/initialize")
+      .send({ ...validBody, nonce: "not-a-uuid" });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -23,10 +23,12 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
 
 const recordTransaction = jest.fn(() => "tx-123");
 const addAuditLog = jest.fn();
+const recordNonceIfNew = jest.fn(() => true);
 
 await jest.unstable_mockModule("../src/database/index.js", () => ({
   recordTransaction,
   addAuditLog,
+  recordNonceIfNew,
   initializeDatabase: jest.fn(),
   getMigrationVersion: jest.fn(() => 1),
 }));

--- a/backend/tests/simulate.test.js
+++ b/backend/tests/simulate.test.js
@@ -86,6 +86,7 @@ await jest.unstable_mockModule("../src/database/index.js", () => ({
   getMigrationVersion: jest.fn(() => 1),
   initializeDatabase: jest.fn(),
   recordTransaction: jest.fn(() => "tx-456"),
+  recordNonceIfNew: jest.fn(() => true),
 }));
 
 const { default: app } = await import("./app.js");

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -187,6 +187,7 @@ export const api = {
     walletAddress: string;
     collaborators: string[];
     shares: number[];
+    nonce?: string;
   }) =>
     post<{ xdr: string; transactionId: number }>(
       "/initialize",

--- a/frontend/src/lib/request-nonce.test.ts
+++ b/frontend/src/lib/request-nonce.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "vitest";
+import { generateRequestNonce } from "./request-nonce";
+
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("generateRequestNonce (#421)", () => {
+  test("returns a valid UUID v4 string", () => {
+    expect(generateRequestNonce()).toMatch(UUID_V4_RE);
+  });
+
+  test("successive calls return different values", () => {
+    const a = generateRequestNonce();
+    const b = generateRequestNonce();
+    expect(a).not.toBe(b);
+  });
+});

--- a/frontend/src/lib/request-nonce.ts
+++ b/frontend/src/lib/request-nonce.ts
@@ -1,0 +1,8 @@
+/**
+ * Generates a UUID v4 nonce for permanent per-contract request dedup on
+ * POST /api/v1/initialize (#421). Distinct from the commit-reveal salt/nonce
+ * in init-commitment.ts, which are 32-byte hex commitment values, not UUIDs.
+ */
+export function generateRequestNonce(): string {
+  return crypto.randomUUID();
+}


### PR DESCRIPTION
## Summary
- Adds an optional `nonce` (UUID v4) field to `POST /api/v1/initialize`. When present, `(contractId, nonce)` is permanently recorded and a repeat returns `409 Conflict` before any transaction is built
- This is distinct from the existing `Idempotency-Key` mechanism on `/distribute`, which caches and replays a response for a 24h TTL window — nonce dedup never replays, so it lets a client distinguish an intentional retry from an accidental duplicate, with no expiry
- Adds a frontend `generateRequestNonce()` utility (`crypto.randomUUID()`) and wires the optional field through `api.ts`
- Documents the new field, the 409 response shape, and how it differs from idempotency in `API.md`

## Test plan
- [x] `backend/tests/initialize-nonce.test.js` — no-nonce backwards compatibility, first-use success, duplicate-nonce 409 (and no transaction built), nonce reusable across different `contractId`s, invalid UUID rejected with 400
- [x] Updated 6 other test files whose `database/index.js` mocks needed the new `recordNonceIfNew` export added to their factories
- [x] Full backend suite: `node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathPatterns=tests/` — same 11 pre-existing failing suites as on `main` (unrelated to this change), zero new failures, +24 passing tests in the initialize suites
- [x] `npx eslint` clean on all touched files
- [x] frontend `npx tsc --noEmit` — no new type errors

Closes #421