### PR TITLE
feat: cache collaborator lookups and add cache hit/miss metrics

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -200,11 +200,24 @@ The endpoint only calls Soroban RPC simulation. It does not submit the transacti
 
 Returns on-chain collaborator addresses and shares.
 
+Cached in memory for 5 minutes (#422) — far longer than the 30s contract-state cache, since collaborator shares are effectively immutable once a contract is initialized. Cache key format: `contract:{network}:{contractId}:collaborators`. The cache is invalidated immediately whenever `/api/v1/initialize` or `/api/v1/initialize/reveal` successfully builds a transaction for that contract, rather than relying solely on the 5-minute TTL to pick up the new collaborator list.
+
+## Caching strategy (#422)
+
+| Cache | TTL | Key format | Invalidation |
+| ----- | --- | ---------- | ------------- |
+| Contract state (`GET /contract/state`) | 30s | `contract:{network}:{contractId}:state:{tokenId}` | TTL only — state (balance, royalty rate) can change at any time, so a short TTL is the primary defense. |
+| Collaborator list (`GET /collaborators/:contractId`) | 5min | `contract:{network}:{contractId}:collaborators` | TTL, plus explicit invalidation on successful initialize/reveal for that contract. |
+
+Both caches are in-memory `Map`s local to a single backend process (no Redis/shared cache layer). Cache hit/miss counts are exposed on the `/metrics` endpoint as `stellar_cache_hits_total{cache="..."}` / `stellar_cache_misses_total{cache="..."}` with `cache` values `contract_state` and `collaborators`.
+
 ## Contract
 
 ### `GET /api/v1/contract/state`
 
-Returns the configured contract's current state for frontend displays: admin address, royalty rate, recipient shares, token balance, and network details. Responses are cached for 30 seconds to reduce Soroban RPC calls.
+Returns the configured contract's current state for frontend displays: admin address, royalty rate, recipient shares, token balance, and network details. Responses are cached in memory for 30 seconds to reduce Soroban RPC calls.
+
+Cache key format: `contract:{network}:{contractId}:state:{tokenId}` (#422). The network segment is included because the same `contractId` string can be queried against both testnet and mainnet; without it, those two distinct on-chain states would alias to the same cache entry.
 
 Uses `ROYALTY_CONTRACT_ID` or `CONTRACT_ID` by default. Pass `contractId` to override. Uses `ROYALTY_TOKEN_ID`, `TOKEN_CONTRACT_ID`, or `TOKEN_ID` by default for the balance token. Pass `tokenId` to override.
 
@@ -278,6 +291,8 @@ Exposes:
 - `stellar_transactions_failed_total`
 - `stellar_horizon_response_time_average_ms`
 - `stellar_horizon_response_time_count`
+- `stellar_cache_hits_total{cache="..."}` (#422)
+- `stellar_cache_misses_total{cache="..."}` (#422)
 
 ## Local Seed
 

--- a/backend/src/metrics.js
+++ b/backend/src/metrics.js
@@ -32,6 +32,10 @@ const metrics = {
   // ── #396: Stellar RPC tracing ─────────────────────────────────────────
   /** Map<operationLabel> → { count, totalMs } */
   stellarRpcCalls: new Map(),
+
+  // ── #422: RPC response cache hit/miss tracking ─────────────────────────
+  /** Map<cacheName> → { hits, misses } */
+  cacheStats: new Map(),
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -123,6 +127,22 @@ export function recordStellarRpcCall(operation, durationMs, success = true) {
   metrics.stellarRpcCalls.set(operation, entry);
 }
 
+// ── #422: Cache hit/miss recorders ──────────────────────────────────────
+
+function getCacheEntry(cacheName) {
+  const entry = metrics.cacheStats.get(cacheName) ?? { hits: 0, misses: 0 };
+  metrics.cacheStats.set(cacheName, entry);
+  return entry;
+}
+
+export function recordCacheHit(cacheName) {
+  getCacheEntry(cacheName).hits += 1;
+}
+
+export function recordCacheMiss(cacheName) {
+  getCacheEntry(cacheName).misses += 1;
+}
+
 // ── Snapshot ──────────────────────────────────────────────────────────────
 
 export function getMetricsSnapshot() {
@@ -156,6 +176,9 @@ export function getMetricsSnapshot() {
         { ...v, averageMs: v.count > 0 ? v.totalMs / v.count : 0 },
       ]),
     ),
+
+    // #422
+    cacheStats: Object.fromEntries(metrics.cacheStats),
   };
 }
 
@@ -233,6 +256,22 @@ export function prometheusMetrics() {
     );
   }
 
+  // #422 — cache hit/miss counters
+  lines.push(
+    "# HELP stellar_cache_hits_total Cache hits by cache name.",
+    "# TYPE stellar_cache_hits_total counter",
+  );
+  for (const [cache, v] of Object.entries(snapshot.cacheStats)) {
+    lines.push(`stellar_cache_hits_total{cache="${cache}"} ${v.hits}`);
+  }
+  lines.push(
+    "# HELP stellar_cache_misses_total Cache misses by cache name.",
+    "# TYPE stellar_cache_misses_total counter",
+  );
+  for (const [cache, v] of Object.entries(snapshot.cacheStats)) {
+    lines.push(`stellar_cache_misses_total{cache="${cache}"} ${v.misses}`);
+  }
+
   lines.push("");
   return lines.join("\n");
 }
@@ -250,4 +289,5 @@ export function resetMetrics() {
   metrics.requestBytesTotal = 0;
   metrics.responseBytesTotal = 0;
   metrics.stellarRpcCalls.clear();
+  metrics.cacheStats.clear();
 }

--- a/backend/src/routes/collaborators.js
+++ b/backend/src/routes/collaborators.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import StellarSdk from "@stellar/stellar-sdk";
-import { server, networkPassphrase } from "../stellar.js";
+import { server, networkPassphrase, getNetworkLabel } from "../stellar.js";
 import logger from "../logger.js";
 import { validateContractIdMiddleware } from "../validation.js";
 import { sendError } from "../error-response.js";
+import { recordCacheHit, recordCacheMiss } from "../metrics.js";
 
 const {
   Address,
@@ -16,6 +17,27 @@ const {
 
 export const collaboratorsRouter = Router();
 
+// Issue #422: collaborator shares are effectively immutable once a contract
+// is initialized, so we cache them for 5 minutes — far longer than the 30s
+// contract-state cache — and invalidate immediately on (re-)initialize
+// rather than relying solely on the TTL.
+const COLLABORATORS_CACHE_TTL_MS = 5 * 60 * 1000;
+const collaboratorsCache = new Map();
+
+/** Cache key format: `contract:{network}:{contractId}:collaborators` (#422). */
+function getCollaboratorsCacheKey(contractId) {
+  return `contract:${getNetworkLabel()}:${contractId}:collaborators`;
+}
+
+export function _resetCollaboratorsCache() {
+  collaboratorsCache.clear();
+}
+
+/** Invalidate the cached collaborator list for a contract (#422). */
+export function invalidateCollaboratorsCache(contractId) {
+  collaboratorsCache.delete(getCollaboratorsCacheKey(contractId));
+}
+
 /**
  * GET /api/collaborators/:contractId
  * Returns: [{ address, basisPoints }]
@@ -26,6 +48,16 @@ export const collaboratorsRouter = Router();
 collaboratorsRouter.get("/:contractId", validateContractIdMiddleware, async (req, res, next) => {
   try {
     const { contractId } = req.params;
+    const cacheKey = getCollaboratorsCacheKey(contractId);
+    const cached = collaboratorsCache.get(cacheKey);
+    const now = Date.now();
+
+    if (cached && now - cached.fetchedAt < COLLABORATORS_CACHE_TTL_MS) {
+      recordCacheHit("collaborators");
+      return res.json(cached.data);
+    }
+
+    recordCacheMiss("collaborators");
     const contract = new Contract(contractId);
 
     const dummyAccount = new Account(
@@ -58,6 +90,7 @@ collaboratorsRouter.get("/:contractId", validateContractIdMiddleware, async (req
     }));
 
     logger.info(`get_all_shares returned ${results.length} collaborators for ${contractId}`);
+    collaboratorsCache.set(cacheKey, { data: results, fetchedAt: now });
     res.json(results);
   } catch (err) {
     next(err);

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -11,6 +11,7 @@ import {
 } from "../stellar.js";
 import { validateContractIdMiddleware, validateContractId } from "../validation.js";
 import { sendError } from "../error-response.js";
+import { recordCacheHit, recordCacheMiss } from "../metrics.js";
 
 const { Contract, SorobanRpc, TransactionBuilder, BASE_FEE, Account } = StellarSdk;
 
@@ -90,8 +91,15 @@ async function readContractState(contractId, tokenId) {
   };
 }
 
+/**
+ * Cache key format: `contract:{network}:{contractId}:state:{tokenId}` (#422).
+ * The network segment is required (not just cosmetic): the same `contractId`
+ * string can be queried against both testnet and mainnet, and without a
+ * network discriminator those two distinct on-chain states would alias to
+ * the same cache entry.
+ */
 function getContractStateCacheKey(contractId, tokenId) {
-  return `${getNetworkLabel()}:${networkPassphrase}:${contractId}:${tokenId}`;
+  return `contract:${getNetworkLabel()}:${contractId}:state:${tokenId}`;
 }
 
 function resolveStateRequest(req, res) {
@@ -123,6 +131,20 @@ export function _resetContractStateCache() {
   contractStateCache.clear();
 }
 
+/**
+ * Invalidate cached state for a contract across all cached token ids (#422).
+ * The 30s TTL already self-heals quickly, but this lets callers (e.g. a
+ * successful initialize) clear stale data immediately instead of waiting
+ * out the TTL.
+ */
+export function invalidateContractStateCache(contractId) {
+  for (const key of contractStateCache.keys()) {
+    if (key.includes(`:${contractId}:`)) {
+      contractStateCache.delete(key);
+    }
+  }
+}
+
 contractRouter.get("/state", async (req, res, next) => {
   try {
     const stateRequest = resolveStateRequest(req, res);
@@ -134,9 +156,11 @@ contractRouter.get("/state", async (req, res, next) => {
     const now = Date.now();
 
     if (cached && now - cached.fetchedAt < CONTRACT_STATE_CACHE_TTL_MS) {
+      recordCacheHit("contract_state");
       return res.json(cached.state);
     }
 
+    recordCacheMiss("contract_state");
     const state = await readContractState(contractId, tokenId);
     contractStateCache.set(cacheKey, { state, fetchedAt: now });
     res.json(state);

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -15,6 +15,7 @@ import {
 } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
 import { createRequestLogger } from "../logger.js";
+import { invalidateCollaboratorsCache } from "./collaborators.js";
 
 export const initializeRouter = Router();
 
@@ -60,6 +61,7 @@ initializeRouter.post(
         correlationId: req.correlationId,
       });
 
+      invalidateCollaboratorsCache(contractId);
       log.info("initialize transaction built", { contractId, transactionId });
       res.json({ xdr, transactionId });
     } catch (err) {
@@ -130,6 +132,7 @@ initializeRouter.post(
         correlationId: req.correlationId,
       });
 
+      invalidateCollaboratorsCache(contractId);
       res.json({ xdr, transactionId, phase: "reveal" });
     } catch (err) {
       if (err.status) return res.status(err.status).json({ error: err.message });

--- a/backend/tests/contract-caching.test.js
+++ b/backend/tests/contract-caching.test.js
@@ -1,0 +1,124 @@
+/**
+ * RPC response caching tests (#422).
+ *
+ * Mounts collaboratorsRouter / contractRouter directly (not via tests/app.js,
+ * which also pulls in initializeRouter and its unrelated, pre-existing mock
+ * requirements) so this suite is isolated to the caching behavior itself.
+ */
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+
+const mockSimulate = jest.fn();
+const mockIsSimError = jest.fn(() => false);
+
+await jest.unstable_mockModule("@stellar/stellar-sdk", () => ({
+  default: {
+    Address: { fromScVal: jest.fn((scv) => ({ toString: () => scv })) },
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn((method) => ({ method })),
+    })),
+    SorobanRpc: {
+      Server: jest.fn().mockImplementation(() => ({ simulateTransaction: mockSimulate })),
+      Api: { isSimulationError: mockIsSimError },
+    },
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+    BASE_FEE: "100",
+    Account: jest.fn(),
+  },
+  Address: { fromScVal: jest.fn((scv) => ({ toString: () => scv })) },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn((method) => ({ method })),
+  })),
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({ simulateTransaction: mockSimulate })),
+    Api: { isSimulationError: mockIsSimError },
+  },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  BASE_FEE: "100",
+  Account: jest.fn(),
+}));
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  server: { simulateTransaction: mockSimulate },
+  networkPassphrase: "Test SDF Network ; September 2015",
+  getNetworkLabel: jest.fn(() => "Testnet"),
+  addressToScVal: jest.fn((a) => a),
+  isContractInitialized: jest.fn(),
+  getConfiguredContractId: jest.fn(() => null),
+  getContractVersionFromContract: jest.fn(),
+}));
+
+const {
+  collaboratorsRouter,
+  _resetCollaboratorsCache,
+  invalidateCollaboratorsCache,
+} = await import("../src/routes/collaborators.js");
+const { resetMetrics, getMetricsSnapshot } = await import("../src/metrics.js");
+
+const app = express();
+app.use("/api/v1/collaborators", collaboratorsRouter);
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const COLLAB1 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+function mockShareMapResult() {
+  return {
+    result: {
+      retval: {
+        map: () => ({
+          entries: [
+            {
+              key: () => COLLAB1,
+              val: () => ({ u32: () => 10000 }),
+            },
+          ],
+        }),
+      },
+    },
+  };
+}
+
+describe("Collaborators cache (#422)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsSimError.mockReturnValue(false);
+    mockSimulate.mockResolvedValue(mockShareMapResult());
+    _resetCollaboratorsCache();
+    resetMetrics();
+  });
+
+  test("second request within TTL is served from cache — simulateTransaction called once", async () => {
+    const first = await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+    const second = await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body).toEqual(first.body);
+    expect(mockSimulate).toHaveBeenCalledTimes(1);
+  });
+
+  test("records a cache miss then a cache hit in metrics", async () => {
+    await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+    await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+
+    const snapshot = getMetricsSnapshot();
+    expect(snapshot.cacheStats.collaborators).toEqual({ hits: 1, misses: 1 });
+  });
+
+  test("invalidateCollaboratorsCache busts the cache and triggers a fresh simulation", async () => {
+    await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+    invalidateCollaboratorsCache(CONTRACT);
+    await request(app).get(`/api/v1/collaborators/${CONTRACT}`);
+
+    expect(mockSimulate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/tests/initialize-commit-reveal.test.js
+++ b/backend/tests/initialize-commit-reveal.test.js
@@ -19,6 +19,9 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   u32ToScVal: jest.fn((n) => n),
   vecToScVal: jest.fn((v) => v),
   bytesN32HexToScVal: jest.fn((h) => h),
+  getNetworkLabel: jest.fn(() => "Testnet"),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
 await jest.unstable_mockModule("../src/database/index.js", () => ({

--- a/backend/tests/initialize.test.js
+++ b/backend/tests/initialize.test.js
@@ -19,6 +19,7 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   bytesN32HexToScVal: jest.fn((h) => h),
   server: {},
   networkPassphrase: "Test SDF Network ; September 2015",
+  getNetworkLabel: jest.fn(() => "Testnet"),
 }));
 
 const recordTransaction = jest.fn(() => "tx-123");


### PR DESCRIPTION
## Summary
- Adds a 5-minute TTL in-memory cache for `GET /api/v1/collaborators/:contractId` (collaborator shares are effectively immutable post-initialize), invalidated immediately on a successful `/initialize` or `/initialize/reveal` for that contract rather than relying solely on the TTL
- Aligns the existing 30s contract-state cache's key format to `contract:{network}:{contractId}:state:{tokenId}` (network kept as a discriminator — same `contractId` string can exist on both testnet and mainnet) and documents it
- New collaborator cache uses `contract:{network}:{contractId}:collaborators`
- Adds `stellar_cache_hits_total{cache="..."}` / `stellar_cache_misses_total{cache="..."}` to the Prometheus `/metrics` endpoint
- Documents the full caching strategy (TTLs, key formats, invalidation) in `API.md`

## Test plan
- [x] `backend/tests/contract-caching.test.js` (new) — second request within TTL served from cache (simulation called once), hit/miss metrics increment correctly, `invalidateCollaboratorsCache` busts the cache and triggers a fresh simulation
- [x] Full backend suite: same 11 pre-existing failing suites as on `main` (unrelated to this change), zero new failures, +3 passing tests
- [x] `npx eslint` clean on all touched files

Closes #422