### PR TITLE
fix(api): validate legacy redirects against traversal

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -27,6 +27,7 @@ import { initializeSigningKey } from "./signing-key.js";
 import { sendError } from "./error-response.js";
 import { verifyRequestSignatureMiddleware } from "./request-signing.js";
 import { apiKeyRateLimiter } from "./api-key-rate-limit.js";
+import { createLegacyApiRedirectMiddleware } from "./legacy-api-redirect.js";
 
 // #399: Cache and event listener imports
 import { getCacheManager } from "./cache.js";
@@ -72,6 +73,11 @@ app.use((req, res, next) => {
   next();
 });
 
+// Guard raw legacy /api request targets before any route can see them so
+// traversal attempts like /api/%2e%2e/admin are rejected instead of
+// normalizing into a different protected path.
+app.use(createLegacyApiRedirectMiddleware({ logger }));
+
 // Security headers
 app.use(helmet());
 
@@ -108,7 +114,8 @@ const generalLimiter = rateLimit({
   max: parseInt(process.env.RATE_LIMIT_MAX ?? "100"),
   standardHeaders: true,
   legacyHeaders: false,
-  handler: (_req, res) => sendError(res, 429, "too_many_requests", "Too many requests, please try again later."),
+  handler: (_req, res) =>
+    sendError(res, 429, "too_many_requests", "Too many requests, please try again later."),
   skip: (req) => req.path === "/api/v1/health" || req.path === "/api/health",
 });
 
@@ -118,7 +125,8 @@ const writeLimiter = rateLimit({
   max: parseInt(process.env.RATE_LIMIT_WRITE_MAX ?? "10"),
   standardHeaders: true,
   legacyHeaders: false,
-  handler: (_req, res) => sendError(res, 429, "too_many_requests", "Too many write requests, please slow down."),
+  handler: (_req, res) =>
+    sendError(res, 429, "too_many_requests", "Too many write requests, please slow down."),
 });
 
 // Read limiter for history/analytics: 30 req / 1 min per IP (issue #394)
@@ -128,7 +136,12 @@ const readAnalyticsLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (_req, res) =>
-    sendError(res, 429, "too_many_requests", "Too many analytics/history requests, please slow down."),
+    sendError(
+      res,
+      429,
+      "too_many_requests",
+      "Too many analytics/history requests, please slow down."
+    ),
 });
 
 app.use(generalLimiter);
@@ -199,15 +212,11 @@ const adminLimiter = rateLimit({
   max: parseInt(process.env.RATE_LIMIT_ADMIN_MAX ?? "5"),
   standardHeaders: true,
   legacyHeaders: false,
-  handler: (_req, res) => sendError(res, 429, "too_many_requests", "Too many admin requests, please slow down."),
+  handler: (_req, res) =>
+    sendError(res, 429, "too_many_requests", "Too many admin requests, please slow down."),
 });
 app.use("/admin", adminLimiter);
 app.use("/admin", adminRouter);
-
-// Legacy /api/* redirect to /api/v1/*
-app.use("/api", (req, res) => {
-  res.redirect(308, `/api/v1${req.url}`);
-});
 
 // Central error handler
 app.use((err, req, res, _next) => {

--- a/backend/src/legacy-api-redirect.js
+++ b/backend/src/legacy-api-redirect.js
@@ -1,0 +1,160 @@
+import { sendError } from "./error-response.js";
+
+const LEGACY_API_PREFIX = "/api";
+
+export const LEGACY_API_ALLOWED_ROOT_SEGMENTS = new Set([
+  "analytics",
+  "audit",
+  "collaborators",
+  "contract",
+  "distribute",
+  "health",
+  "history",
+  "initialize",
+  "metrics",
+  "secondary-royalty",
+  "simulate",
+  "transaction",
+  "webhooks",
+]);
+
+function buildRequestUrl(requestTarget) {
+  const normalizedRequestTarget = requestTarget.startsWith("/")
+    ? requestTarget
+    : `/${requestTarget}`;
+  const parsedUrl = new URL(normalizedRequestTarget, "http://legacy-api.local");
+  const rawPath = normalizedRequestTarget.slice(
+    0,
+    normalizedRequestTarget.length - parsedUrl.search.length
+  );
+
+  return {
+    parsedUrl,
+    rawPath,
+  };
+}
+
+function collectDecodedPathVariants(rawPath, maxPasses = 3) {
+  const variants = [];
+  let current = rawPath;
+
+  for (let index = 0; index < maxPasses; index += 1) {
+    variants.push(current);
+
+    try {
+      const decoded = decodeURIComponent(current);
+      if (decoded === current) {
+        return { malformedEncoding: false, variants };
+      }
+      current = decoded;
+    } catch {
+      return { malformedEncoding: true, variants };
+    }
+  }
+
+  variants.push(current);
+  return { malformedEncoding: false, variants };
+}
+
+function containsTraversalSegment(pathname) {
+  return pathname
+    .replaceAll("\\", "/")
+    .split("/")
+    .some((segment) => segment === "..");
+}
+
+function getLegacyRootSegment(normalizedPathname) {
+  if (normalizedPathname === LEGACY_API_PREFIX) {
+    return "";
+  }
+
+  if (!normalizedPathname.startsWith(`${LEGACY_API_PREFIX}/`)) {
+    return null;
+  }
+
+  return normalizedPathname.slice(LEGACY_API_PREFIX.length + 1).split("/")[0] ?? "";
+}
+
+export function validateLegacyApiRequestTarget(requestTarget) {
+  const { parsedUrl, rawPath } = buildRequestUrl(requestTarget);
+  const { malformedEncoding, variants } = collectDecodedPathVariants(rawPath);
+
+  if (malformedEncoding) {
+    return {
+      allowed: false,
+      normalizedPathname: parsedUrl.pathname,
+      reason: "malformed_encoding",
+    };
+  }
+
+  if (variants.some(containsTraversalSegment)) {
+    return {
+      allowed: false,
+      normalizedPathname: parsedUrl.pathname,
+      reason: "path_traversal",
+    };
+  }
+
+  const rootSegment = getLegacyRootSegment(parsedUrl.pathname);
+
+  if (rootSegment == null) {
+    return {
+      allowed: false,
+      normalizedPathname: parsedUrl.pathname,
+      reason: "invalid_prefix",
+    };
+  }
+
+  if (rootSegment !== "" && !LEGACY_API_ALLOWED_ROOT_SEGMENTS.has(rootSegment)) {
+    return {
+      allowed: false,
+      normalizedPathname: parsedUrl.pathname,
+      reason: "disallowed_path",
+      rootSegment,
+    };
+  }
+
+  const redirectPath =
+    parsedUrl.pathname === LEGACY_API_PREFIX
+      ? "/api/v1"
+      : `/api/v1${parsedUrl.pathname.slice(LEGACY_API_PREFIX.length)}`;
+
+  return {
+    allowed: true,
+    normalizedPathname: parsedUrl.pathname,
+    redirectTarget: `${redirectPath}${parsedUrl.search}`,
+    rootSegment,
+  };
+}
+
+export function createLegacyApiRedirectMiddleware({ logger } = {}) {
+  return (req, res, next) => {
+    if (req.originalUrl === "/api/v1" || req.originalUrl.startsWith("/api/v1/")) {
+      return next();
+    }
+
+    if (
+      req.originalUrl !== LEGACY_API_PREFIX &&
+      !req.originalUrl.startsWith(`${LEGACY_API_PREFIX}/`)
+    ) {
+      return next();
+    }
+
+    const validation = validateLegacyApiRequestTarget(req.originalUrl);
+
+    if (!validation.allowed) {
+      logger?.warn?.("Rejected legacy API redirect target", {
+        correlationId: req.correlationId,
+        ip: req.ip,
+        method: req.method,
+        normalizedPathname: validation.normalizedPathname,
+        path: req.originalUrl,
+        reason: validation.reason,
+      });
+
+      return sendError(res, 400, "invalid_legacy_api_path", "Invalid legacy API path.");
+    }
+
+    return res.redirect(308, validation.redirectTarget);
+  };
+}

--- a/backend/tests/legacy-api-redirect.test.js
+++ b/backend/tests/legacy-api-redirect.test.js
@@ -1,0 +1,187 @@
+import express from "express";
+import http from "node:http";
+import net from "node:net";
+import request from "supertest";
+import { describe, expect, jest, test } from "@jest/globals";
+import {
+  createLegacyApiRedirectMiddleware,
+  validateLegacyApiRequestTarget,
+} from "../src/legacy-api-redirect.js";
+
+function createApp() {
+  const logger = {
+    warn: jest.fn(),
+  };
+
+  const app = express();
+  app.use(createLegacyApiRedirectMiddleware({ logger }));
+  app.get("/admin", (_req, res) => {
+    res.status(200).json({ area: "admin" });
+  });
+  app.get("/api/v1/health", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  return { app, logger };
+}
+
+function sendRawHttpRequest(app, requestTarget) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+
+    server.listen(0, () => {
+      const { port } = server.address();
+      const client = net.createConnection({ port }, () => {
+        client.write(
+          `GET ${requestTarget} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`
+        );
+      });
+
+      const chunks = [];
+
+      client.on("data", (chunk) => {
+        chunks.push(chunk);
+      });
+
+      client.on("error", (error) => {
+        server.close(() => reject(error));
+      });
+
+      client.on("end", () => {
+        server.close(() => {
+          const rawResponse = Buffer.concat(chunks).toString("utf8");
+          const [head, body = ""] = rawResponse.split("\r\n\r\n");
+          const [statusLine, ...headerLines] = head.split("\r\n");
+          const headers = {};
+
+          for (const line of headerLines) {
+            const separatorIndex = line.indexOf(":");
+            if (separatorIndex === -1) continue;
+
+            const key = line.slice(0, separatorIndex).trim().toLowerCase();
+            const value = line.slice(separatorIndex + 1).trim();
+            headers[key] = value;
+          }
+
+          resolve({
+            body,
+            headers,
+            statusCode: Number.parseInt(statusLine.split(" ")[1], 10),
+          });
+        });
+      });
+    });
+  });
+}
+
+describe("legacy API redirect security", () => {
+  test("redirects allowlisted legacy API paths to /api/v1", async () => {
+    const { app, logger } = createApp();
+
+    const response = await request(app).get("/api/health?full=true");
+
+    expect(response.status).toBe(308);
+    expect(response.headers.location).toBe("/api/v1/health?full=true");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("does not interfere with already-versioned API routes", async () => {
+    const { app, logger } = createApp();
+
+    const response = await request(app).get("/api/v1/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  test("rejects legacy paths outside the allowlist so admin does not redirect", async () => {
+    const { app, logger } = createApp();
+
+    const response = await request(app).get("/api/admin");
+
+    expect(response.status).toBe(400);
+    expect(response.headers.location).toBeUndefined();
+    expect(response.body.code).toBe("invalid_legacy_api_path");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Rejected legacy API redirect target",
+      expect.objectContaining({
+        path: "/api/admin",
+        reason: "disallowed_path",
+      })
+    );
+  });
+
+  test("rejects raw encoded traversal attempts before they can reach /admin", async () => {
+    const { app, logger } = createApp();
+
+    const response = await sendRawHttpRequest(app, "/api/%2e%2e/admin");
+    const payload = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.headers.location).toBeUndefined();
+    expect(payload.code).toBe("invalid_legacy_api_path");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Rejected legacy API redirect target",
+      expect.objectContaining({
+        path: "/api/%2e%2e/admin",
+        reason: "path_traversal",
+      })
+    );
+  });
+
+  test("rejects traversal attempts encoded as an escaped slash", () => {
+    const result = validateLegacyApiRequestTarget("/api/..%2fadmin");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reason: "path_traversal",
+      })
+    );
+  });
+
+  test("rejects traversal attempts encoded as a full ../ sequence", () => {
+    const result = validateLegacyApiRequestTarget("/api/%2e%2e%2fadmin");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reason: "path_traversal",
+      })
+    );
+  });
+
+  test("rejects double-encoded traversal attempts after repeated decoding", () => {
+    const result = validateLegacyApiRequestTarget("/api/%252e%252e/admin");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reason: "path_traversal",
+      })
+    );
+  });
+
+  test("rejects uppercase encoded traversal attempts", () => {
+    const result = validateLegacyApiRequestTarget("/api/%2E%2E/admin");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reason: "path_traversal",
+      })
+    );
+  });
+
+  test("rejects malformed encoded paths instead of redirecting them", () => {
+    const result = validateLegacyApiRequestTarget("/api/%E0%A4%A");
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        allowed: false,
+        reason: "malformed_encoding",
+      })
+    );
+  });
+});


### PR DESCRIPTION
Closes #465

## Summary
- add a dedicated legacy `/api` redirect validator and middleware
- validate redirect targets with `URL` parsing before redirecting to `/api/v1/*`
- reject traversal and malformed paths instead of redirecting them
- enforce a top-level allowlist for legacy API routes
- log suspected traversal and invalid redirect attempts
- add security coverage for raw and encoded traversal payloads

## Why
The legacy `/api/*` redirect previously forwarded `req.url` directly to `/api/v1/*`. That allowed crafted paths such as `/api/../admin` or encoded traversal variants to normalize into protected paths and weaken path-based access control assumptions.

## Security Notes
- traversal patterns like `%2e%2e`, `..%2f`, `%2e%2e%2f`, and double-encoded variants are rejected with `400`
- malformed encoded paths are rejected instead of redirected
- only allowlisted legacy roots can redirect
- blocked attempts are logged with `logger.warn`
- existing `/api/v1/*` routes are explicitly left untouched

## Validation
- targeted security suite passed: `9/9`
- includes raw HTTP coverage for `/api/%2e%2e/admin`
- targeted lint on touched source files passed without errors

## Repo Notes
The full backend test and lint runs currently have unrelated pre-existing failures in this repo, including Jest ESM `module is already linked` errors, missing `ioredis`, and existing lint errors in `src/routes/initialize.js`.