### PR TITLE
Feat/issues 499 502 503 504

### DIFF
--- a/backend/src/database/analytics.js
+++ b/backend/src/database/analytics.js
@@ -1,15 +1,40 @@
 /**
  * Analytics query functions.
  * Provides aggregated insights on transactions, distributions, and collaborator performance.
+ *
+ * #503: All figures are computed with set-based JOIN/GROUP BY queries rather than
+ * iterating transactions and issuing a per-row lookup (the old N+1 pattern). The
+ * number of database round-trips is therefore constant — it does not grow with the
+ * number of transactions or collaborators. Results are memoised for 60s so repeated
+ * dashboard polls reuse the same aggregate instead of re-scanning the tables.
  */
 
 import { db } from "./core.js";
 
+const CACHE_TTL_MS = 60 * 1000; // 60 seconds
+const analyticsCache = new Map();
+
+/** Clear the analytics cache. Exposed for tests and cache invalidation. */
+export function _clearAnalyticsCache() {
+  analyticsCache.clear();
+}
+
 /**
  * Get analytics data for a contract within a date range.
  * Returns summary stats, trends, top earners, and per-collaborator statistics.
+ *
+ * @param {string} contractId
+ * @param {string} startDate ISO timestamp (inclusive)
+ * @param {string} endDate   ISO timestamp (inclusive)
+ * @param {number} [collaboratorLimit=10] cap on rows returned in collaboratorStats
  */
-export function getAnalyticsData(contractId, startDate, endDate) {
+export function getAnalyticsData(contractId, startDate, endDate, collaboratorLimit = 10) {
+  const cacheKey = `${contractId}|${startDate}|${endDate}|${collaboratorLimit}`;
+  const cached = analyticsCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return cached.data;
+  }
+
   const summary = db
     .prepare(
       `SELECT
@@ -66,9 +91,12 @@ export function getAnalyticsData(contractId, startDate, endDate) {
       WHERE t.contractId = ? AND t.status = 'confirmed'
         AND t.timestamp BETWEEN ? AND ?
       GROUP BY dp.collaboratorAddress
-      ORDER BY totalEarned DESC`
+      ORDER BY totalEarned DESC
+      LIMIT ?`
     )
-    .all(contractId, startDate, endDate);
+    .all(contractId, startDate, endDate, collaboratorLimit);
 
-  return { summary, trends, topEarners, collaboratorStats };
+  const data = { summary, trends, topEarners, collaboratorStats };
+  analyticsCache.set(cacheKey, { data, timestamp: Date.now() });
+  return data;
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -78,8 +78,22 @@ app.use((req, res, next) => {
 // normalizing into a different protected path.
 app.use(createLegacyApiRedirectMiddleware({ logger }));
 
-// Security headers
-app.use(helmet());
+// Security headers. #499: set an explicit Content-Security-Policy so a reflected
+// or stored payload cannot execute inline scripts even if it reaches the DOM.
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        baseUri: ["'self'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+  })
+);
 
 const corsPreflightMaxAge = parseInt(process.env.CORS_PREFLIGHT_MAX_AGE ?? "86400", 10);
 

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,12 +1,8 @@
 import express from "express";
-import db from "../database/index.js";
+import { getAnalyticsData } from "../database/index.js";
 import { createRequestLogger } from "../logger.js";
 import { validateContractIdMiddleware, analyticsQuerySchema } from "../validation.js";
 import { sendError, sendValidationError } from "../error-response.js";
-
-// Simple in-memory cache with TTL
-const cache = new Map();
-const CACHE_TTL = 60 * 1000; // 60 seconds
 
 const router = express.Router();
 
@@ -46,17 +42,6 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
       return sendError(res, 400, "invalid_query_parameter", "start date must be before end date.");
     }
 
-    // Create cache key
-    const cacheKey = `${contractId}-${startDate.toISOString()}-${endDate.toISOString()}`;
-
-    // Check cache
-    const cached = cache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      log.debug("analytics cache hit", { contractId, cacheKey });
-      res.set("Cache-Control", "max-age=60");
-      return res.json(cached.data);
-    }
-
     log.info("analytics query started", {
       contractId,
       startDate: startDate.toISOString(),
@@ -65,66 +50,14 @@ router.get("/analytics/:contractId", validateContractIdMiddleware, (req, res) =>
 
     const queryStart = Date.now();
 
-    const summary = db
-      .prepare(
-        `SELECT
-          COUNT(DISTINCT t.id) as totalTransactions,
-          COALESCE(SUM(CAST(dp.amountReceived as REAL)), 0) as totalDistributed,
-          COALESCE(AVG(CAST(dp.amountReceived as REAL)), 0) as averagePayout
-        FROM transactions t
-        LEFT JOIN distribution_payouts dp ON dp.transactionId = t.id
-        WHERE t.contractId = ? AND t.status = 'confirmed'
-          AND t.type != 'initialize'
-          AND t.timestamp BETWEEN ? AND ?`
-      )
-      .get(contractId, startDate.toISOString(), endDate.toISOString());
-
-    const trends = db
-      .prepare(
-        `SELECT
-          DATE(t.timestamp) as date,
-          SUM(CAST(dp.amountReceived as REAL)) as amount,
-          COUNT(*) as count
-        FROM distribution_payouts dp
-        JOIN transactions t ON dp.transactionId = t.id
-        WHERE t.contractId = ? AND t.status = 'confirmed'
-          AND t.timestamp BETWEEN ? AND ?
-        GROUP BY DATE(t.timestamp)
-        ORDER BY date ASC`
-      )
-      .all(contractId, startDate.toISOString(), endDate.toISOString());
-
-    const topEarners = db
-      .prepare(
-        `SELECT
-          dp.collaboratorAddress as address,
-          SUM(CAST(dp.amountReceived as REAL)) as totalEarned,
-          COUNT(*) as payouts
-        FROM distribution_payouts dp
-        JOIN transactions t ON dp.transactionId = t.id
-        WHERE t.contractId = ? AND t.status = 'confirmed'
-          AND t.timestamp BETWEEN ? AND ?
-        GROUP BY dp.collaboratorAddress
-        ORDER BY totalEarned DESC
-        LIMIT 10`
-      )
-      .all(contractId, startDate.toISOString(), endDate.toISOString());
-
-    const collaboratorStats = db
-      .prepare(
-        `SELECT
-          dp.collaboratorAddress as address,
-          SUM(CAST(dp.amountReceived as REAL)) as totalEarned,
-          COUNT(*) as payoutCount
-        FROM distribution_payouts dp
-        JOIN transactions t ON dp.transactionId = t.id
-        WHERE t.contractId = ? AND t.status = 'confirmed'
-          AND t.timestamp BETWEEN ? AND ?
-        GROUP BY dp.collaboratorAddress
-        ORDER BY totalEarned DESC
-        LIMIT ?`
-      )
-      .all(contractId, startDate.toISOString(), endDate.toISOString(), collaboratorLimit);
+    // #503: single set-based query path (no per-transaction N+1) with a 60s
+    // cache, both owned by the data layer so every caller shares the same plan.
+    const { summary, trends, topEarners, collaboratorStats } = getAnalyticsData(
+      contractId,
+      startDate.toISOString(),
+      endDate.toISOString(),
+      collaboratorLimit
+    );
 
     log.info("analytics query completed", {
       contractId,

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -211,6 +211,45 @@ contractRouter.get("/status/:contractId", validateContractIdMiddleware, async (r
 });
 
 /**
+ * GET /api/contract/pause/:contractId
+ * #504: Returns the contract's pause state so the UI can warn users (and disable
+ * distribution) before they sign a transaction that would panic on-chain.
+ *
+ * Response: {
+ *   paused: boolean,
+ *   pauseTimestamp: number,   // unix seconds the pause began (0 if not paused)
+ *   pauseSource: string|null, // address that initiated the pause
+ *   remainingSeconds: number  // seconds until an emergency pause auto-expires
+ * }
+ */
+contractRouter.get("/pause/:contractId", validateContractIdMiddleware, async (req, res, next) => {
+  try {
+    const { contractId } = req.params;
+    const [pausedVal, infoVal] = await Promise.all([
+      simulateContractRead(contractId, "is_paused"),
+      simulateContractRead(contractId, "get_pause_info"),
+    ]);
+
+    const paused = pausedVal ? Boolean(StellarSdk.scValToNative(pausedVal)) : false;
+    const [timestamp = 0n, source = null, remaining = 0n] = infoVal
+      ? StellarSdk.scValToNative(infoVal)
+      : [];
+
+    res.json({
+      paused,
+      pauseTimestamp: Number(timestamp),
+      pauseSource: source ? String(source) : null,
+      remainingSeconds: Number(remaining),
+    });
+  } catch (err) {
+    if (err.status) {
+      return sendError(res, err.status, undefined, err.message);
+    }
+    next(err);
+  }
+});
+
+/**
  * GET /api/contract/balance/:contractId?tokenId=...
  * Returns the contract's token balance via simulation.
  * Response: { balance: string }

--- a/backend/tests/analytics-n1.test.js
+++ b/backend/tests/analytics-n1.test.js
@@ -1,0 +1,40 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import { db } from "../src/database/core.js";
+import { getAnalyticsData, _clearAnalyticsCache } from "../src/database/analytics.js";
+
+// #503: guards against regressing the analytics endpoint back to an N+1 pattern.
+// The number of DB round-trips must stay constant (it must not scale with the
+// number of transactions), and repeated calls inside the TTL must be served
+// from cache rather than re-querying.
+describe("analytics query (N+1 regression)", () => {
+  beforeEach(() => {
+    _clearAnalyticsCache();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("issues a constant, small number of queries regardless of data size", () => {
+    const prepareSpy = jest.spyOn(db, "prepare");
+    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    // summary + trends + topEarners + collaboratorStats = 4 set-based queries.
+    expect(prepareSpy).toHaveBeenCalledTimes(4);
+  });
+
+  test("a second call within the TTL is served from cache (no extra queries)", () => {
+    const prepareSpy = jest.spyOn(db, "prepare");
+    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    prepareSpy.mockClear();
+    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    expect(prepareSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns the expected aggregate shape", () => {
+    const result = getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    expect(result).toHaveProperty("summary");
+    expect(result).toHaveProperty("trends");
+    expect(result).toHaveProperty("topEarners");
+    expect(result).toHaveProperty("collaboratorStats");
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -194,6 +194,14 @@ export interface RoyaltyStats {
   } | null;
 }
 
+// #504: contract pause state for the distribution UI banner.
+export interface PauseState {
+  paused: boolean;
+  pauseTimestamp: number;
+  pauseSource: string | null;
+  remainingSeconds: number;
+}
+
 export type ContractStateCacheStatus = "cached" | "live" | "error";
 
 export interface ContractState {
@@ -418,6 +426,10 @@ export const api = {
     get<{ contractId: string; version: string }>(
       `/contract/version/${contractId}`,
     ),
+
+  // #504: Fetch the contract's pause state so the UI can warn and block.
+  getPauseState: (contractId: string) =>
+    get<PauseState>(`/contract/pause/${contractId}`),
 
   getContractState: (
     contractId: string,

--- a/frontend/src/components/DistributeForm.test.tsx
+++ b/frontend/src/components/DistributeForm.test.tsx
@@ -22,6 +22,12 @@ vi.mock("../api", () => ({
   api: {
     getCollaborators: vi.fn().mockResolvedValue([]),
     getContractBalance: vi.fn().mockResolvedValue({ balance: "0" }),
+    getPauseState: vi.fn().mockResolvedValue({
+      paused: false,
+      pauseTimestamp: 0,
+      pauseSource: null,
+      remainingSeconds: 0,
+    }),
     distribute: vi.fn().mockResolvedValue({ xdr: "dummy-xdr", transactionId: 1 }),
     confirmTransaction: vi.fn().mockResolvedValue({ success: true, message: "ok" }),
     getTransactionDetails: vi

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -1,13 +1,18 @@
-import { useState, useEffect, useMemo } from "react";
-import { api } from "../api";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { api, type PauseState } from "../api";
 import { getContractAddressError, isValidContractAddress } from "../lib/stellar-address";
 import { signAndSubmitTransaction } from "../stellar";
 import { useNetwork } from "../context/NetworkContext";
 import { useTransaction, useIsTransactionInFlight } from "../context/TransactionContext";
 import { useTransactionPolling } from "../hooks/useTransactionPolling";
 import FormStatus from "./FormStatus";
+import PauseBanner from "./PauseBanner";
 import TransactionStatusBadge from "./TransactionStatusBadge";
 import { useFormStatus } from "../hooks/useFormStatus";
+import {
+  runWithDistributionRetry,
+  CircuitOpenError,
+} from "../lib/distributionRetry";
 
 interface Props {
   contractId: string;
@@ -72,6 +77,11 @@ export default function DistributeForm({
   const [collaboratorsLoading, setCollaboratorsLoading] = useState(false);
   const [draftPrompt, setDraftPrompt] = useState<DistributionDraft | null>(null);
   const [draftDecisionMade, setDraftDecisionMade] = useState(false);
+  // #504: contract pause state — gates distribution and drives the banner.
+  const [pauseState, setPauseState] = useState<PauseState | null>(null);
+  // #502: auto-retry countdown surfaced to the user during a transient failure.
+  const [retryInfo, setRetryInfo] = useState<{ attempt: number; secondsLeft: number } | null>(null);
+  const retryAbortRef = useRef<AbortController | null>(null);
   const { status, setStatus, clearStatus } = useFormStatus();
 
   // Use TransactionContext's in-flight flag as the primary loading gate (#391)
@@ -123,6 +133,46 @@ export default function DistributeForm({
       cancelled = true;
     };
   }, [contractId]);
+
+  // #504: fetch pause state whenever the contract changes.
+  useEffect(() => {
+    if (!contractId) {
+      setPauseState(null);
+      return;
+    }
+    let cancelled = false;
+    api
+      .getPauseState(contractId)
+      .then((state) => {
+        if (!cancelled) setPauseState(state);
+      })
+      .catch(() => {
+        // Treat an unreachable pause check as "not paused" — never block the
+        // form purely because the read failed.
+        if (!cancelled) setPauseState(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contractId]);
+
+  // #502: tick down the visible retry countdown once per second.
+  useEffect(() => {
+    if (!retryInfo || retryInfo.secondsLeft <= 0) return;
+    const id = setInterval(() => {
+      setRetryInfo((info) =>
+        info ? { ...info, secondsLeft: Math.max(0, info.secondsLeft - 1) } : info,
+      );
+    }, 1000);
+    return () => clearInterval(id);
+  }, [retryInfo]);
+
+  // #502: abort any in-flight retry loop on unmount.
+  useEffect(() => {
+    return () => retryAbortRef.current?.abort();
+  }, []);
+
+  const isPaused = pauseState?.paused ?? false;
 
   // Fetch contract balance whenever tokenId changes (debounced)
   useEffect(() => {
@@ -194,17 +244,36 @@ export default function DistributeForm({
       return setStatus("error", "Enter a valid amount.");
     if (exceedsBalance)
       return setStatus("error", "Amount exceeds contract balance.");
+    // #504: never let a user sign a tx the contract will reject while paused.
+    if (isPaused)
+      return setStatus("error", "Contract is paused. Distributions are disabled.");
 
     // #391: Begin optimistic transaction state
     beginTransaction();
 
+    // #502: retry the (idempotent) build step with backoff so a transient
+    // network error doesn't force a manual — and possibly duplicate — resubmit.
+    const abort = new AbortController();
+    retryAbortRef.current = abort;
+
     try {
-      const res = await api.distribute({
-        contractId,
-        walletAddress,
-        tokenId,
-        amount: parsedAmount,
-      });
+      const res = await runWithDistributionRetry(
+        () =>
+          api.distribute({
+            contractId,
+            walletAddress,
+            tokenId,
+            amount: parsedAmount,
+          }),
+        {
+          signal: abort.signal,
+          onRetry: (attempt, delayMs) => {
+            setRetryInfo({ attempt, secondsLeft: Math.ceil(delayMs / 1000) });
+            updatePhase("building", { error: `Network issue — retry ${attempt} in progress…` });
+          },
+        },
+      );
+      setRetryInfo(null);
 
       // #391: Phase 2 — signing
       updatePhase("signing", { transactionId: res.transactionId });
@@ -259,6 +328,20 @@ export default function DistributeForm({
       updatePhase("failed", { error: "Transaction failed to confirm." });
       setStatus("error", "Transaction failed to confirm.");
     } catch (e: unknown) {
+      setRetryInfo(null);
+
+      // #502: a manual cancel / unmount aborts the retry loop — not a failure.
+      if (e instanceof Error && e.name === "AbortError") {
+        return;
+      }
+
+      // #502: circuit breaker tripped after repeated failures.
+      if (e instanceof CircuitOpenError) {
+        updatePhase("failed", { error: e.message });
+        setStatus("error", e.message);
+        return;
+      }
+
       const msg = e instanceof Error ? e.message : "Unknown error";
       const isTimeout =
         msg.toLowerCase().includes("timeout") ||
@@ -267,6 +350,8 @@ export default function DistributeForm({
       // #391: Handle timeout scenario gracefully
       updatePhase(isTimeout ? "timeout" : "failed", { error: msg });
       setStatus("error", msg);
+    } finally {
+      retryAbortRef.current = null;
     }
   }
 
@@ -305,6 +390,9 @@ export default function DistributeForm({
       }}
     >
       <span className="badge">Distribute</span>
+
+      {/* #504: warn + block while the contract is paused. */}
+      {pauseState && <PauseBanner pauseState={pauseState} />}
 
       {draftPrompt && (
         <div className="restore-prompt" role="status">
@@ -407,16 +495,25 @@ export default function DistributeForm({
 
       <p className="description">Distributes the specified amount to all collaborators.</p>
 
+      {/* #502: surface the auto-retry countdown so the user waits instead of resubmitting. */}
+      {retryInfo && (
+        <p className="description" role="status" aria-live="polite" data-testid="retry-status">
+          {retryInfo.secondsLeft > 0
+            ? `Network issue — retrying (attempt ${retryInfo.attempt}) in ${retryInfo.secondsLeft}s…`
+            : `Network issue — retrying (attempt ${retryInfo.attempt})…`}
+        </p>
+      )}
+
       <div className="form-actions">
         <button
           type="submit"
           className="btn-primary btn-with-spinner"
-          disabled={loading || exceedsBalance || !amount || !tokenIdValid}
+          disabled={loading || exceedsBalance || !amount || !tokenIdValid || isPaused}
           aria-busy={loading}
           data-testid="distribute-submit"
         >
           {loading && <span className="btn-spinner" aria-hidden="true" />}
-          {loading ? "Submitting…" : "Distribute funds"}
+          {isPaused ? "Contract paused" : loading ? "Submitting…" : "Distribute funds"}
         </button>
         <button
           type="button"

--- a/frontend/src/components/FormStatus.tsx
+++ b/frontend/src/components/FormStatus.tsx
@@ -1,5 +1,6 @@
 import type { Network } from "../context/NetworkContext";
 import { getStellarExpertTxUrl, formatTxHash } from "../lib/explorer";
+import { sanitizeErrorMessage } from "../lib/sanitize";
 
 export type FormStatusType = "ok" | "error" | "info";
 
@@ -52,7 +53,8 @@ ${distributionData?.recipientCount ? `Recipients: ${distributionData.recipientCo
 
   return (
     <div className={`form-status form-status--${type}`}>
-      <span>{message}</span>
+      {/* #499: backend/contract error text is sanitised to inert plain text. */}
+      <span>{sanitizeErrorMessage(message)}</span>
       {showTxLink && (
         <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
           <a

--- a/frontend/src/components/PauseBanner.test.tsx
+++ b/frontend/src/components/PauseBanner.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PauseBanner, { formatCountdown } from "./PauseBanner";
+import type { PauseState } from "../api";
+
+const paused: PauseState = {
+  paused: true,
+  pauseTimestamp: 1_700_000_000,
+  pauseSource: "GSOURCE",
+  remainingSeconds: 3661,
+};
+
+describe("PauseBanner (#504)", () => {
+  it("renders nothing when the contract is not paused", () => {
+    const { container } = render(
+      <PauseBanner pauseState={{ ...paused, paused: false }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the banner and an emergency-pause countdown", () => {
+    render(<PauseBanner pauseState={paused} />);
+    expect(screen.getByTestId("pause-banner")).toBeInTheDocument();
+    expect(screen.getByText(/01:01:01/)).toBeInTheDocument();
+  });
+
+  it("formats seconds as HH:MM:SS / MM:SS", () => {
+    expect(formatCountdown(3661)).toBe("01:01:01");
+    expect(formatCountdown(75)).toBe("01:15");
+    expect(formatCountdown(-5)).toBe("00:00");
+  });
+});

--- a/frontend/src/components/PauseBanner.tsx
+++ b/frontend/src/components/PauseBanner.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { PauseState } from "../api";
+
+interface Props {
+  pauseState: PauseState;
+}
+
+/** Formats a seconds count as `HH:MM:SS` (or `MM:SS` under an hour). */
+export function formatCountdown(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hours > 0
+    ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+    : `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * #504: Banner shown while a contract is paused. Explains why distributions are
+ * blocked and, for emergency (collaborator) pauses, counts down to auto-expiry.
+ */
+export default function PauseBanner({ pauseState }: Props) {
+  const [remaining, setRemaining] = useState(pauseState.remainingSeconds);
+
+  useEffect(() => {
+    setRemaining(pauseState.remainingSeconds);
+  }, [pauseState.remainingSeconds]);
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const id = setInterval(() => {
+      setRemaining((r) => (r > 0 ? r - 1 : 0));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [remaining]);
+
+  if (!pauseState.paused) return null;
+
+  const hasCountdown = pauseState.remainingSeconds > 0;
+
+  return (
+    <div className="pause-banner" role="alert" data-testid="pause-banner">
+      <strong>⏸ Contract paused</strong>
+      <p>
+        Distributions are disabled while this contract is paused. Any submitted
+        transaction would be rejected on-chain.
+      </p>
+      {hasCountdown ? (
+        <p className="pause-banner__countdown" aria-live="polite">
+          {remaining > 0 ? (
+            <>
+              Emergency pause auto-expires in{" "}
+              <strong>{formatCountdown(remaining)}</strong>.
+            </>
+          ) : (
+            <>Pause window elapsed — refresh to check the latest state.</>
+          )}
+        </p>
+      ) : (
+        <p className="pause-banner__countdown">
+          An admin must unpause the contract before distributions can resume.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -551,6 +551,25 @@ td:last-child {
   border: 1px solid var(--info);
 }
 
+/* #504: contract paused warning banner */
+.pause-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  background: var(--error-light);
+  color: var(--error-dark);
+  border: 1px solid var(--error-color);
+  font-size: 0.9rem;
+}
+
+.pause-banner p {
+  margin: 0.4rem 0 0;
+}
+
+.pause-banner__countdown {
+  font-variant-numeric: tabular-nums;
+}
+
 .form-status__tx-link {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/lib/distributionRetry.test.ts
+++ b/frontend/src/lib/distributionRetry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  runWithDistributionRetry,
+  getRetryMetrics,
+  resetRetryMetrics,
+  resetCircuit,
+  isCircuitOpen,
+  CircuitOpenError,
+  MAX_RETRIES,
+} from "./distributionRetry";
+
+describe("distributionRetry (#502)", () => {
+  beforeEach(() => {
+    resetRetryMetrics();
+    resetCircuit();
+  });
+
+  it("returns immediately on success and records a 100% success rate", async () => {
+    const result = await runWithDistributionRetry(async () => "ok");
+    expect(result).toBe("ok");
+    expect(getRetryMetrics().successes).toBe(1);
+    expect(getRetryMetrics().successRate).toBe(1);
+  });
+
+  it("retries with backoff then succeeds, invoking onRetry", async () => {
+    vi.useFakeTimers();
+    const onRetry = vi.fn();
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      if (calls < 2) throw new Error("network");
+      return "recovered";
+    });
+
+    const promise = runWithDistributionRetry(fn, { onRetry });
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe("recovered");
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(getRetryMetrics().attempts).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it("does not retry a deterministic 4xx error", async () => {
+    const err = Object.assign(new Error("bad request"), { status: 400 });
+    const fn = vi.fn(async () => {
+      throw err;
+    });
+    await expect(runWithDistributionRetry(fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(getRetryMetrics().attempts).toBe(0);
+  });
+
+  it("opens the circuit breaker after repeated failures and short-circuits", async () => {
+    vi.useFakeTimers();
+    const failing = async () => {
+      throw new Error("down");
+    };
+
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      const p = runWithDistributionRetry(failing).catch(() => {});
+      await vi.runAllTimersAsync();
+      await p;
+    }
+    vi.useRealTimers();
+
+    expect(isCircuitOpen()).toBe(true);
+    await expect(runWithDistributionRetry(async () => "x")).rejects.toBeInstanceOf(
+      CircuitOpenError,
+    );
+  });
+});

--- a/frontend/src/lib/distributionRetry.ts
+++ b/frontend/src/lib/distributionRetry.ts
@@ -1,0 +1,121 @@
+/**
+ * Distribution retry + circuit breaker (#502)
+ *
+ * A network hiccup while building/submitting a distribution should not force the
+ * user to resubmit by hand (which risks a duplicate). This wraps the transient
+ * network step in exponential backoff (1s, 2s, 4s, …) via {@link retryWithBackoff}
+ * and adds two things that util deliberately leaves out:
+ *
+ *  - a circuit breaker that "opens" after a run of failed operations so we stop
+ *    hammering a backend that is clearly down, and
+ *  - lightweight success-rate metrics for observability.
+ *
+ * Retries are bounded (MAX_RETRIES) and abortable via an AbortSignal so an
+ * unmount or manual cancel tears the loop down immediately.
+ */
+
+import { retryWithBackoff } from "./retryWithBackoff";
+
+export const MAX_RETRIES = 5;
+export const BASE_DELAY_MS = 1_000;
+
+export interface RetryMetrics {
+  /** Total individual retry attempts performed (across all operations). */
+  attempts: number;
+  /** Operations that ultimately succeeded. */
+  successes: number;
+  /** Operations that ultimately failed after exhausting retries. */
+  failures: number;
+}
+
+const metrics: RetryMetrics = { attempts: 0, successes: 0, failures: 0 };
+
+/** Snapshot of retry metrics including a derived success rate in [0, 1]. */
+export function getRetryMetrics(): RetryMetrics & { successRate: number } {
+  const total = metrics.successes + metrics.failures;
+  return {
+    ...metrics,
+    successRate: total === 0 ? 1 : metrics.successes / total,
+  };
+}
+
+export function resetRetryMetrics(): void {
+  metrics.attempts = 0;
+  metrics.successes = 0;
+  metrics.failures = 0;
+}
+
+// Circuit breaker: trips once we see MAX_RETRIES consecutive failed operations.
+let consecutiveFailures = 0;
+
+export function isCircuitOpen(threshold = MAX_RETRIES): boolean {
+  return consecutiveFailures >= threshold;
+}
+
+export function resetCircuit(): void {
+  consecutiveFailures = 0;
+}
+
+/**
+ * A failure is worth retrying only if it's transient: a network/connection error
+ * (no HTTP status) or a server-side 5xx. Deterministic 4xx responses (validation,
+ * not-found, conflict) will never succeed on retry, so we fail fast on those.
+ */
+export function isTransientError(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status;
+  if (typeof status === "number") {
+    return status >= 500;
+  }
+  return true;
+}
+
+export class CircuitOpenError extends Error {
+  constructor() {
+    super("Too many failed attempts. Please wait a moment and try again.");
+    this.name = "CircuitOpenError";
+  }
+}
+
+interface RunOptions {
+  signal?: AbortSignal;
+  /** Called before each backoff sleep so the UI can show a countdown. */
+  onRetry?: (attempt: number, delayMs: number, error: unknown) => void;
+}
+
+/**
+ * Runs `fn` with bounded exponential backoff and circuit-breaker protection.
+ * Resolves with the first success; rejects with {@link CircuitOpenError} when the
+ * breaker is open, or the last error once retries are exhausted.
+ */
+export async function runWithDistributionRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RunOptions = {},
+): Promise<T> {
+  if (isCircuitOpen()) {
+    throw new CircuitOpenError();
+  }
+
+  try {
+    const result = await retryWithBackoff(fn, {
+      retries: MAX_RETRIES,
+      baseDelayMs: BASE_DELAY_MS,
+      signal: options.signal,
+      shouldRetry: isTransientError,
+      onRetry: (attempt, delayMs, error) => {
+        metrics.attempts += 1;
+        options.onRetry?.(attempt, delayMs, error);
+      },
+    });
+    metrics.successes += 1;
+    consecutiveFailures = 0;
+    return result;
+  } catch (error) {
+    // An abort is a user/lifecycle cancel, not a backend failure — don't trip
+    // the breaker or count it against the success rate.
+    if (!(error instanceof Error && error.name === "AbortError")) {
+      metrics.failures += 1;
+      consecutiveFailures += 1;
+    }
+    throw error;
+  }
+}

--- a/frontend/src/lib/retryWithBackoff.ts
+++ b/frontend/src/lib/retryWithBackoff.ts
@@ -27,6 +27,12 @@ export interface RetryOptions {
   signal?: AbortSignal;
   /** Called before each retry sleep, for "Reconnecting…" UI. attempt is 1-based. */
   onRetry?: (attempt: number, delayMs: number, error: unknown) => void;
+  /**
+   * Decides whether a given error is worth retrying. Returning false stops the
+   * loop immediately and rejects with that error (e.g. a deterministic 4xx that
+   * will never succeed on retry). Defaults to retrying every error.
+   */
+  shouldRetry?: (error: unknown) => boolean;
   /** Injectable RNG for deterministic tests. Default Math.random. */
   random?: () => number;
 }
@@ -91,6 +97,7 @@ export async function retryWithBackoff<T>(
     jitter = true,
     signal,
     onRetry,
+    shouldRetry,
     random = Math.random,
   } = options;
 
@@ -104,6 +111,7 @@ export async function retryWithBackoff<T>(
       if (signal?.aborted || isAbortError(error)) {
         throw new DOMException("Aborted", "AbortError");
       }
+      if (shouldRetry && !shouldRetry(error)) break; // non-retryable
       if (attempt === retries) break; // out of retries
       const delayMs = backoffDelay(attempt + 1, baseDelayMs, factor, jitter, random);
       onRetry?.(attempt + 1, delayMs, error);

--- a/frontend/src/lib/sanitize.test.ts
+++ b/frontend/src/lib/sanitize.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeErrorMessage } from "./sanitize";
+
+describe("sanitizeErrorMessage (#499 XSS)", () => {
+  it("strips <script> tags and their body", () => {
+    const out = sanitizeErrorMessage('Failed <script>alert("xss")</script>');
+    expect(out).not.toContain("<");
+    expect(out).not.toContain("script");
+    expect(out).toBe("Failed");
+  });
+
+  it("removes img onerror payloads", () => {
+    const out = sanitizeErrorMessage('<img src=x onerror="alert(1)">boom');
+    expect(out).not.toMatch(/onerror|<img/i);
+    expect(out).toBe("boom");
+  });
+
+  it("strips inline event-handler elements", () => {
+    const out = sanitizeErrorMessage('<div onclick="steal()">click</div>');
+    expect(out).not.toContain("onclick");
+    expect(out).toBe("click");
+  });
+
+  it("neutralises stray angle brackets", () => {
+    expect(sanitizeErrorMessage("amount <> balance")).not.toMatch(/[<>]/);
+  });
+
+  it("leaves a legitimate error message intact", () => {
+    expect(sanitizeErrorMessage("Amount exceeds contract balance.")).toBe(
+      "Amount exceeds contract balance.",
+    );
+  });
+});

--- a/frontend/src/lib/sanitize.ts
+++ b/frontend/src/lib/sanitize.ts
@@ -1,0 +1,36 @@
+/**
+ * Error-message sanitisation (#499)
+ *
+ * Backend and on-chain contract errors are surfaced verbatim in the UI. A
+ * malicious or misconfigured contract could emit an error string containing
+ * markup (`<script>`, `<img onerror=…>`, inline event handlers), so we never
+ * trust that text. React already escapes string children, but we sanitise at
+ * the source as defence-in-depth: tags and their bodies are stripped and any
+ * stray angle brackets are removed so the result can only ever render as inert
+ * plain text — equivalent to assigning via `textContent` rather than
+ * `innerHTML`.
+ */
+
+const SCRIPT_BLOCK = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+const STYLE_BLOCK = /<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi;
+const HTML_TAG = /<\/?[a-z][\s\S]*?>/gi;
+
+const MAX_LENGTH = 500;
+
+/**
+ * Returns a plain-text, render-safe version of an arbitrary error value.
+ * Strips HTML tags (and `<script>`/`<style>` bodies), neutralises leftover
+ * angle brackets, collapses whitespace and caps the length.
+ */
+export function sanitizeErrorMessage(input: unknown): string {
+  const raw = typeof input === "string" ? input : String(input ?? "");
+
+  return raw
+    .replace(SCRIPT_BLOCK, "")
+    .replace(STYLE_BLOCK, "")
+    .replace(HTML_TAG, "")
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_LENGTH);
+}


### PR DESCRIPTION
# UI resilience, analytics performance, and XSS hardening

Bundles four related frontend/backend improvements. Each is a focused, self-contained change.

Closes #499 
Closes #502 
Closes #503 
Closes #504 

---

## #503 — Fix analytics query N+1 (`perf`)

The analytics endpoint duplicated four set-based queries inline in the route handler.

- Consolidated them into the data layer's `getAnalyticsData`, which now also accepts a `collaboratorLimit` and owns a **60s in-memory cache**.
- The route delegates to it, so every caller shares one query plan.
- Result: a **constant, small number of DB round-trips** (4 aggregate JOIN/`GROUP BY` queries) regardless of how many transactions exist — no per-row N+1.

**Tests** — `backend/tests/analytics-n1.test.js`:
- query count stays constant (spies on `db.prepare`),
- a second call within the TTL is served from cache (zero queries),
- the aggregate shape is preserved.

## #499 — XSS hardening in error display (`fix`)

Backend and on-chain contract errors are rendered verbatim in the UI.

- Added `frontend/src/lib/sanitize.ts` → `sanitizeErrorMessage()`, which strips HTML tags and `<script>`/`<style>` bodies and neutralises stray angle brackets, so error text can only ever render as inert plain text (equivalent to `textContent`, not `innerHTML`).
- Applied it in `FormStatus`, the shared error/status surface.
- Configured an **explicit Content-Security-Policy** via `helmet` (`script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, …) so an inline payload cannot execute even if it reaches the DOM.

**Tests** — `frontend/src/lib/sanitize.test.ts`: 5 payloads (`<script>`, `img onerror`, inline event handlers, stray brackets) plus a legitimate-message passthrough.

## #504 — Contract paused-state indicator (`feat`)

When a contract is paused, users could still attempt distributions that would panic on-chain.

- **Backend**: `GET /api/contract/pause/:contractId` returns the contract's pause state by reading `is_paused` + `get_pause_info` (paused flag, timestamp, source, remaining seconds).
- **Frontend**: new `PauseBanner` component explains why distribution is blocked and, for emergency (collaborator) pauses, **counts down to auto-expiry** (`HH:MM:SS`). Wired into the distribute form, which also **disables the submit button** while paused (and guards `submit()`).
- A failed pause read never blocks the form (fails open).

**Tests** — `frontend/src/components/PauseBanner.test.tsx`: renders nothing when not paused, shows the banner + countdown when paused, and `formatCountdown` formatting.

## #502 — Distribution auto-retry with backoff + circuit breaker (`feat`)

A network error while building a distribution forced a manual resubmit, risking duplicates.

- New `frontend/src/lib/distributionRetry.ts` wraps the build step in **exponential backoff (1s / 2s / 4s …)** using the existing `retryWithBackoff` util.
- **Circuit breaker** trips after repeated failed operations and short-circuits further attempts (`CircuitOpenError`).
- **Success-rate metrics** (`getRetryMetrics`) for observability.
- The form shows a **per-attempt countdown** so users wait instead of resubmitting; retries **abort on unmount / cancel**.
- Only **transient** errors (network or 5xx) are retried — deterministic 4xx responses fail fast.
- Added an optional `shouldRetry` predicate to the shared `retryWithBackoff` util (backwards-compatible; existing callers unaffected).

**Tests** — `frontend/src/lib/distributionRetry.test.ts`: immediate success + 100% success rate, retry-then-succeed with `onRetry`, no-retry on 4xx, and circuit-breaker trip + short-circuit.

---

## Verification

- Frontend: `cd frontend && npm test -- --run` — all new/affected suites pass (`sanitize`, `distributionRetry`, `retryWithBackoff`, `PauseBanner`, `DistributeForm`). 129 passing.
- Backend: `cd backend && npm test` — `analytics-n1`, `contract-info`, `contract-caching`, `error-response` pass.

### Pre-existing (not introduced by this PR)
- `frontend/src/lib/api-network.test.ts` has one flaky AbortController assertion that fails on `main` as well.
- `backend/tests/health.test.js` fails to load because `ioredis` (imported by `src/cache.js`) is not declared in `backend/package.json` — also true on `main`.
