### PR TITLE
feat: implement backend audit log export

### DIFF
--- a/backend/src/database/audit.js
+++ b/backend/src/database/audit.js
@@ -65,3 +65,56 @@ export function addAuditLog(contractId, action, user, details) {
   stmt.run(contractId, action, user, detailsJson, entryHash, prevHash, timestamp);
   countWrite();
 }
+
+export function exportAuditLogs(filters = {}, limit = 10000, offset = 0) {
+  const conditions = [];
+  const params = [];
+
+  if (filters.contractId) {
+    conditions.push("contractId = ?");
+    params.push(filters.contractId);
+  }
+
+  if (filters.action) {
+    conditions.push("action = ?");
+    params.push(filters.action);
+  }
+
+  if (filters.start) {
+    conditions.push("timestamp >= ?");
+    params.push(filters.start);
+  }
+
+  if (filters.end) {
+    conditions.push("timestamp <= ?");
+    params.push(filters.end);
+  }
+
+  let sql = `
+    SELECT 
+      timestamp,
+      action,
+      contractId,
+      user AS actor,
+      details
+    FROM audit_log
+  `;
+
+  if (conditions.length > 0) {
+    sql += " WHERE " + conditions.join(" AND ");
+  }
+
+  sql += " ORDER BY timestamp DESC LIMIT ? OFFSET ?";
+  params.push(limit, offset);
+
+  const stmt = db.prepare(sql);
+  return stmt.all(...params).map((row) => {
+    let details = null;
+    try {
+      details = JSON.parse(row.details || "{}");
+    } catch (_) {
+      // Keep malformed legacy audit details readable as null.
+    }
+    return { ...row, details };
+  });
+}

--- a/backend/src/database/index.js
+++ b/backend/src/database/index.js
@@ -41,7 +41,7 @@ export {
 } from "./webhooks.js";
 
 // Audit logging
-export { getAuditLog, addAuditLog } from "./audit.js";
+export { getAuditLog, addAuditLog, exportAuditLogs } from "./audit.js";
 
 // Request nonce dedup (#421)
 export { recordNonceIfNew } from "./request-nonces.js";

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import logger from "./logger.js";
 import { correlationMiddleware } from "./correlation.js";
+import { auditExportRouter } from "./routes/audit-export.js";
 import { recordHttpRequest } from "./metrics.js";
 import { resolveCorsOrigin } from "./cors-config.js";
 import { initializeRouter } from "./routes/initialize.js";
@@ -103,7 +104,13 @@ app.use(
       "X-Signature",
       "X-API-Key",
     ],
-    exposedHeaders: ["X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"],
+    exposedHeaders: [
+      "X-RateLimit-Limit",
+      "X-RateLimit-Remaining",
+      "X-RateLimit-Reset",
+      "X-Export-Signature",
+      "X-Export-Public-Key",
+    ],
     maxAge: Number.isNaN(corsPreflightMaxAge) ? 86400 : corsPreflightMaxAge,
   })
 );
@@ -203,6 +210,7 @@ app.use("/api/v1", webhooksRouter);
 app.use("/api/v1", analyticsRouter);
 app.use("/api/v1/contract", contractRouter);
 app.use("/api/v1/health", healthRouter);
+app.use("/api/v1/admin", auditExportRouter);
 app.use("/metrics", metricsRouter);
 app.use("/api/v1/metrics", metricsRouter);
 

--- a/backend/src/routes/audit-export.js
+++ b/backend/src/routes/audit-export.js
@@ -1,0 +1,170 @@
+import { Router } from "express";
+import { exportAuditLogs } from "../database/index.js";
+import { getSigningKeypair, isAdminRotateTokenValid } from "../signing-key.js";
+import { sendError } from "../error-response.js";
+import logger from "../logger.js";
+import zlib from "zlib";
+
+export const auditExportRouter = Router();
+
+/**
+ * Require valid bearer token corresponding to ADMIN_ROTATE_TOKEN.
+ */
+function requireAdminToken(req, res, next) {
+  if (!process.env.ADMIN_ROTATE_TOKEN) {
+    logger.warn("Admin export rejected: ADMIN_ROTATE_TOKEN not configured", {
+      event: "audit_export_denied",
+      reason: "token_not_configured",
+    });
+    return sendError(
+      res,
+      503,
+      "service_unavailable",
+      "Admin token is not configured on this server"
+    );
+  }
+
+  const authHeader = req.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return sendError(res, 401, "unauthorized", "Unauthorized");
+  }
+  const token = authHeader.slice("Bearer ".length).trim();
+  if (!isAdminRotateTokenValid(token)) {
+    return sendError(res, 401, "unauthorized", "Unauthorized");
+  }
+  next();
+}
+
+/**
+ * Standard RFC 4180-compliant CSV serializer.
+ */
+export function stringifyCSV(records, headers) {
+  const escapeField = (val) => {
+    if (val === null || val === undefined) return "";
+    const str = typeof val === "object" ? JSON.stringify(val) : String(val);
+    if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const lines = [];
+  lines.push(headers.join(","));
+
+  for (const record of records) {
+    const row = headers.map((header) => escapeField(record[header]));
+    lines.push(row.join(","));
+  }
+
+  return lines.join("\n");
+}
+
+auditExportRouter.get("/audit-export", requireAdminToken, (req, res, next) => {
+  try {
+    const format = (req.query.format || "json").toLowerCase();
+    if (format !== "json" && format !== "csv") {
+      return sendError(
+        res,
+        400,
+        "invalid_format",
+        "Format must be either 'json' or 'csv'"
+      );
+    }
+
+    const { start, end, contractId, action } = req.query;
+
+    const dateRegex = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?)?$/;
+    if (start && !dateRegex.test(start)) {
+      return sendError(
+        res,
+        400,
+        "invalid_start_date",
+        "Start date must be in YYYY-MM-DD or ISO 8601 format"
+      );
+    }
+    if (end && !dateRegex.test(end)) {
+      return sendError(
+        res,
+        400,
+        "invalid_end_date",
+        "End date must be in YYYY-MM-DD or ISO 8601 format"
+      );
+    }
+
+    let startVal = start;
+    if (startVal && /^\d{4}-\d{2}-\d{2}$/.test(startVal)) {
+      startVal = `${startVal}T00:00:00.000Z`;
+    }
+    let endVal = end;
+    if (endVal && /^\d{4}-\d{2}-\d{2}$/.test(endVal)) {
+      endVal = `${endVal}T23:59:59.999Z`;
+    }
+
+    const maxLimit = 10000;
+    let limit = parseInt(req.query.limit ?? "10000", 10);
+    if (Number.isNaN(limit) || limit <= 0 || limit > maxLimit) {
+      limit = maxLimit;
+    }
+    let offset = parseInt(req.query.offset ?? "0", 10);
+    if (Number.isNaN(offset) || offset < 0) {
+      offset = 0;
+    }
+
+    const filters = {
+      contractId,
+      action,
+      start: startVal,
+      end: endVal,
+    };
+
+    const records = exportAuditLogs(filters, limit, offset);
+
+    const keypair = getSigningKeypair();
+    if (!keypair) {
+      return sendError(
+        res,
+        500,
+        "signing_key_not_configured",
+        "Server signing key is not configured"
+      );
+    }
+
+    const headers = ["timestamp", "action", "contractId", "actor", "details"];
+
+    let bodyData = "";
+    let contentType = "";
+
+    if (format === "csv") {
+      bodyData = stringifyCSV(records, headers);
+      contentType = "text/csv";
+    } else {
+      // JSON format
+      const dataStr = JSON.stringify(records);
+      const signature = keypair.sign(Buffer.from(dataStr)).toString("base64");
+      const responsePayload = {
+        signature,
+        publicKey: keypair.publicKey(),
+        data: records,
+      };
+      bodyData = JSON.stringify(responsePayload);
+      contentType = "application/json";
+    }
+
+    // Set signature headers
+    const fullSignature = keypair.sign(Buffer.from(bodyData)).toString("base64");
+    res.setHeader("X-Export-Signature", fullSignature);
+    res.setHeader("X-Export-Public-Key", keypair.publicKey());
+    res.setHeader("Content-Type", contentType);
+
+    // Compress if > 1MB
+    let outputBuffer = Buffer.from(bodyData, "utf8");
+    if (outputBuffer.length > 1024 * 1024) {
+      outputBuffer = zlib.gzipSync(outputBuffer);
+      res.setHeader("Content-Encoding", "gzip");
+    }
+
+    res.send(outputBuffer);
+  } catch (err) {
+    next(err);
+  }
+});

--- a/backend/tests/audit-export.test.js
+++ b/backend/tests/audit-export.test.js
@@ -1,0 +1,200 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import StellarSdk from "@stellar/stellar-sdk";
+
+let fakeAuditLogs = [];
+
+const exportAuditLogs = jest.fn((filters = {}, limit = 10000, offset = 0) => {
+  let filtered = [...fakeAuditLogs];
+  if (filters.contractId) {
+    filtered = filtered.filter((x) => x.contractId === filters.contractId);
+  }
+  if (filters.action) {
+    filtered = filtered.filter((x) => x.action === filters.action);
+  }
+  if (filters.start) {
+    filtered = filtered.filter((x) => x.timestamp >= filters.start);
+  }
+  if (filters.end) {
+    filtered = filtered.filter((x) => x.timestamp <= filters.end);
+  }
+  return filtered.slice(offset, offset + limit);
+});
+
+// Mock database module
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  exportAuditLogs,
+}));
+
+process.env.ADMIN_ROTATE_TOKEN = "test-admin-token";
+
+const { auditExportRouter, stringifyCSV } = await import("../src/routes/audit-export.js");
+const { rotateSigningKey, getSigningKeypair } = await import("../src/signing-key.js");
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/admin", auditExportRouter);
+  app.use((err, req, res, next) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+describe("Audit Log Export System (#424)", () => {
+  let testKeypair;
+
+  beforeEach(() => {
+    fakeAuditLogs = [
+      {
+        timestamp: "2026-06-20T10:00:00.000Z",
+        action: "initialize",
+        contractId: "CA123",
+        actor: "G123",
+        details: { version: 1 },
+      },
+      {
+        timestamp: "2026-06-21T10:00:00.000Z",
+        action: "distribute",
+        contractId: "CA456",
+        actor: "G456",
+        details: { amount: "100" },
+      },
+      {
+        timestamp: "2026-06-22T10:00:00.000Z",
+        action: "secondary_royalty",
+        contractId: "CA123",
+        actor: "G123",
+        details: { rate: 5 },
+      },
+    ];
+    jest.clearAllMocks();
+
+    testKeypair = StellarSdk.Keypair.random();
+    rotateSigningKey(testKeypair.secret(), { source: "test" });
+  });
+
+  test("returns 401 when Authorization header is missing or invalid", async () => {
+    const app = makeApp();
+
+    const noAuth = await request(app).get("/api/v1/admin/audit-export");
+    expect(noAuth.status).toBe(401);
+
+    const badAuth = await request(app)
+      .get("/api/v1/admin/audit-export")
+      .set("Authorization", "Bearer wrong-token");
+    expect(badAuth.status).toBe(401);
+  });
+
+  test("exports audit logs in JSON format with valid signatures", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/api/v1/admin/audit-export?format=json")
+      .set("Authorization", "Bearer test-admin-token");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/json");
+
+    // Assert signature headers are set
+    const headerSig = res.headers["x-export-signature"];
+    const headerPub = res.headers["x-export-public-key"];
+    expect(headerSig).toBeDefined();
+    expect(headerPub).toBe(testKeypair.publicKey());
+
+    // Verify response body signature using header public key
+    const verifyHeaderSig = StellarSdk.Keypair.fromPublicKey(headerPub).verify(
+      Buffer.from(res.text, "utf8"),
+      Buffer.from(headerSig, "base64")
+    );
+    expect(verifyHeaderSig).toBe(true);
+
+    // Verify inner payload signature
+    const body = JSON.parse(res.text);
+    expect(body).toHaveProperty("signature");
+    expect(body).toHaveProperty("publicKey");
+    expect(body).toHaveProperty("data");
+
+    const innerVerify = StellarSdk.Keypair.fromPublicKey(body.publicKey).verify(
+      Buffer.from(JSON.stringify(body.data), "utf8"),
+      Buffer.from(body.signature, "base64")
+    );
+    expect(innerVerify).toBe(true);
+    expect(body.data.length).toBe(3);
+  });
+
+  test("exports audit logs in CSV format with valid signatures", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/api/v1/admin/audit-export?format=csv")
+      .set("Authorization", "Bearer test-admin-token");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+
+    const headerSig = res.headers["x-export-signature"];
+    const headerPub = res.headers["x-export-public-key"];
+    expect(headerSig).toBeDefined();
+    expect(headerPub).toBe(testKeypair.publicKey());
+
+    const verifyHeaderSig = StellarSdk.Keypair.fromPublicKey(headerPub).verify(
+      Buffer.from(res.text, "utf8"),
+      Buffer.from(headerSig, "base64")
+    );
+    expect(verifyHeaderSig).toBe(true);
+
+    const lines = res.text.split("\n");
+    expect(lines[0]).toBe("timestamp,action,contractId,actor,details");
+    expect(lines.length).toBe(4); // Header + 3 records
+    expect(lines[1]).toContain("2026-06-20T10:00:00.000Z,initialize,CA123,G123");
+  });
+
+  test("supports filtering by date range, contractId, and action", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get(
+        "/api/v1/admin/audit-export?format=json&start=2026-06-21&end=2026-06-22&contractId=CA123&action=secondary_royalty"
+      )
+      .set("Authorization", "Bearer test-admin-token");
+
+    expect(res.status).toBe(200);
+
+    expect(exportAuditLogs).toHaveBeenCalledWith(
+      {
+        start: "2026-06-21T00:00:00.000Z",
+        end: "2026-06-22T23:59:59.999Z",
+        contractId: "CA123",
+        action: "secondary_royalty",
+      },
+      10000,
+      0
+    );
+
+    const body = JSON.parse(res.text);
+    expect(body.data.length).toBe(1);
+    expect(body.data[0].action).toBe("secondary_royalty");
+  });
+
+  test("supports limit and offset pagination", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/api/v1/admin/audit-export?format=json&limit=2&offset=1")
+      .set("Authorization", "Bearer test-admin-token");
+
+    expect(res.status).toBe(200);
+    expect(exportAuditLogs).toHaveBeenCalledWith(
+      {
+        start: undefined,
+        end: undefined,
+        contractId: undefined,
+        action: undefined,
+      },
+      2,
+      1
+    );
+
+    const body = JSON.parse(res.text);
+    expect(body.data.length).toBe(2);
+    expect(body.data[0].action).toBe("distribute");
+  });
+});


### PR DESCRIPTION
Resolves #424. Implements audit log exports in CSV and JSON formats at GET /api/v1/admin/audit-export, supporting date range, contractId, and action filtering, pagination (up to 10k records), gzip compression, and Ed25519 payload signatures.