### PR TITLE
fix: standardize error response format across all API routes

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -5,6 +5,27 @@ Base URL: `http://localhost:3001` (default)
 All JSON POST bodies must use `Content-Type: application/json`.
 JSON request bodies are limited to `10kb`; oversized requests return `413 Payload Too Large`.
 
+## Standardized Error Response Format (#227)
+
+All API routes consistently return structured error responses matching the standardized shape:
+
+```json
+{
+  "status": 400,
+  "code": "bad_request",
+  "message": "Human-readable error description",
+  "error": "Human-readable error description",
+  "timestamp": "2026-06-26T14:00:00.000Z"
+}
+```
+
+- `status`: The HTTP status code (integer)
+- `code`: Machine-readable snake_case error code (e.g. `bad_request`, `validation_error`, `conflict`, `payload_too_large`, `internal_server_error`)
+- `message`: Human-readable error message (string)
+- `error`: Maintained alongside `message` for 100% backward compatibility with legacy clients
+
+---
+
 ## Health
 
 ### `GET /api/v1/health`

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -113,18 +113,14 @@ function resolveStateRequest(req, res) {
   const tokenId = firstQueryValue(req.query.tokenId) ?? getConfiguredTokenId();
 
   if (!contractId) {
-    res.status(400).json({
-      error: "contractId query param required when no default contract is configured",
-    });
+    sendError(res, 400, "bad_request", "contractId query param required when no default contract is configured");
     return null;
   }
 
   if (!validateContractId(contractId, res)) return null;
 
   if (!tokenId) {
-    res.status(400).json({
-      error: "tokenId query param required when no default token is configured",
-    });
+    sendError(res, 400, "bad_request", "tokenId query param required when no default token is configured");
     return null;
   }
 
@@ -157,7 +153,7 @@ contractRouter.get("/state", async (req, res, next) => {
     res.json(withCacheMetadata(state, "live", now));
   } catch (err) {
     if (err.status) {
-      return res.status(err.status).json({ error: err.message });
+      return sendError(res, err.status, undefined, err.message);
     }
     next(err);
   }

--- a/backend/src/routes/initialize.js
+++ b/backend/src/routes/initialize.js
@@ -15,6 +15,7 @@ import {
 } from "../validation.js";
 import { buildAndRecordTransaction } from "./_shared.js";
 import { createRequestLogger } from "../logger.js";
+import { sendError } from "../error-response.js";
 
 export const initializeRouter = Router();
 
@@ -22,9 +23,7 @@ async function ensureNotInitialized(contractId, res, log) {
   const alreadyInitialized = await isContractInitialized(contractId);
   if (alreadyInitialized) {
     log?.warn("contract already initialized", { contractId });
-    res.status(409).json({
-      error: "Contract is already initialized. Cannot re-initialize an existing contract.",
-    });
+    sendError(res, 409, "conflict", "Contract is already initialized. Cannot re-initialize an existing contract.");
     return false;
   }
   return true;
@@ -67,7 +66,7 @@ initializeRouter.post(
         error: err.message ?? String(err),
         status: err.status,
       });
-      if (err.status) return res.status(err.status).json({ error: err.message });
+      if (err.status) return sendError(res, err.status, undefined, err.message);
       next(err);
     }
   }
@@ -99,7 +98,7 @@ initializeRouter.post("/commit", validate(commitInitializeSchema), async (req, r
 
     res.json({ xdr, transactionId, phase: "commit" });
   } catch (err) {
-    if (err.status) return res.status(err.status).json({ error: err.message });
+    if (err.status) return sendError(res, err.status, undefined, err.message);
     next(err);
   }
 });
@@ -132,7 +131,7 @@ initializeRouter.post(
 
       res.json({ xdr, transactionId, phase: "reveal" });
     } catch (err) {
-      if (err.status) return res.status(err.status).json({ error: err.message });
+      if (err.status) return sendError(res, err.status, undefined, err.message);
       next(err);
     }
   }

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -158,14 +158,14 @@ export function validateInitializePayloadSize(req, res, next) {
   const totalBodyBytes = getJsonByteLength(req.body);
 
   if (totalBodyBytes > INITIALIZE_PAYLOAD_LIMIT_BYTES) {
-    return res.status(413).json({ error: "Payload too large" });
+    return sendError(res, 413, "payload_too_large", "Payload too large");
   }
 
   if (Array.isArray(req.body?.collaborators)) {
     const collaboratorsBytes = getJsonByteLength(req.body.collaborators);
 
     if (collaboratorsBytes > INITIALIZE_COLLABORATORS_PAYLOAD_LIMIT_BYTES) {
-      return res.status(413).json({ error: "Collaborators payload too large" });
+      return sendError(res, 413, "payload_too_large", "Collaborators payload too large");
     }
   }
 

--- a/backend/tests/error-response.test.js
+++ b/backend/tests/error-response.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "@jest/globals";
+import { describe, test, expect, jest } from "@jest/globals";
 import {
   ERROR_CODES,
   buildErrorPayload,

--- a/backend/tests/standardized-route-errors.test.js
+++ b/backend/tests/standardized-route-errors.test.js
@@ -1,0 +1,48 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { validateInitializePayloadSize } from "../src/validation.js";
+
+describe("Standardized error responses (#227)", () => {
+  const mockRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  test("validateInitializePayloadSize returns standardized error payload on oversized body", () => {
+    const req = {
+      body: { data: "x".repeat(100_000) },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    validateInitializePayloadSize(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(413);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toMatchObject({
+      status: 413,
+      code: "payload_too_large",
+      message: "Payload too large",
+    });
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  test("validateInitializePayloadSize returns standardized error on oversized collaborators", () => {
+    const req = {
+      body: {
+        collaborators: Array.from({ length: 145 }, () => "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    validateInitializePayloadSize(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(413);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toMatchObject({
+      status: 413,
+      code: "payload_too_large",
+      message: "Collaborators payload too large",
+    });
+  });
+});


### PR DESCRIPTION
Closes #227

## Summary
Standardizes all API error responses across every Express route and validation middleware to follow a consistent, structured shape: `{ status, code, message, error, timestamp }`. Eliminates discrepancies between raw `{ error }` and `{ message }` returns while preserving legacy field mappings for 100% backward compatibility.

## Changes
- **Routes & Validation (`contract.js`, `initialize.js`, `validation.js`)**:
  - Replaced all raw `res.status(...).json({ error })` returns with standardized `sendError` helper invocations
  - Ensured HTTP status code matches response body `status` field and assigned machine-readable `code` identifiers (`bad_request`, `conflict`, `payload_too_large`)
- **Documentation (`API.md`)**:
  - Added dedicated specification section detailing the standardized error response format and updated error JSON examples
- **Tests (`standardized-route-errors.test.js`, `error-response.test.js`)**:
  - Created unit test suite verifying standardized error payload structure on oversized request bodies and collaborators arrays
  - Fixed missing Jest global imports in error response test suite

## Acceptance Criteria & Testing
- [x] All error responses use `{ status, code, message }` format
- [x] Status matches HTTP status code
- [x] Code is machine-readable error code
- [x] Message is human-readable description
- [x] No breaking changes to existing API interface (maintains `error` alias)
- [x] Unit tests passing 100%

GPG-signed commit by modrispath@gmail.com