### PR TITLE
feat: notification toast system with context provider

### DIFF
--- a/frontend/src/context/NotificationContext.test.tsx
+++ b/frontend/src/context/NotificationContext.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  NotificationProvider,
+  useNotification,
+  MAX_VISIBLE_TOASTS,
+  DEFAULT_TOAST_DURATION_MS,
+} from "./NotificationContext";
+
+// A harness exposing the notification API through buttons.
+function Harness({ onReady }: { onReady?: (api: ReturnType<typeof useNotification>) => void }) {
+  const api = useNotification();
+  onReady?.(api);
+  return (
+    <div>
+      <button onClick={() => api.success("Saved!")}>success</button>
+      <button onClick={() => api.error("Boom")}>error</button>
+      <button onClick={() => api.warning("Careful")}>warning</button>
+      <button onClick={() => api.info("FYI")}>info</button>
+    </div>
+  );
+}
+
+function renderHarness(onReady?: (api: ReturnType<typeof useNotification>) => void) {
+  return render(
+    <NotificationProvider>
+      <Harness onReady={onReady} />
+    </NotificationProvider>,
+  );
+}
+
+describe("NotificationContext", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("renders the four toast types with distinct classes", () => {
+    renderHarness();
+    for (const t of ["success", "error", "warning", "info"]) {
+      act(() => {
+        fireEvent.click(screen.getByText(t));
+      });
+    }
+    const toasts = screen.getAllByTestId("toast");
+    // Only MAX_VISIBLE_TOASTS are shown at once.
+    expect(toasts.length).toBe(MAX_VISIBLE_TOASTS);
+    expect(document.querySelector(".toast--success")).toBeTruthy();
+    expect(document.querySelector(".toast--error")).toBeTruthy();
+    expect(document.querySelector(".toast--warning")).toBeTruthy();
+  });
+
+  test("auto-dismisses after the configured duration", () => {
+    let api!: ReturnType<typeof useNotification>;
+    renderHarness((a) => (api = a));
+
+    act(() => {
+      api.notify({ type: "info", message: "temp", duration: 3000 });
+    });
+    expect(screen.getAllByTestId("toast")).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.queryByTestId("toast")).toBeNull();
+  });
+
+  test("caps visible toasts at 3 and promotes a queued one on dismiss", () => {
+    let api!: ReturnType<typeof useNotification>;
+    renderHarness((a) => (api = a));
+
+    act(() => {
+      api.info("one", { duration: 0 });
+      api.info("two", { duration: 0 });
+      api.info("three", { duration: 0 });
+      api.info("four", { duration: 0 }); // queued
+    });
+    expect(screen.getAllByTestId("toast")).toHaveLength(MAX_VISIBLE_TOASTS);
+    expect(screen.queryByText("four")).toBeNull();
+
+    // Dismiss the first → the queued "four" is promoted.
+    act(() => {
+      fireEvent.click(screen.getAllByLabelText("Dismiss notification")[0]);
+    });
+    expect(screen.getByText("four")).toBeInTheDocument();
+  });
+
+  test("Retry action runs the callback and dismisses the toast", () => {
+    let api!: ReturnType<typeof useNotification>;
+    const onRetry = vi.fn();
+    renderHarness((a) => (api = a));
+
+    act(() => {
+      api.error("failed", { duration: 0, onRetry });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("toast")).toBeNull();
+  });
+
+  test("Copy action writes the provided text to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    (navigator as any).clipboard = { writeText };
+    let api!: ReturnType<typeof useNotification>;
+    renderHarness((a) => (api = a));
+
+    act(() => {
+      api.success("Hash ready", { duration: 0, copyText: "LONG_TX_HASH_".repeat(10) });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    });
+    expect(writeText).toHaveBeenCalledWith("LONG_TX_HASH_".repeat(10));
+  });
+
+  test("default duration constant is 5 seconds", () => {
+    expect(DEFAULT_TOAST_DURATION_MS).toBe(5000);
+  });
+});

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -1,0 +1,199 @@
+/**
+ * NotificationContext (#417)
+ *
+ * App-wide toast notifications replacing browser alerts. Supports
+ * success/error/warning/info types, optional Retry/Copy/Dismiss actions,
+ * configurable auto-dismiss, bottom-right stacking, and a max of 3 visible
+ * toasts (the rest are queued). Styling is theme-aware (data-theme).
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import "./NotificationToast.css";
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface NotifyOptions {
+  type?: ToastType;
+  title?: string;
+  message: string;
+  /** Auto-dismiss after this many ms. Default 5000; 0 disables auto-dismiss. */
+  duration?: number;
+  /** When set, a Retry button is shown that runs this then dismisses. */
+  onRetry?: () => void;
+  /** When set, a Copy button copies this text (handles long text). */
+  copyText?: string;
+}
+
+interface Toast extends NotifyOptions {
+  id: number;
+  type: ToastType;
+  duration: number;
+}
+
+interface NotificationContextValue {
+  notify: (opts: NotifyOptions) => number;
+  success: (message: string, opts?: Omit<NotifyOptions, "message" | "type">) => number;
+  error: (message: string, opts?: Omit<NotifyOptions, "message" | "type">) => number;
+  warning: (message: string, opts?: Omit<NotifyOptions, "message" | "type">) => number;
+  info: (message: string, opts?: Omit<NotifyOptions, "message" | "type">) => number;
+  dismiss: (id: number) => void;
+}
+
+export const MAX_VISIBLE_TOASTS = 3;
+export const DEFAULT_TOAST_DURATION_MS = 5000;
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+const ICONS: Record<ToastType, string> = {
+  success: "✓",
+  error: "✕",
+  warning: "⚠",
+  info: "ℹ",
+};
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [visible, setVisible] = useState<Toast[]>([]);
+  const queueRef = useRef<Toast[]>([]);
+  const nextId = useRef(1);
+
+  const dismiss = useCallback((id: number) => {
+    setVisible((prev) => {
+      const remaining = prev.filter((t) => t.id !== id);
+      // Promote a queued toast into the freed slot.
+      if (remaining.length < MAX_VISIBLE_TOASTS && queueRef.current.length > 0) {
+        const next = queueRef.current.shift()!;
+        return [...remaining, next];
+      }
+      return remaining;
+    });
+  }, []);
+
+  const notify = useCallback((opts: NotifyOptions): number => {
+    const toast: Toast = {
+      id: nextId.current++,
+      type: opts.type ?? "info",
+      duration: opts.duration ?? DEFAULT_TOAST_DURATION_MS,
+      title: opts.title,
+      message: opts.message,
+      onRetry: opts.onRetry,
+      copyText: opts.copyText,
+    };
+    setVisible((prev) => {
+      if (prev.length >= MAX_VISIBLE_TOASTS) {
+        queueRef.current.push(toast);
+        return prev;
+      }
+      return [...prev, toast];
+    });
+    return toast.id;
+  }, []);
+
+  const byType = useCallback(
+    (type: ToastType) =>
+      (message: string, opts?: Omit<NotifyOptions, "message" | "type">) =>
+        notify({ ...opts, type, message }),
+    [notify],
+  );
+
+  const value: NotificationContextValue = {
+    notify,
+    success: byType("success"),
+    error: byType("error"),
+    warning: byType("warning"),
+    info: byType("info"),
+    dismiss,
+  };
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+      <div className="toast-container" role="region" aria-label="Notifications">
+        {visible.map((toast) => (
+          <ToastItem key={toast.id} toast={toast} onDismiss={dismiss} />
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  );
+};
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: number) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (toast.duration <= 0) return;
+    const timer = setTimeout(() => onDismiss(toast.id), toast.duration);
+    return () => clearTimeout(timer);
+  }, [toast.id, toast.duration, onDismiss]);
+
+  async function handleCopy() {
+    if (!toast.copyText) return;
+    try {
+      await navigator.clipboard.writeText(toast.copyText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className={`toast toast--${toast.type}`} role="alert" data-testid="toast">
+      <span className="toast__icon" aria-hidden="true">
+        {ICONS[toast.type]}
+      </span>
+      <div className="toast__body">
+        {toast.title && <div className="toast__title">{toast.title}</div>}
+        <div className="toast__message">{toast.message}</div>
+        <div className="toast__actions">
+          {toast.onRetry && (
+            <button
+              type="button"
+              className="toast__action"
+              onClick={() => {
+                toast.onRetry?.();
+                onDismiss(toast.id);
+              }}
+            >
+              Retry
+            </button>
+          )}
+          {toast.copyText && (
+            <button type="button" className="toast__action" onClick={handleCopy}>
+              {copied ? "Copied" : "Copy"}
+            </button>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="toast__dismiss"
+        aria-label="Dismiss notification"
+        onClick={() => onDismiss(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export function useNotification(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error("useNotification must be used within NotificationProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/context/NotificationToast.css
+++ b/frontend/src/context/NotificationToast.css
@@ -1,0 +1,117 @@
+/* Notification toasts (#417) — bottom-right, stacked, theme-aware. */
+
+.toast-container {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-width: min(380px, calc(100vw - 2rem));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  border-left: 4px solid var(--toast-accent, #5c7cfa);
+  background: #ffffff;
+  color: #1a1a2e;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  animation: toast-in 0.18s ease-out;
+}
+
+[data-theme="dark"] .toast {
+  background: #1b1b2b;
+  color: #e8e8f0;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+}
+
+.toast--success {
+  --toast-accent: #22c55e;
+}
+.toast--error {
+  --toast-accent: #ef4444;
+}
+.toast--warning {
+  --toast-accent: #f59e0b;
+}
+.toast--info {
+  --toast-accent: #5c7cfa;
+}
+
+.toast__icon {
+  font-weight: 700;
+  color: var(--toast-accent, #5c7cfa);
+  line-height: 1.4;
+}
+
+.toast__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast__title {
+  font-weight: 700;
+  margin-bottom: 0.15rem;
+}
+
+.toast__message {
+  font-size: 0.88rem;
+  /* Long messages wrap rather than truncate. */
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.toast__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.toast__action {
+  background: transparent;
+  border: 1px solid var(--toast-accent, #5c7cfa);
+  color: var(--toast-accent, #5c7cfa);
+  border-radius: 6px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.toast__action:hover {
+  background: var(--toast-accent, #5c7cfa);
+  color: #fff;
+}
+
+.toast__dismiss {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.6;
+  padding: 0 0.2rem;
+}
+
+.toast__dismiss:hover {
+  opacity: 1;
+}
+
+@keyframes toast-in {
+  from {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "./context/ThemeContext";
 import { SettingsProvider } from "./context/SettingsContext";
 import { NetworkProvider } from "./context/NetworkContext";
 import { TransactionProvider } from "./context/TransactionContext";
+import { NotificationProvider } from "./context/NotificationContext";
 import "./modern-styles.css";
 import "./index.css";
 
@@ -16,7 +17,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <NetworkProvider>
           <SettingsProvider>
             <TransactionProvider>
-              <App />
+              <NotificationProvider>
+                <App />
+              </NotificationProvider>
             </TransactionProvider>
           </SettingsProvider>
         </NetworkProvider>


### PR DESCRIPTION
## Summary
Replaces browser alerts with a persistent, themed toast notification system.

Closes #417

## What's included
- **`NotificationProvider` / `useNotification`** — `success` / `error` / `warning` / `info` helpers plus a generic `notify()`.
- **Toast UI** — per-type icon + accent colour, optional **Retry** and **Copy** actions, and a **Dismiss** button. Long messages **wrap** (no truncation); Copy handles long text (e.g. tx hashes).
- **Auto-dismiss after 5s**, configurable per toast (`duration`; `0` = sticky).
- **Bottom-right stacking**, **max 3 visible** with the rest **queued** and promoted as slots free up.
- **Theme-aware** styling via `[data-theme]` (matches the app's dark/light theme).
- Wired `NotificationProvider` into the app root.

## Acceptance criteria
- [x] Toast component with 4 types
- [x] `NotificationContext` provider
- [x] Auto-dismiss after 5s (configurable)
- [x] Action buttons (Retry, Copy, Dismiss)
- [x] Multiple toasts stack
- [x] Styles match dark/light theme
- [x] 4+ notification scenario tests (6)
- [x] Max 3 on screen, queue others
- [x] Copy works for long text

## Tests
Four types render, auto-dismiss after duration, 3-visible cap + queue promotion, Retry runs callback and dismisses, Copy writes to clipboard. **6 passing**; no new type errors.

## Note
The contributor note suggested **Tailwind**, but this repo doesn't use Tailwind (it styles with plain CSS + a `data-theme` `ThemeContext`). I followed the repo's existing conventions instead — a dedicated `NotificationToast.css` with bottom-right positioning and theme-aware selectors — so it stays consistent with the codebase. Easy to port to Tailwind classes if you'd prefer.