### PR TITLE
feat(frontend): add transaction history search & filter UI

### DIFF
--- a/frontend/src/components/TransactionHistory.css
+++ b/frontend/src/components/TransactionHistory.css
@@ -508,3 +508,66 @@
   border-top: 1px solid #e5e7eb;
   color: #4b5563;
 }
+
+/* Transaction filters (#413) */
+.tx-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+.tx-filter-search {
+  flex: 1 1 220px;
+  min-width: 180px;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  background: var(--input-bg, transparent);
+  color: inherit;
+}
+.tx-filter-select {
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  background: var(--input-bg, transparent);
+  color: inherit;
+}
+.tx-filter-clear {
+  padding: 0.45rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.tx-filter-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+.tx-filter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(92, 124, 250, 0.15);
+  color: #5c7cfa;
+}
+.tx-filter-badge button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0;
+}
+.tx-result-count {
+  font-size: 0.82rem;
+  opacity: 0.75;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/components/TransactionHistory.test.tsx
+++ b/frontend/src/components/TransactionHistory.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { TransactionHistory } from "./TransactionHistory";
+import { api } from "../api";
+
+vi.mock("../api", () => ({
+  api: {
+    getTransactionHistory: vi.fn(),
+    getTransactionDetails: vi.fn(),
+  },
+}));
+
+const mockedHistory = api.getTransactionHistory as unknown as ReturnType<typeof vi.fn>;
+
+const DAY = 86_400_000;
+const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+const TXNS = [
+  { id: 1, txHash: "AAAA1111aaaa1111", contractId: "C", type: "distribute", initiatorAddress: "GAAAA", requestedAmount: "100", tokenId: null, timestamp: iso(0), blockTime: null, status: "confirmed", errorMessage: null },
+  { id: 2, txHash: "BBBB2222bbbb2222", contractId: "C", type: "distribute", initiatorAddress: "GBBBB", requestedAmount: "200", tokenId: null, timestamp: iso(10 * DAY), blockTime: null, status: "pending", errorMessage: null },
+  { id: 3, txHash: "CCCC3333cccc3333", contractId: "C", type: "distribute", initiatorAddress: "GAAAA", requestedAmount: "300", tokenId: null, timestamp: iso(40 * DAY), blockTime: null, status: "failed", errorMessage: "boom" },
+  { id: 4, txHash: "AAAA4444aaaa4444", contractId: "C", type: "distribute", initiatorAddress: "GCCCC", requestedAmount: "400", tokenId: null, timestamp: iso(100 * DAY), blockTime: null, status: "confirmed", errorMessage: null },
+  { id: 5, txHash: null, contractId: "C", type: "initialize", initiatorAddress: "GBBBB", requestedAmount: null, tokenId: null, timestamp: iso(0), blockTime: null, status: "pending", errorMessage: null },
+];
+
+function count(): string {
+  return screen.getByTestId("tx-result-count").textContent ?? "";
+}
+
+async function renderHistory() {
+  render(<TransactionHistory contractId="CABC" />);
+  await waitFor(() => expect(screen.getByTestId("tx-result-count")).toBeInTheDocument());
+}
+
+describe("TransactionHistory filters (#413)", () => {
+  beforeEach(() => {
+    mockedHistory.mockReset();
+    mockedHistory.mockResolvedValue({
+      data: TXNS,
+      pagination: { limit: 10, offset: 0, total: 5 },
+    });
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  test("shows the result count out of the server total", async () => {
+    await renderHistory();
+    expect(count()).toBe("5 of 5 transactions");
+  });
+
+  test("filters by transaction hash substring (debounced)", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Search by transaction hash"), {
+      target: { value: "AAAA" },
+    });
+    // Debounced: not applied immediately.
+    expect(count()).toBe("5 of 5 transactions");
+    await waitFor(() => expect(count()).toBe("2 of 5 transactions"));
+  });
+
+  test("filters by status", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "failed" } });
+    expect(count()).toBe("1 of 5 transactions");
+  });
+
+  test("filters by initiator", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by initiator"), { target: { value: "GAAAA" } });
+    expect(count()).toBe("2 of 5 transactions");
+  });
+
+  test("filters by date range (last 7 days)", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by date range"), { target: { value: "7" } });
+    // Only the two "now" transactions fall within 7 days.
+    expect(count()).toBe("2 of 5 transactions");
+  });
+
+  test("combines status and initiator filters", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "confirmed" } });
+    fireEvent.change(screen.getByLabelText("Filter by initiator"), { target: { value: "GAAAA" } });
+    expect(count()).toBe("1 of 5 transactions"); // only tx1
+  });
+
+  test("shows active-filter badges and a single badge can be cleared", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "failed" } });
+    const badges = screen.getByLabelText("Active filters");
+    expect(within(badges).getByText(/Status: failed/)).toBeInTheDocument();
+
+    fireEvent.click(within(badges).getByLabelText("Clear status filter"));
+    expect(count()).toBe("5 of 5 transactions");
+  });
+
+  test("clear-all resets every filter", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "failed" } });
+    fireEvent.change(screen.getByLabelText("Filter by initiator"), { target: { value: "GAAAA" } });
+    expect(count()).toBe("1 of 5 transactions");
+
+    fireEvent.click(screen.getByRole("button", { name: /clear all/i }));
+    expect(count()).toBe("5 of 5 transactions");
+  });
+
+  test("persists filters in the URL query string", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "failed" } });
+    await waitFor(() =>
+      expect(new URLSearchParams(window.location.search).get("status")).toBe("failed"),
+    );
+  });
+
+  test("shows a no-match message when filters exclude everything", async () => {
+    await renderHistory();
+    fireEvent.change(screen.getByLabelText("Filter by initiator"), { target: { value: "GAAAA" } });
+    fireEvent.change(screen.getByLabelText("Filter by status"), { target: { value: "pending" } });
+    expect(count()).toBe("0 of 5 transactions");
+    expect(screen.getByText(/No transactions match your filters/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TransactionHistory.tsx
+++ b/frontend/src/components/TransactionHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { api, TransactionRecord, TransactionDetails } from "../api";
 import "./TransactionHistory.css";
 import { formatNumber } from "../utils/format";
@@ -6,6 +6,20 @@ import { CopyButton } from "./CopyButton";
 
 interface TransactionHistoryProps {
   contractId: string;
+}
+
+type StatusFilter = "" | "pending" | "confirmed" | "failed";
+type RangeFilter = "" | "7" | "30" | "90";
+
+const RANGE_LABELS: Record<Exclude<RangeFilter, "">, string> = {
+  "7": "Last 7 days",
+  "30": "Last 30 days",
+  "90": "Last 90 days",
+};
+
+function readParam(key: string): string {
+  if (typeof window === "undefined") return "";
+  return new URLSearchParams(window.location.search).get(key) ?? "";
 }
 
 export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
@@ -19,6 +33,69 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
   const [selected, setSelected] = useState<TransactionDetails | null>(null);
   const [modalLoading, setModalLoading] = useState(false);
   const LIMIT = 10;
+
+  // ─── Filters (#413) ──────────────────────────────────────────────────────
+  const [search, setSearch] = useState(() => readParam("q"));
+  const [debouncedSearch, setDebouncedSearch] = useState(() => readParam("q"));
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(
+    () => readParam("status") as StatusFilter,
+  );
+  const [initiatorFilter, setInitiatorFilter] = useState(() => readParam("initiator"));
+  const [rangeFilter, setRangeFilter] = useState<RangeFilter>(
+    () => readParam("range") as RangeFilter,
+  );
+
+  // Debounce the hash search (300ms) so we don't filter on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Persist active filters in the URL query string.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const apply = (key: string, value: string) =>
+      value ? params.set(key, value) : params.delete(key);
+    apply("q", debouncedSearch);
+    apply("status", statusFilter);
+    apply("initiator", initiatorFilter);
+    apply("range", rangeFilter);
+    const qs = params.toString();
+    window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
+  }, [debouncedSearch, statusFilter, initiatorFilter, rangeFilter]);
+
+  // Initiator options come from the currently loaded transactions.
+  const initiatorOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const tx of transactions) seen.add(tx.initiatorAddress);
+    return Array.from(seen);
+  }, [transactions]);
+
+  const filtered = useMemo(() => {
+    const q = debouncedSearch.trim().toLowerCase();
+    const days = rangeFilter ? Number(rangeFilter) : 0;
+    const cutoff = days > 0 ? Date.now() - days * 86_400_000 : 0;
+    return transactions.filter((tx) => {
+      if (q && !(tx.txHash ?? "").toLowerCase().includes(q)) return false;
+      if (statusFilter && tx.status !== statusFilter) return false;
+      if (initiatorFilter && tx.initiatorAddress !== initiatorFilter) return false;
+      if (cutoff && new Date(tx.timestamp).getTime() < cutoff) return false;
+      return true;
+    });
+  }, [transactions, debouncedSearch, statusFilter, initiatorFilter, rangeFilter]);
+
+  const hasActiveFilters = Boolean(
+    debouncedSearch || statusFilter || initiatorFilter || rangeFilter,
+  );
+
+  const clearFilters = () => {
+    setSearch("");
+    setDebouncedSearch("");
+    setStatusFilter("");
+    setInitiatorFilter("");
+    setRangeFilter("");
+  };
 
   const fetchHistory = async () => {
     setLoading(true);
@@ -93,6 +170,93 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 
       {transactions.length > 0 && (
         <>
+          <div className="tx-filters" role="search" aria-label="Filter transactions">
+            <input
+              type="text"
+              className="tx-filter-search"
+              placeholder="Search by transaction hash…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              aria-label="Search by transaction hash"
+            />
+            <select
+              className="tx-filter-select"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+              aria-label="Filter by status"
+            >
+              <option value="">All statuses</option>
+              <option value="pending">Pending</option>
+              <option value="confirmed">Confirmed</option>
+              <option value="failed">Failed</option>
+            </select>
+            <select
+              className="tx-filter-select"
+              value={initiatorFilter}
+              onChange={(e) => setInitiatorFilter(e.target.value)}
+              aria-label="Filter by initiator"
+            >
+              <option value="">All initiators</option>
+              {initiatorOptions.map((addr) => (
+                <option key={addr} value={addr}>
+                  {truncateAddress(addr)}
+                </option>
+              ))}
+            </select>
+            <select
+              className="tx-filter-select"
+              value={rangeFilter}
+              onChange={(e) => setRangeFilter(e.target.value as RangeFilter)}
+              aria-label="Filter by date range"
+            >
+              <option value="">All time</option>
+              <option value="7">Last 7 days</option>
+              <option value="30">Last 30 days</option>
+              <option value="90">Last 90 days</option>
+            </select>
+            {hasActiveFilters && (
+              <button type="button" className="tx-filter-clear" onClick={clearFilters}>
+                Clear all
+              </button>
+            )}
+          </div>
+
+          {hasActiveFilters && (
+            <div className="tx-filter-badges" aria-label="Active filters">
+              {debouncedSearch && (
+                <span className="tx-filter-badge">
+                  Hash: {debouncedSearch}
+                  <button type="button" aria-label="Clear hash filter" onClick={() => { setSearch(""); setDebouncedSearch(""); }}>×</button>
+                </span>
+              )}
+              {statusFilter && (
+                <span className="tx-filter-badge">
+                  Status: {statusFilter}
+                  <button type="button" aria-label="Clear status filter" onClick={() => setStatusFilter("")}>×</button>
+                </span>
+              )}
+              {initiatorFilter && (
+                <span className="tx-filter-badge">
+                  Initiator: {truncateAddress(initiatorFilter)}
+                  <button type="button" aria-label="Clear initiator filter" onClick={() => setInitiatorFilter("")}>×</button>
+                </span>
+              )}
+              {rangeFilter && (
+                <span className="tx-filter-badge">
+                  {RANGE_LABELS[rangeFilter]}
+                  <button type="button" aria-label="Clear date filter" onClick={() => setRangeFilter("")}>×</button>
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className="tx-result-count" data-testid="tx-result-count">
+            {filtered.length} of {total} transactions
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="empty-state">No transactions match your filters</div>
+          ) : (
           <div className="transactions-table">
             <table>
               <thead>
@@ -106,7 +270,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
                 </tr>
               </thead>
               <tbody>
-                {transactions.map((tx) => (
+                {filtered.map((tx) => (
                   <tr
                     key={tx.id}
                     className="tx-row-clickable"
@@ -147,6 +311,7 @@ export const TransactionHistory: React.FC<TransactionHistoryProps> = ({
               </tbody>
             </table>
           </div>
+          )}
 
           <div className="pagination">
             <button onClick={() => setOffset(Math.max(0, offset - LIMIT))} disabled={offset === 0}>


### PR DESCRIPTION
## Summary

Adds client-side search and filtering to the Transaction History view (#413).

- **Search by transaction hash** — debounced (300ms) substring match.
- **Status filter** — dropdown (confirmed / pending / failed).
- **Initiator filter** — dropdown built from the unique initiator addresses on the loaded page.
- **Date-range filter** — dropdown (last 7 / 30 / 90 days).
- **Active-filter badges** — each active filter shows a chip with an individual clear (×), plus a *Clear all* action.
- **Result count** — "{matched} of {total} transactions".
- **No-match message** when filters exclude everything.
- **URL persistence** — filter state is reflected in the query string (`q`, `status`, `initiator`, `range`) via `history.replaceState`, so filters survive reloads and can be shared.

## Implementation notes

- Filtering is **client-side over the currently loaded page**; server-side pagination is preserved unchanged.
- The issue mentions a *collaborator* dropdown — the list endpoint only exposes `initiatorAddress` as a participant field, so the dropdown filters by initiator. Happy to extend if the API gains a collaborator field.
- Styling uses the existing plain-CSS approach (`TransactionHistory.css`); no new dependencies.

## Testing

- New `TransactionHistory.test.tsx` with 10 tests covering result count, debounced hash search, status/initiator/date-range filters, combined filters, badges + per-filter and clear-all reset, URL persistence, and the no-match message.
- Full frontend suite: **84 tests passing**, `tsc --noEmit` clean.

Closes #413