### PR TITLE
fix: atomic secondary distribution, idempotency keys, and API error docs

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -613,3 +613,181 @@ The limiter uses a true sliding window (a per-key timestamp log, not a fixed-win
 | -------- | ------- | ------- |
 | `API_KEY_RATE_LIMIT_WINDOW_MS` | `60000` (1 minute) | Sliding window size |
 | `API_KEY_RATE_LIMIT_MAX` | `60` | Max requests per key per window |
+
+## Error Reference (#470)
+
+All error responses share a common envelope:
+
+```json
+{
+  "status": 400,
+  "code": "validation_error",
+  "message": "Human-readable description of what went wrong.",
+  "error": "Human-readable description of what went wrong.",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+`code` is a machine-readable string clients can switch on. `message` and `error` carry the same value and are both present for backwards compatibility.
+
+### Error code enum
+
+| Code | HTTP status | Meaning |
+| ---- | ----------- | ------- |
+| `bad_request` | 400 | The request body or parameters are malformed or logically invalid. |
+| `validation_error` | 400 | Schema validation failed; a `details` array is included with per-field errors. |
+| `invalid_idempotency_key` | 400 | `Idempotency-Key` header value contains disallowed characters or exceeds 255 chars. |
+| `invalid_sale_price` | 400 | Secondary-royalty sale price is zero or negative. |
+| `invalid_royalty_rate` | 400 | Royalty rate is outside the allowed `0`–`10000` basis-point range. |
+| `invalid_collaborators` | 400 | Collaborator `basisPoints` values do not sum to exactly 10000. |
+| `invalid_query_parameter` | 400 | A query-string value (e.g. `startDate`, `endDate`) is invalid. |
+| `unauthorized` | 401 | Request signing verification failed or no valid session. |
+| `auth_error` | 401 | Authentication error (missing or invalid credentials). |
+| `invalid_api_key` | 401 | The `X-API-Key` header is missing, unknown, or revoked. |
+| `forbidden` | 403 | Authenticated but not permitted to perform this action. |
+| `not_found` | 404 | The requested resource does not exist. |
+| `method_not_allowed` | 405 | HTTP method not allowed on this endpoint. |
+| `conflict` | 409 | Duplicate request: the resource already exists or has already been processed. |
+| `gone` | 410 | The resource existed but has been permanently removed. |
+| `payload_too_large` | 413 | Request body exceeds the 10 KB limit. |
+| `unsupported_media_type` | 415 | `Content-Type` must be `application/json`. |
+| `unprocessable_entity` | 422 | Request is syntactically valid but semantically unprocessable. |
+| `too_many_requests` | 429 | Per-IP or per-API-key rate limit exceeded. |
+| `internal_server_error` | 500 | Unexpected server-side error. |
+| `database_error` | 500 | A database operation failed. |
+| `not_implemented` | 501 | Feature not yet implemented. |
+| `service_unavailable` | 503 | Stellar RPC or Horizon is unreachable. |
+| `gateway_timeout` | 504 | Stellar RPC or Horizon did not respond within the configured timeout. |
+| `contract_error` | 400/500 | The Soroban contract rejected the call or returned an unexpected error. |
+| `webhook_error` | 400/500 | Webhook registration or delivery operation failed. |
+
+### HTTP status code reference
+
+| Status | When it appears |
+| ------ | --------------- |
+| `200 OK` | Success. |
+| `400 Bad Request` | Validation failure, bad parameters, or domain-rule violation. |
+| `401 Unauthorized` | Missing or invalid authentication (signing headers, API key). |
+| `403 Forbidden` | Authenticated but not authorized. |
+| `404 Not Found` | Resource does not exist. |
+| `405 Method Not Allowed` | Wrong HTTP verb. |
+| `409 Conflict` | Duplicate request (nonce already used, sale already recorded, transaction already settled). |
+| `410 Gone` | Resource permanently removed. |
+| `413 Payload Too Large` | Body exceeds 10 KB. |
+| `415 Unsupported Media Type` | Missing or wrong `Content-Type`. |
+| `422 Unprocessable Entity` | Semantically invalid request. |
+| `429 Too Many Requests` | Rate limit hit (per-IP or per-API-key). |
+| `500 Internal Server Error` | Unhandled exception, database failure. |
+| `501 Not Implemented` | Feature not available. |
+| `503 Service Unavailable` | Stellar RPC / Horizon unreachable. |
+| `504 Gateway Timeout` | Stellar RPC / Horizon response timed out. |
+
+### Example error responses
+
+**Validation failure (400)**
+
+```json
+{
+  "status": 400,
+  "code": "validation_error",
+  "message": "walletAddress must be a valid Stellar address",
+  "error": "walletAddress must be a valid Stellar address",
+  "timestamp": "2026-06-01T12:00:00.000Z",
+  "details": [
+    { "field": "walletAddress", "message": "walletAddress must be a valid Stellar address", "constraint": null }
+  ]
+}
+```
+
+**Rate limit exceeded (429)**
+
+```json
+{
+  "status": 429,
+  "code": "too_many_requests",
+  "message": "Too many requests, please try again later.",
+  "error": "Too many requests, please try again later.",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+Headers on a 429 from the API-key limiter:
+
+| Header | Meaning |
+| ------ | ------- |
+| `X-RateLimit-Limit` | Max requests per window for this key |
+| `X-RateLimit-Remaining` | Requests remaining (`0` on 429) |
+| `X-RateLimit-Reset` | Unix seconds when the window resets |
+
+**Invalid idempotency key (400)**
+
+```json
+{
+  "status": 400,
+  "code": "invalid_idempotency_key",
+  "message": "Invalid Idempotency-Key format. Must be 1-255 alphanumeric characters, hyphens, or underscores.",
+  "error": "Invalid Idempotency-Key format. Must be 1-255 alphanumeric characters, hyphens, or underscores.",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+**Conflict — duplicate nonce (409)**
+
+```json
+{
+  "status": 409,
+  "code": "conflict",
+  "message": "A request with this nonce has already been processed for this contract.",
+  "error": "A request with this nonce has already been processed for this contract.",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+**Stellar RPC timeout (504)**
+
+```json
+{
+  "status": 504,
+  "code": "gateway_timeout",
+  "message": "Soroban RPC timed out after 10000ms",
+  "error": "Soroban RPC timed out after 10000ms",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+**Service unavailable (503)**
+
+```json
+{
+  "status": 503,
+  "code": "service_unavailable",
+  "message": "Stellar RPC is currently unavailable",
+  "error": "Stellar RPC is currently unavailable",
+  "timestamp": "2026-06-01T12:00:00.000Z"
+}
+```
+
+### Retry policy
+
+| Code / Status | Retry? | Strategy |
+| ------------- | ------ | -------- |
+| `validation_error` / 400 | No | Fix the request before retrying. |
+| `bad_request` / 400 | No | Fix the request before retrying. |
+| `unauthorized` / 401 | After re-auth | Re-authenticate (rotate key or reconnect wallet), then retry once. |
+| `forbidden` / 403 | No | Retrying will not change the outcome. |
+| `not_found` / 404 | No | The resource does not exist. |
+| `conflict` / 409 | No | The operation already completed or the resource already exists. |
+| `too_many_requests` / 429 | Yes | Wait until `X-RateLimit-Reset`, then retry with exponential backoff. |
+| `internal_server_error` / 500 | Yes | Retry up to 3 times with exponential backoff (e.g. 1 s, 2 s, 4 s). |
+| `service_unavailable` / 503 | Yes | Retry with backoff; the Stellar network may be temporarily degraded. |
+| `gateway_timeout` / 504 | Yes | Retry with backoff; use an `Idempotency-Key` to prevent duplicate submissions. |
+
+### Client error-handling guide
+
+1. **Always send `Content-Type: application/json`** on POST/PUT/DELETE requests.
+2. **Parse `code`**, not `status`, for programmatic error handling — HTTP status codes can overlap across error types.
+3. **Use `Idempotency-Key`** on `/distribute` and `/secondary-royalty/distribute` before any retry. Generate the key once (`crypto.randomUUID()`) and reuse it on each retry attempt so the server returns the cached first-success response instead of creating a duplicate transaction.
+4. **Do not retry 4xx errors** (except 429) — they indicate a request problem that retrying will not fix.
+5. **Back off exponentially** on 429, 500, 503, and 504 responses. Start with a 1-second delay and double on each retry, up to a maximum of 30 seconds.
+6. **Check `details`** on `validation_error` (400) — the array identifies which fields failed and why, enabling targeted error messages in the UI.
+7. **Re-authenticate on 401** — the signing session or API key may have expired or been revoked.

--- a/backend/src/database/index.js
+++ b/backend/src/database/index.js
@@ -56,6 +56,7 @@ export {
   getSecondaryRoyaltyDistributions,
   getRoyaltyStatistics,
   applyLargestRemainder,
+  commitSecondaryDistributionAtomic,
 } from "./secondary-royalties.js";
 
 // Analytics

--- a/backend/src/database/secondary-royalties.js
+++ b/backend/src/database/secondary-royalties.js
@@ -4,6 +4,8 @@
  */
 
 import { db, countWrite } from "./core.js";
+import { addAuditLog } from "./audit.js";
+import { recordTransaction } from "./transactions.js";
 
 // ---------------------------------------------------------------------------
 // Largest-remainder rounding algorithm (#427)
@@ -254,6 +256,71 @@ export function getSecondaryRoyaltyDistributions(contractId, limit = 50, offset 
 
   return stmt.all(contractId, limit, offset);
 }
+
+/**
+ * Atomically record a secondary distribution: insert the transaction row,
+ * mark all pending sales as distributed, insert the distribution record, and
+ * write the audit log entries — all inside a single SQLite transaction (#471).
+ *
+ * If any step throws, the entire transaction is rolled back, preventing
+ * orphaned pending-sale rows when the Stellar XDR is already built.
+ *
+ * @param {object} params
+ * @param {string}  params.contractId
+ * @param {string}  params.walletAddress
+ * @param {bigint}  params.totalRoyalties
+ * @param {number}  params.numberOfSales
+ * @param {number[]} params.pendingSaleIds
+ * @param {bigint}  params.totalDustAllocated
+ * @param {object|null} params.dustAuditData  — null when no dust was allocated
+ * @returns {number} transactionId
+ */
+export const commitSecondaryDistributionAtomic = db.transaction(
+  ({
+    contractId,
+    walletAddress,
+    totalRoyalties,
+    numberOfSales,
+    pendingSaleIds,
+    totalDustAllocated,
+    dustAuditData,
+  }) => {
+    const transactionId = recordTransaction(
+      contractId,
+      "secondary_distribute",
+      walletAddress,
+      { totalRoyalties: totalRoyalties.toString(), numberOfSales }
+    );
+
+    markSalesDistributed(pendingSaleIds);
+
+    recordSecondaryRoyaltyDistribution(
+      transactionId,
+      contractId,
+      totalRoyalties.toString(),
+      numberOfSales,
+      totalDustAllocated
+    );
+
+    if (dustAuditData) {
+      addAuditLog(
+        contractId,
+        "secondary_distribution_dust_allocated",
+        walletAddress,
+        dustAuditData
+      );
+    }
+
+    addAuditLog(contractId, "secondary_distribution_initiated", walletAddress, {
+      transactionId,
+      numberOfSales,
+      totalRoyalties: totalRoyalties.toString(),
+      dustAllocated: totalDustAllocated.toString(),
+    });
+
+    return transactionId;
+  }
+);
 
 /**
  * Get royalty statistics for a contract.

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -11,15 +11,15 @@ import {
 import {
   recordTransaction,
   recordSecondarySale,
-  recordSecondaryRoyaltyDistribution,
   getSecondarySales,
   getSecondaryRoyaltyDistributions,
   getRoyaltyStatistics,
-  markSalesDistributed,
   countSecondarySales,
   addAuditLog,
   applyLargestRemainder,
+  commitSecondaryDistributionAtomic,
 } from "../database/index.js";
+import { idempotencyMiddleware } from "../idempotency.js";
 import {
   validate,
   recordSecondarySaleSchema,
@@ -58,7 +58,7 @@ secondaryRoyaltyRouter.get("/pool/:contractId", validateContractIdMiddleware, as
  * Body: { contractId, walletAddress, nftId, previousOwner, newOwner, salePrice, saleToken, royaltyRate }
  * Returns: { xdr, transactionId, royaltyAmount }
  */
-secondaryRoyaltyRouter.post("/", validate(recordSecondarySaleSchema), async (req, res, next) => {
+secondaryRoyaltyRouter.post("/", idempotencyMiddleware, validate(recordSecondarySaleSchema), async (req, res, next) => {
   try {
     const {
       contractId,
@@ -224,104 +224,94 @@ secondaryRoyaltyRouter.get("/rate/:contractId", async (req, res, next) => {
  * deterministically allocated to collaborators with the largest fractional share.
  * Returns: { xdr, transactionId } — unsigned transaction to distribute secondary royalties
  */
-secondaryRoyaltyRouter.post("/distribute", validate(distributeSecondarySchema), async (req, res, next) => {
-  try {
-    const { contractId, walletAddress, tokenId, collaborators } = req.body;
+secondaryRoyaltyRouter.post(
+  "/distribute",
+  idempotencyMiddleware,
+  validate(distributeSecondarySchema),
+  async (req, res, next) => {
+    try {
+      const { contractId, walletAddress, tokenId, collaborators } = req.body;
 
-    // Get pending (undistributed) secondary sales
-    const pendingSales = getSecondarySales(contractId, 1000, 0, null, true);
+      // Get pending (undistributed) secondary sales
+      const pendingSales = getSecondarySales(contractId, 1000, 0, null, true);
 
-    if (pendingSales.length === 0) {
-      return sendError(res, 400, "bad_request", "No pending secondary royalties to distribute.");
-    }
-
-    // Calculate total royalties (BigInt for precision)
-    const totalRoyalties = pendingSales.reduce((sum, sale) => {
-      return sum + BigInt(sale.royaltyAmount);
-    }, 0n);
-
-    // ---------------------------------------------------------------------------
-    // #427: Apply largest-remainder rounding when collaborator shares are provided
-    // ---------------------------------------------------------------------------
-    let roundingAllocations = null;
-    let totalDustAllocated = 0n;
-
-    if (Array.isArray(collaborators) && collaborators.length > 0) {
-      // Validate that basis points sum to exactly 10000
-      const bpSum = collaborators.reduce((s, c) => s + (c.basisPoints ?? 0), 0);
-      if (bpSum !== 10000) {
-        return sendError(
-          res,
-          400,
-          "invalid_collaborators",
-          `collaborators basisPoints must sum to 10000, got ${bpSum}.`
-        );
+      if (pendingSales.length === 0) {
+        return sendError(res, 400, "bad_request", "No pending secondary royalties to distribute.");
       }
 
-      // Apply largest-remainder algorithm — guarantees SUM === totalRoyalties
-      roundingAllocations = applyLargestRemainder(totalRoyalties, collaborators);
-      totalDustAllocated = roundingAllocations.reduce((s, a) => s + a.dustReceived, 0n);
+      // Calculate total royalties (BigInt for precision)
+      const totalRoyalties = pendingSales.reduce((sum, sale) => {
+        return sum + BigInt(sale.royaltyAmount);
+      }, 0n);
 
-      // Log the rounding decisions for debugging (#427 requirement)
-      if (totalDustAllocated > 0n) {
-        const dustRecipients = roundingAllocations
-          .filter((a) => a.dustReceived > 0n)
-          .map((a) => ({ address: a.address, dust: a.dustReceived.toString() }));
-        // logger is not imported in this file; use console-style log via audit
-        addAuditLog(contractId, "secondary_distribution_dust_allocated", walletAddress, {
-          totalDust: totalDustAllocated.toString(),
-          dustRecipients,
-        });
+      // ---------------------------------------------------------------------------
+      // #427: Apply largest-remainder rounding when collaborator shares are provided
+      // ---------------------------------------------------------------------------
+      let roundingAllocations = null;
+      let totalDustAllocated = 0n;
+      let dustAuditData = null;
+
+      if (Array.isArray(collaborators) && collaborators.length > 0) {
+        const bpSum = collaborators.reduce((s, c) => s + (c.basisPoints ?? 0), 0);
+        if (bpSum !== 10000) {
+          return sendError(
+            res,
+            400,
+            "invalid_collaborators",
+            `collaborators basisPoints must sum to 10000, got ${bpSum}.`
+          );
+        }
+
+        roundingAllocations = applyLargestRemainder(totalRoyalties, collaborators);
+        totalDustAllocated = roundingAllocations.reduce((s, a) => s + a.dustReceived, 0n);
+
+        if (totalDustAllocated > 0n) {
+          dustAuditData = {
+            totalDust: totalDustAllocated.toString(),
+            dustRecipients: roundingAllocations
+              .filter((a) => a.dustReceived > 0n)
+              .map((a) => ({ address: a.address, dust: a.dustReceived.toString() })),
+          };
+        }
       }
+
+      // Build the Stellar XDR *before* any DB writes so that a Stellar failure
+      // never leaves sales in an inconsistent state (#471).
+      const txXdr = await buildTx(walletAddress, contractId, "distribute_secondary_royalties", [
+        addressToScVal(tokenId),
+      ]);
+
+      // All DB writes are atomic: if any step fails, the transaction rolls back
+      // and pending sales remain undistributed (#471).
+      const transactionId = commitSecondaryDistributionAtomic({
+        contractId,
+        walletAddress,
+        totalRoyalties,
+        numberOfSales: pendingSales.length,
+        pendingSaleIds: pendingSales.map((s) => s.id),
+        totalDustAllocated,
+        dustAuditData,
+      });
+
+      res.json({
+        xdr: txXdr,
+        transactionId,
+        numberOfSales: pendingSales.length,
+        totalRoyalties: totalRoyalties.toString(),
+        dustAllocated: totalDustAllocated.toString(),
+        ...(roundingAllocations && {
+          allocations: roundingAllocations.map((a) => ({
+            address: a.address,
+            amount: a.amount.toString(),
+            dustReceived: a.dustReceived.toString(),
+          })),
+        }),
+      });
+    } catch (err) {
+      next(err);
     }
-
-    const transactionId = recordTransaction(contractId, "secondary_distribute", walletAddress, {
-      totalRoyalties: totalRoyalties.toString(),
-      numberOfSales: pendingSales.length,
-    });
-
-    // Build transaction to distribute secondary royalties
-    const txXdr = await buildTx(walletAddress, contractId, "distribute_secondary_royalties", [
-      addressToScVal(tokenId),
-    ]);
-
-    // Mark sales as distributed
-    markSalesDistributed(pendingSales.map((s) => s.id));
-
-    // Record the distribution, including dust for analytics (#427)
-    recordSecondaryRoyaltyDistribution(
-      transactionId,
-      contractId,
-      totalRoyalties.toString(),
-      pendingSales.length,
-      totalDustAllocated
-    );
-
-    addAuditLog(contractId, "secondary_distribution_initiated", walletAddress, {
-      transactionId,
-      numberOfSales: pendingSales.length,
-      totalRoyalties: totalRoyalties.toString(),
-      dustAllocated: totalDustAllocated.toString(),
-    });
-
-    res.json({
-      xdr: txXdr,
-      transactionId,
-      numberOfSales: pendingSales.length,
-      totalRoyalties: totalRoyalties.toString(),
-      dustAllocated: totalDustAllocated.toString(),
-      ...(roundingAllocations && {
-        allocations: roundingAllocations.map((a) => ({
-          address: a.address,
-          amount: a.amount.toString(),
-          dustReceived: a.dustReceived.toString(),
-        })),
-      }),
-    });
-  } catch (err) {
-    next(err);
   }
-});
+);
 
 /**
  * GET /api/secondary-royalty/stats/:contractId

--- a/backend/tests/secondary-royalty-atomic.test.js
+++ b/backend/tests/secondary-royalty-atomic.test.js
@@ -1,0 +1,172 @@
+/**
+ * Tests for atomic secondary royalty distribution (#471).
+ *
+ * Verifies that all database writes (transaction record, mark-sales-distributed,
+ * distribution record, and audit logs) occur as a single atomic operation, and
+ * that the Stellar XDR is built BEFORE any DB writes so that a Stellar failure
+ * never leaves sales in an inconsistent state.
+ */
+
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import request from "supertest";
+
+// --- Stellar mock ---------------------------------------------------------
+const buildTx = jest.fn();
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  buildTx,
+  retryBuildTx: jest.fn(),
+  addressToScVal: jest.fn((a) => a),
+  i128ToScVal: jest.fn((n) => n),
+  u32ToScVal: jest.fn((n) => n),
+  getRoyaltyRateFromContract: jest.fn(),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+// --- Database mock --------------------------------------------------------
+const getSecondarySales = jest.fn();
+const commitSecondaryDistributionAtomic = jest.fn();
+const applyLargestRemainder = jest.fn();
+const recordTransaction = jest.fn(() => 1);
+const recordSecondarySale = jest.fn();
+const addAuditLog = jest.fn();
+const getRoyaltyStatistics = jest.fn();
+const getSecondaryRoyaltyDistributions = jest.fn();
+const countSecondarySales = jest.fn();
+const initializeDatabase = jest.fn();
+const getMigrationVersion = jest.fn(() => 7);
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  getSecondarySales,
+  commitSecondaryDistributionAtomic,
+  applyLargestRemainder,
+  recordTransaction,
+  recordSecondarySale,
+  addAuditLog,
+  getRoyaltyStatistics,
+  getSecondaryRoyaltyDistributions,
+  countSecondarySales,
+  initializeDatabase,
+  getMigrationVersion,
+}));
+
+// --- Build test app after mocks ------------------------------------------
+const express = (await import("express")).default;
+const { secondaryRoyaltyRouter } = await import("../src/routes/secondary-royalty.js");
+
+const app = express();
+app.use(express.json({ limit: "10kb" }));
+app.use("/api/v1/secondary-royalty", secondaryRoyaltyRouter);
+app.use((err, _req, res, _next) => {
+  res.status(err.status || 500).json({ error: err.message ?? "Internal server error" });
+});
+
+// --- Constants -----------------------------------------------------------
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET  = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN   = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+const PENDING_SALES = [
+  { id: 1, royaltyAmount: "100" },
+  { id: 2, royaltyAmount: "200" },
+];
+
+const VALID_BODY = { contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN };
+
+// =========================================================================
+
+describe("POST /api/v1/secondary-royalty/distribute — atomic DB commit (#471)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSecondarySales.mockReturnValue(PENDING_SALES);
+    buildTx.mockResolvedValue("distribute-xdr");
+    commitSecondaryDistributionAtomic.mockReturnValue(42);
+  });
+
+  test("1. successful distribution: commitSecondaryDistributionAtomic called after buildTx", async () => {
+    const callOrder = [];
+    buildTx.mockImplementation(async () => {
+      callOrder.push("buildTx");
+      return "dist-xdr";
+    });
+    commitSecondaryDistributionAtomic.mockImplementation((params) => {
+      callOrder.push("commit");
+      return 42;
+    });
+
+    const res = await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      xdr: "dist-xdr",
+      transactionId: 42,
+      numberOfSales: 2,
+    });
+    // XDR must be built before any DB writes
+    expect(callOrder).toEqual(["buildTx", "commit"]);
+  });
+
+  test("2. Stellar failure prevents any DB writes", async () => {
+    buildTx.mockRejectedValue(new Error("Stellar RPC unavailable"));
+
+    const res = await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(res.status).toBe(500);
+    // The atomic commit must NEVER be called when buildTx fails
+    expect(commitSecondaryDistributionAtomic).not.toHaveBeenCalled();
+  });
+
+  test("3. DB commit failure propagates as 500 and does not send a partial response", async () => {
+    commitSecondaryDistributionAtomic.mockImplementation(() => {
+      throw new Error("SQLITE constraint violation");
+    });
+
+    const res = await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/SQLITE constraint violation/);
+    // buildTx was called (XDR was built) but the route never returned 200
+    expect(buildTx).toHaveBeenCalledTimes(1);
+  });
+
+  test("4. no pending sales returns 400 before buildTx or commit are called", async () => {
+    getSecondarySales.mockReturnValue([]);
+
+    const res = await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/No pending secondary royalties/);
+    expect(buildTx).not.toHaveBeenCalled();
+    expect(commitSecondaryDistributionAtomic).not.toHaveBeenCalled();
+  });
+
+  test("5. commitSecondaryDistributionAtomic receives correct sale IDs and totals", async () => {
+    await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(commitSecondaryDistributionAtomic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractId: CONTRACT,
+        walletAddress: WALLET,
+        totalRoyalties: 300n,       // 100 + 200
+        numberOfSales: 2,
+        pendingSaleIds: [1, 2],
+        totalDustAllocated: 0n,
+        dustAuditData: null,
+      })
+    );
+  });
+
+  test("6. buildTx is called exactly once regardless of sale count", async () => {
+    getSecondarySales.mockReturnValue([
+      { id: 1, royaltyAmount: "50" },
+      { id: 2, royaltyAmount: "50" },
+      { id: 3, royaltyAmount: "50" },
+    ]);
+
+    await request(app).post("/api/v1/secondary-royalty/distribute").send(VALID_BODY);
+
+    expect(buildTx).toHaveBeenCalledTimes(1);
+    expect(commitSecondaryDistributionAtomic).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/tests/secondary-royalty-idempotency.test.js
+++ b/backend/tests/secondary-royalty-idempotency.test.js
@@ -1,0 +1,281 @@
+/**
+ * Tests for idempotency key support on secondary-royalty endpoints (#472).
+ *
+ * Verifies that:
+ *  - POST /secondary-royalty/distribute accepts an Idempotency-Key header
+ *  - Duplicate requests within 24 h return the cached response
+ *  - Error responses are never cached
+ *  - Cache expires after the 24-hour TTL
+ *  - Invalid key formats are rejected with 400
+ *  - Different request bodies create separate cache entries
+ */
+
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import request from "supertest";
+
+// --- Stellar mock ---------------------------------------------------------
+const buildTx = jest.fn();
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  buildTx,
+  retryBuildTx: jest.fn(),
+  addressToScVal: jest.fn((a) => a),
+  i128ToScVal: jest.fn((n) => n),
+  u32ToScVal: jest.fn((n) => n),
+  getRoyaltyRateFromContract: jest.fn(),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+// --- Database mock --------------------------------------------------------
+const getSecondarySales = jest.fn();
+const commitSecondaryDistributionAtomic = jest.fn();
+const applyLargestRemainder = jest.fn();
+const recordTransaction = jest.fn(() => 1);
+const recordSecondarySale = jest.fn();
+const addAuditLog = jest.fn();
+const getRoyaltyStatistics = jest.fn();
+const getSecondaryRoyaltyDistributions = jest.fn();
+const countSecondarySales = jest.fn();
+const initializeDatabase = jest.fn();
+const getMigrationVersion = jest.fn(() => 7);
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  getSecondarySales,
+  commitSecondaryDistributionAtomic,
+  applyLargestRemainder,
+  recordTransaction,
+  recordSecondarySale,
+  addAuditLog,
+  getRoyaltyStatistics,
+  getSecondaryRoyaltyDistributions,
+  countSecondarySales,
+  initializeDatabase,
+  getMigrationVersion,
+}));
+
+// --- Import idempotency cache helpers and build app ----------------------
+const { clearCache } = await import("../src/idempotency.js");
+
+const express = (await import("express")).default;
+const { secondaryRoyaltyRouter } = await import("../src/routes/secondary-royalty.js");
+
+const app = express();
+app.use(express.json({ limit: "10kb" }));
+app.use("/api/v1/secondary-royalty", secondaryRoyaltyRouter);
+app.use((err, _req, res, _next) => {
+  res.status(err.status || 500).json({ error: err.message ?? "Internal server error" });
+});
+
+// --- Constants -----------------------------------------------------------
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN_A  = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const TOKEN_B  = "CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+
+const PENDING   = [{ id: 1, royaltyAmount: "500" }];
+const DIST_BODY = { contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN_A };
+
+// =========================================================================
+
+describe("POST /api/v1/secondary-royalty/distribute — idempotency (#472)", () => {
+  beforeEach(() => {
+    // resetAllMocks clears both call history AND the Once-implementation queue,
+    // preventing unconsumed Once values from leaking between tests.
+    jest.resetAllMocks();
+    clearCache();
+    getSecondarySales.mockReturnValue(PENDING);
+    buildTx.mockResolvedValue("dist-xdr");
+    commitSecondaryDistributionAtomic.mockReturnValue(99);
+  });
+
+  afterEach(() => {
+    clearCache();
+  });
+
+  test("1. processes normally without Idempotency-Key header", async () => {
+    const res = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .send(DIST_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ xdr: "dist-xdr", transactionId: 99 });
+    expect(buildTx).toHaveBeenCalledTimes(1);
+  });
+
+  test("2. duplicate Idempotency-Key returns cached response without re-processing", async () => {
+    buildTx.mockResolvedValue("xdr-first");
+    commitSecondaryDistributionAtomic.mockReturnValue(101);
+
+    const res1 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "key-dedup-test")
+      .send(DIST_BODY);
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.transactionId).toBe(101);
+    expect(buildTx).toHaveBeenCalledTimes(1);
+    expect(commitSecondaryDistributionAtomic).toHaveBeenCalledTimes(1);
+
+    // Second request with same key — backend must not be called again
+    buildTx.mockResolvedValue("xdr-second");
+    commitSecondaryDistributionAtomic.mockReturnValue(999);
+
+    const res2 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "key-dedup-test")
+      .send(DIST_BODY);
+
+    // Still returns the first cached response
+    expect(res2.status).toBe(200);
+    expect(res2.body.transactionId).toBe(101);
+    // Neither mock is called a second time
+    expect(buildTx).toHaveBeenCalledTimes(1);
+    expect(commitSecondaryDistributionAtomic).toHaveBeenCalledTimes(1);
+  });
+
+  test("3. invalid Idempotency-Key format returns 400", async () => {
+    const res = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "bad key with spaces!")
+      .send(DIST_BODY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid Idempotency-Key format/);
+    expect(buildTx).not.toHaveBeenCalled();
+  });
+
+  test("4. error responses are NOT cached — retry with same key re-processes", async () => {
+    buildTx.mockRejectedValue(new Error("Stellar RPC unavailable"));
+
+    const res1 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "key-error-test")
+      .send(DIST_BODY);
+
+    expect(res1.status).toBe(500);
+    expect(buildTx).toHaveBeenCalledTimes(1);
+
+    // Retry after fixing the transient error — must be processed fresh
+    buildTx.mockResolvedValue("xdr-retry-ok");
+    commitSecondaryDistributionAtomic.mockReturnValue(202);
+
+    const res2 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "key-error-test")
+      .send(DIST_BODY);
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.transactionId).toBe(202);
+    expect(buildTx).toHaveBeenCalledTimes(2);
+  });
+
+  test("5. different request bodies with same Idempotency-Key produce separate cache entries", async () => {
+    let callCount = 0;
+    buildTx.mockImplementation(() => {
+      callCount++;
+      return Promise.resolve(`xdr-${callCount}`);
+    });
+    commitSecondaryDistributionAtomic.mockImplementation(() => callCount);
+
+    const resA = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "shared-key")
+      .send({ ...DIST_BODY, tokenId: TOKEN_A });
+
+    const resB = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "shared-key")
+      .send({ ...DIST_BODY, tokenId: TOKEN_B });
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+    // Different bodies → different content hash → different cache keys → both processed
+    expect(buildTx).toHaveBeenCalledTimes(2);
+    expect(resA.body.transactionId).toBe(1);
+    expect(resB.body.transactionId).toBe(2);
+  });
+
+  test("6. cache expires after 24-hour TTL — re-sends as a new request", async () => {
+    const realNow = Date.now;
+    const start = 1_000_000_000_000;
+    Date.now = jest.fn(() => start);
+
+    buildTx.mockResolvedValue("xdr-initial");
+    commitSecondaryDistributionAtomic.mockReturnValue(300);
+
+    const res1 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "ttl-test-key")
+      .send(DIST_BODY);
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.transactionId).toBe(300);
+
+    // Advance past 24-hour TTL
+    Date.now = jest.fn(() => start + 86_400_001);
+
+    buildTx.mockResolvedValue("xdr-after-ttl");
+    commitSecondaryDistributionAtomic.mockReturnValue(301);
+
+    const res2 = await request(app)
+      .post("/api/v1/secondary-royalty/distribute")
+      .set("Idempotency-Key", "ttl-test-key")
+      .send(DIST_BODY);
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.transactionId).toBe(301);   // fresh response, not cached
+    expect(buildTx).toHaveBeenCalledTimes(2);
+
+    Date.now = realNow;
+  });
+
+  test("7. Idempotency-Key header accepted with various valid formats", async () => {
+    const validKeys = [
+      "simple-key",
+      "key_with_underscores",
+      "AlphaNumeric123",
+      "a1b2c3d4e5f6",
+    ];
+
+    for (const key of validKeys) {
+      clearCache();
+      jest.resetAllMocks();
+      getSecondarySales.mockReturnValue(PENDING);
+      buildTx.mockResolvedValue("dist-xdr");
+      commitSecondaryDistributionAtomic.mockReturnValue(99);
+
+      const res = await request(app)
+        .post("/api/v1/secondary-royalty/distribute")
+        .set("Idempotency-Key", key)
+        .send(DIST_BODY);
+
+      expect(res.status).toBe(200);
+      expect(buildTx).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("8. concurrent identical requests both succeed and return same response", async () => {
+    buildTx.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve("xdr-concurrent"), 30))
+    );
+    commitSecondaryDistributionAtomic.mockReturnValue(500);
+
+    const [r1, r2] = await Promise.all([
+      request(app)
+        .post("/api/v1/secondary-royalty/distribute")
+        .set("Idempotency-Key", "concurrent-key")
+        .send(DIST_BODY),
+      request(app)
+        .post("/api/v1/secondary-royalty/distribute")
+        .set("Idempotency-Key", "concurrent-key")
+        .send(DIST_BODY),
+    ]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r1.body).toEqual(r2.body);
+    expect(buildTx.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(buildTx.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -99,6 +99,7 @@ async function post<T>(
   path: string,
   body: unknown,
   walletAddress?: string,
+  extraHeaders?: Record<string, string>,
 ): Promise<T> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
 
@@ -116,11 +117,23 @@ async function post<T>(
     }
   }
 
+  if (extraHeaders) {
+    Object.assign(headers, extraHeaders);
+  }
+
   return request<T>(path, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
   });
+}
+
+/**
+ * Generate a fresh idempotency key for retry-safe POST requests.
+ * Generate once per user action, then pass the same key on every retry.
+ */
+export function generateIdempotencyKey(): string {
+  return crypto.randomUUID();
 }
 
 async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
@@ -237,15 +250,19 @@ export const api = {
       body.walletAddress,
     ),
 
-  distribute: (body: {
-    contractId: string;
-    walletAddress: string;
-    tokenId: string;
-  }) =>
+  distribute: (
+    body: {
+      contractId: string;
+      walletAddress: string;
+      tokenId: string;
+    },
+    idempotencyKey?: string,
+  ) =>
     post<{ xdr: string; transactionId: number }>(
       "/distribute",
       body,
       body.walletAddress,
+      idempotencyKey ? { "Idempotency-Key": idempotencyKey } : undefined,
     ),
 
   getContractBalance: (contractId: string, tokenId: string) =>
@@ -335,17 +352,25 @@ export const api = {
       body.walletAddress,
     ),
 
-  distributeSecondaryRoyalties: (body: {
-    contractId: string;
-    walletAddress: string;
-    tokenId: string;
-  }) =>
+  distributeSecondaryRoyalties: (
+    body: {
+      contractId: string;
+      walletAddress: string;
+      tokenId: string;
+    },
+    idempotencyKey?: string,
+  ) =>
     post<{
       xdr: string;
       transactionId: number;
       numberOfSales: number;
       totalRoyalties: string;
-    }>("/secondary-royalty/distribute", body, body.walletAddress),
+    }>(
+      "/secondary-royalty/distribute",
+      body,
+      body.walletAddress,
+      idempotencyKey ? { "Idempotency-Key": idempotencyKey } : undefined,
+    ),
 
   getRoyaltyStats: (contractId: string) =>
     get<RoyaltyStats>(`/secondary-royalty/stats/${contractId}`),


### PR DESCRIPTION
## Summary

- **#471** — Moved `buildTx()` before all DB writes in the secondary-royalty distribute endpoint and wrapped `recordTransaction`, `markSalesDistributed`, `recordSecondaryRoyaltyDistribution`, and both `addAuditLog` calls in a single `db.transaction()` via `commitSecondaryDistributionAtomic()`. A Stellar failure or any DB error now fully rolls back, preventing orphaned pending-sale rows.
- **#472** — Added `idempotencyMiddleware` to `POST /secondary-royalty` and `POST /secondary-royalty/distribute`. Exposed `generateIdempotencyKey()` in the frontend API client and added an optional `idempotencyKey` param to `api.distribute()` and `api.distributeSecondaryRoyalties()` so callers can reuse the same key on retries.
- **#470** — Added a comprehensive Error Reference section to `API.md` covering 25+ error codes, all HTTP status codes, example payloads, per-error retry policies, and a client error-handling guide.

## Test plan

- [ ] Run `npm test` in `backend/` — 14 new tests in `secondary-royalty-atomic.test.js` (6) and `secondary-royalty-idempotency.test.js` (8) all pass
- [ ] Verify `POST /secondary-royalty/distribute` returns the same response on duplicate `Idempotency-Key` within 24 h
- [ ] Verify that when `buildTx()` throws, no rows are inserted/updated in the DB
- [ ] Verify `API.md` Error Reference section is rendered correctly

closes #471
closes #472
closes #470