### PR TITLE
feat: contract address validation, copy & QR display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import DistributeSecondaryRoyalties from "./components/DistributeSecondaryRoyalt
 import ResaleHistory from "./components/ResaleHistory";
 import { Skeleton } from "./components/Skeleton";
 import { CopyButton } from "./components/CopyButton";
+import { ContractAddress } from "./components/ContractAddress";
 import { api, SESSION_EXPIRED_EVENT } from "./api";
 import { OnboardingWalkthrough } from "./components/OnboardingWalkthrough";
 
@@ -364,6 +365,9 @@ export default function App() {
             </div>
             {contractIdError && (
               <p className="contract-input-error">{contractIdError}</p>
+            )}
+            {contractIdValid && (
+              <ContractAddress address={contractId} label="contract ID" />
             )}
             {contractIdValid && contractInitialized !== null && (
               <p className={`contract-status ${contractInitialized ? "contract-status--ok" : "contract-status--warn"}`}>

--- a/frontend/src/components/ContractAddress.css
+++ b/frontend/src/components/ContractAddress.css
@@ -1,0 +1,99 @@
+/* ContractAddress (#418) */
+
+.contract-address {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.contract-address__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.contract-address__value {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+  background: rgba(127, 127, 127, 0.12);
+  padding: 0.2rem 0.45rem;
+  border-radius: 6px;
+}
+
+.contract-address__badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.contract-address__badge.is-valid {
+  color: #0f7b2e;
+  background: rgba(34, 197, 94, 0.15);
+}
+
+.contract-address__badge.is-invalid {
+  color: #b3261e;
+  background: rgba(239, 68, 68, 0.15);
+}
+
+.contract-address__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.contract-address__toast {
+  font-size: 0.75rem;
+  color: #0f7b2e;
+  background: rgba(34, 197, 94, 0.12);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+}
+
+.contract-address__modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.contract-address__modal {
+  background: var(--card-bg, #fff);
+  color: var(--text, #111);
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 320px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.contract-address__modal h4 {
+  margin: 0;
+}
+
+.contract-address__modal-value {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  word-break: break-all;
+  text-align: center;
+}
+
+/* Mobile: keep the address readable rather than overflowing. */
+@media (max-width: 600px) {
+  .contract-address__value {
+    font-size: 0.78rem;
+  }
+}

--- a/frontend/src/components/ContractAddress.test.tsx
+++ b/frontend/src/components/ContractAddress.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { ContractAddress, truncateMiddle } from "./ContractAddress";
+
+const VALID = "C" + "A".repeat(55); // valid Stellar C-address format
+const INVALID = "not-a-contract";
+
+describe("truncateMiddle", () => {
+  test("keeps short values intact and middle-truncates long ones", () => {
+    expect(truncateMiddle("CABC")).toBe("CABC");
+    const out = truncateMiddle(VALID);
+    expect(out).toContain("…");
+    expect(out.startsWith("CAAAAAAA")).toBe(true);
+    expect(out.endsWith("AAAAAA")).toBe(true);
+    expect(out.length).toBeLessThan(VALID.length);
+  });
+});
+
+describe("ContractAddress", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete (navigator as any).clipboard;
+  });
+
+  test("validates a well-formed address on mount and exposes the full address", () => {
+    render(<ContractAddress address={VALID} />);
+    expect(screen.getByText(/✓ Valid/)).toBeInTheDocument();
+    // Full address available for verification via the title/aria-label tooltip.
+    expect(screen.getByTitle(VALID)).toBeInTheDocument();
+  });
+
+  test("flags an invalid address format on mount", () => {
+    render(<ContractAddress address={INVALID} />);
+    expect(screen.getByText(/⚠ Invalid/)).toBeInTheDocument();
+  });
+
+  test("copies the address and shows a toast confirmation", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    (navigator as any).clipboard = { writeText };
+
+    render(<ContractAddress address={VALID} label="contract ID" />);
+    fireEvent.click(screen.getByRole("button", { name: /Copy contract ID/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(VALID));
+    expect(await screen.findByText(/Address copied to clipboard/i)).toBeInTheDocument();
+  });
+
+  test("opens a QR modal that contains the full address", () => {
+    render(<ContractAddress address={VALID} />);
+    fireEvent.click(screen.getByRole("button", { name: /Show QR code/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /QR code/i });
+    expect(dialog).toBeInTheDocument();
+    // Full address shown under the QR for manual verification.
+    expect(within(dialog).getByText(VALID)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ContractAddress.tsx
+++ b/frontend/src/components/ContractAddress.tsx
@@ -1,0 +1,122 @@
+/**
+ * ContractAddress (#418)
+ *
+ * Displays a Stellar contract address in a copy/verify-friendly way:
+ * - monospace, middle-truncated so it stays readable on mobile
+ * - full address in a hover tooltip (and aria-label) for verification
+ * - validity badge computed on mount (Stellar C-address format)
+ * - copy-to-clipboard with a transient toast confirmation
+ * - a QR-code modal for easy sharing
+ */
+import { useEffect, useMemo, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { isValidContractAddress } from "../lib/stellar-address";
+import { CopyButton } from "./CopyButton";
+import "./ContractAddress.css";
+
+interface ContractAddressProps {
+  address: string;
+  label?: string;
+}
+
+/** Middle-truncates a long address (keeps it verifiable but compact). */
+export function truncateMiddle(value: string, lead = 8, tail = 6): string {
+  if (value.length <= lead + tail + 1) return value;
+  return `${value.slice(0, lead)}…${value.slice(-tail)}`;
+}
+
+export function ContractAddress({ address, label = "contract address" }: ContractAddressProps) {
+  // Validated on mount (and whenever the address changes).
+  const isValid = useMemo(() => isValidContractAddress(address), [address]);
+  const [showQr, setShowQr] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
+  // Allow closing the QR modal with Escape.
+  useEffect(() => {
+    if (!showQr) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowQr(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [showQr]);
+
+  function handleCopied() {
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 2000);
+  }
+
+  return (
+    <div className="contract-address" data-testid="contract-address">
+      <div className="contract-address__row">
+        <code
+          className="contract-address__value"
+          title={address}
+          aria-label={`${label}: ${address}`}
+        >
+          {truncateMiddle(address)}
+        </code>
+        <span
+          className={`contract-address__badge ${isValid ? "is-valid" : "is-invalid"}`}
+          role="status"
+          title={
+            isValid
+              ? "Valid Stellar contract address"
+              : "Invalid contract address format"
+          }
+        >
+          {isValid ? "✓ Valid" : "⚠ Invalid"}
+        </span>
+      </div>
+
+      <div className="contract-address__actions">
+        <CopyButton value={address} label={label} size="sm" onCopied={handleCopied} />
+        <button
+          type="button"
+          className="copy-btn-sm"
+          onClick={() => setShowQr(true)}
+          aria-haspopup="dialog"
+          aria-label="Show QR code"
+        >
+          🔳 QR
+        </button>
+      </div>
+
+      {showToast && (
+        <div className="contract-address__toast" role="status" aria-live="polite">
+          Address copied to clipboard
+        </div>
+      )}
+
+      {showQr && (
+        <div
+          className="contract-address__modal-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Contract address QR code"
+          onClick={() => setShowQr(false)}
+        >
+          <div
+            className="contract-address__modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h4>Contract address</h4>
+            <QRCodeSVG value={address} size={200} data-testid="contract-qr" />
+            <code className="contract-address__modal-value">{address}</code>
+            <div className="contract-address__actions">
+              <CopyButton value={address} label={label} size="sm" onCopied={handleCopied} />
+              <button
+                type="button"
+                className="copy-btn-sm"
+                onClick={() => setShowQr(false)}
+                aria-label="Close QR code"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -5,6 +5,8 @@ interface CopyButtonProps {
   label?: string;
   className?: string;
   size?: "sm" | "md";
+  /** Called after the value is successfully copied (e.g. to show a toast). */
+  onCopied?: () => void;
 }
 
 export function CopyButton({
@@ -12,6 +14,7 @@ export function CopyButton({
   label = "Copy",
   className = "",
   size = "md",
+  onCopied,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
@@ -22,12 +25,13 @@ export function CopyButton({
       try {
         await navigator.clipboard.writeText(value);
         setCopied(true);
+        onCopied?.();
         setTimeout(() => setCopied(false), 2000);
       } catch {
         setCopied(false);
       }
     },
-    [value],
+    [value, onCopied],
   );
 
   const sizeClass = size === "sm" ? "copy-btn-sm" : "copy-btn";


### PR DESCRIPTION
## Summary
The contract ID was shown only as an editable input — hard to verify, and unreadable when truncated on mobile. This adds a reusable `ContractAddress` display.

Closes #418

## What's included
- **`ContractAddress`** component:
  - **validity badge** computed **on mount** (Stellar C-address format via the existing `stellar-address` lib)
  - **monospace, middle-truncated** value with the **full address in a hover tooltip** (`title` + `aria-label`) for verification
  - **copy-to-clipboard** with a transient **toast** confirmation
  - **QR-code modal** (`qrcode.react`) for sharing — closeable via overlay click or **Escape**
  - **responsive** CSS so the address stays readable on mobile
- Rendered in the sidebar "Contract ID" card once the entered ID is valid.
- `CopyButton` gains an optional `onCopied` callback (used to drive the toast).

## Acceptance criteria
- [x] Copy-to-clipboard button works
- [x] Toast confirmation shown after copy
- [x] Contract ID validated on mount
- [x] Tooltip shows full address on hover
- [x] QR code modal available
- [x] Mobile-friendly address display
- [x] 3+ address-handling tests (5 here)

## Tests
Valid/invalid validation on mount, copy + toast, QR modal contains the full address, and `truncateMiddle` behaviour. All pass.

## Notes
- Reused the repo's existing `CopyButton` and `stellar-address` validation rather than duplicating, and `qrcode.react` (already a dependency).
- **Pre-existing, unrelated:** `DistributeForm.test.tsx` (4 tests) fails on `main` (renders without `TransactionProvider`) — untouched here; fixed separately in #446.