### PR TITLE
fix: add explicit validation to reject fractional shares and basis points

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -101,6 +101,7 @@ Build an unsigned `initialize` transaction XDR.
 All initialize and royalty split payloads pass through request validation middleware before reaching contract processing. The middleware verifies that:
 - All recipient addresses are valid Stellar public keys (`G...`)
 - Revenue allocations sum to exactly `100%` (or `10,000` basis points)
+- Shares/percentages must resolve to integer basis points (no fractional basis points allowed)
 **Body:** `{ contractId, walletAddress, collaborators, shares, nonce? }`
 
 | Field | Type | Description |

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -269,11 +269,11 @@ export function validateRoyaltySplitMiddleware(req, res, next) {
     items = body.recipients.map((r, idx) => ({
       address: r.address ?? r.recipient ?? r.walletAddress ?? "",
       percentage: typeof r.percentage === "number" ? r.percentage : (typeof r.share === "number" ? r.share / 100 : null),
-      share: typeof r.share === "number" ? r.share : (typeof r.percentage === "number" ? Math.round(r.percentage * 100) : null),
+      share: typeof r.share === "number" ? r.share : (typeof r.percentage === "number" ? Number((r.percentage * 100).toFixed(4)) : null),
       path: `recipients.${idx}`,
     }));
   } else if (Array.isArray(body.recipients) && typeof body.recipients[0] === "string") {
-    const shares = body.shares ?? body.percentages?.map((p) => Math.round(p * 100)) ?? [];
+    const shares = body.shares ?? body.percentages?.map((p) => Number((p * 100).toFixed(4))) ?? [];
     const percentages = body.percentages ?? body.shares?.map((s) => s / 100) ?? [];
     if (body.recipients.length !== (body.percentages ?? body.shares ?? []).length) {
       return sendError(res, 400, "validation_error", "Validation failed: recipients and percentages/shares arrays must be the same length");
@@ -285,7 +285,7 @@ export function validateRoyaltySplitMiddleware(req, res, next) {
       path: `recipients.${idx}`,
     }));
   } else if (Array.isArray(body.collaborators)) {
-    const shares = body.shares ?? body.percentages?.map((p) => Math.round(p * 100)) ?? [];
+    const shares = body.shares ?? body.percentages?.map((p) => Number((p * 100).toFixed(4))) ?? [];
     const percentages = body.percentages ?? body.shares?.map((s) => s / 100) ?? [];
     if (body.collaborators.length !== (body.shares ?? body.percentages ?? []).length) {
       return sendError(res, 400, "validation_error", "Validation failed: collaborators and shares/percentages arrays must be the same length");
@@ -320,6 +320,11 @@ export function validateRoyaltySplitMiddleware(req, res, next) {
       issues.push({
         field: `${item.path}.share`,
         message: "Validation failed: Percentage or share must be a positive number",
+      });
+    } else if (!Number.isInteger(item.share)) {
+      issues.push({
+        field: `${item.path}.share`,
+        message: "Validation failed: Share must be an integer (fractional basis points are not allowed)",
       });
     }
   }

--- a/frontend/src/components/InitializeForm.test.tsx
+++ b/frontend/src/components/InitializeForm.test.tsx
@@ -53,17 +53,33 @@ describe("InitializeForm", () => {
     expect(screen.getByRole("button", { name: /Commit initialization/i })).toBeDisabled();
   });
 
-  test("shows percentage validation error for unsupported decimal precision", () => {
+  test("shows percentage validation error for fractional basis points", () => {
     render(
       <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
     );
 
     const percentInput = screen.getByPlaceholderText(/% \(0–100\)/i);
+    
+    // 1. Test with 33.333 (fractional basis points)
     fireEvent.change(percentInput, { target: { value: "33.333" } });
     fireEvent.blur(percentInput);
-
-    expect(screen.getByText(/up to 2 decimal places/i)).toBeInTheDocument();
+    expect(screen.getByText(/Fractional basis points are not allowed/i)).toBeInTheDocument();
     expect(percentInput).toHaveClass("input-error");
+
+    // 2. Test with 0.005 (fractional basis points)
+    fireEvent.change(percentInput, { target: { value: "0.005" } });
+    fireEvent.blur(percentInput);
+    expect(screen.getByText(/Fractional basis points are not allowed/i)).toBeInTheDocument();
+
+    // 3. Test with 3333.33 (too large percentage, fractional basis points if it were allowed)
+    fireEvent.change(percentInput, { target: { value: "3333.33" } });
+    fireEvent.blur(percentInput);
+    expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
+
+    // 4. Test with -0.5 (negative decimal percentage)
+    fireEvent.change(percentInput, { target: { value: "-0.5" } });
+    fireEvent.blur(percentInput);
+    expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
   });
 
   test("adds a second collaborator row when Add collaborator is clicked", () => {

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -42,7 +42,7 @@ interface Props {
 const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
 const MAX_COLLABORATORS = 50;
 const BASIS_POINTS_TOTAL = 10_000;
-const PERCENTAGE_INPUT_RE = /^(\d+(\.\d{0,2})?|\.\d{1,2})?$/;
+const PERCENTAGE_INPUT_RE = /^(\d+(\.\d*)?|\.\d+)?$/;
 const SIGNED_PERCENTAGE_INPUT_RE = /^-(\d+(\.\d*)?|\.\d+)$/;
 const PERCENTAGE_NAVIGATION_KEYS = [
   "Backspace",
@@ -63,15 +63,15 @@ function getPercentageError(value: string) {
   if (SIGNED_PERCENTAGE_INPUT_RE.test(value)) {
     return "Percentage must be between 0 and 100.";
   }
-  if (/^\d+(\.\d{3,})$|^\.\d{3,}$/.test(value)) {
-    return "Percentage supports up to 2 decimal places.";
-  }
-  if (!PERCENTAGE_INPUT_RE.test(value)) return "Percentage must be a number.";
-
   const numericValue = Number(value);
   if (Number.isNaN(numericValue)) return "Percentage must be a number.";
   if (numericValue < 0 || numericValue > 100) {
     return "Percentage must be between 0 and 100.";
+  }
+
+  const basisPoints = Number((numericValue * 100).toFixed(4));
+  if (!Number.isInteger(basisPoints)) {
+    return "Fractional basis points are not allowed.";
   }
 
   return "";
@@ -84,7 +84,7 @@ function isAllowedPercentageInput(value: string) {
 function parsePercentageToBasisPoints(value: string) {
   const error = getPercentageError(value);
   if (error) return null;
-  return Math.round(Number(value) * 100);
+  return Number((Number(value) * 100).toFixed(4));
 }
 
 function formatBasisPointsAsPercent(basisPoints: number) {


### PR DESCRIPTION


# Description

This PR fixes an issue where the frontend and backend middlewares were silently rounding decimal percentages or fractional shares instead of throwing a validation error. The contract requires integer basis points strictly to avoid misallocations and rounding errors. 

### Changes Made
- **Frontend Validation:** Updated the percentage regex in `InitializeForm.tsx` to explicitly check for and reject inputs that result in fractional basis points with a clear user-facing error (`"Fractional basis points are not allowed."`), stopping submission early.
- **Backend Middleware:** Replaced `Math.round()` inside `validateRoyaltySplitMiddleware` in `validation.js` with exact conversions, and added a strict `!Number.isInteger(share)` check to explicitly throw a `400 Bad Request` if fractional shares are submitted via API.
- **Test Coverage:** Added 4+ new test cases in `InitializeForm.test.tsx` verifying error states for inputs like `33.333`, `0.005`, `3333.33`, and negative decimals (`-0.5`). 
- **Documentation:** Updated `backend/API.md` to officially document the integer-only constraint for basis points.

Closes #483
