### PR TITLE
feat: add batch processing for large distributions (#521)

### DIFF
--- a/backend/src/database/batch-jobs.js
+++ b/backend/src/database/batch-jobs.js
@@ -1,0 +1,118 @@
+import { db, countWrite } from "./core.js";
+
+export const BATCH_SIZE = 100;
+
+/**
+ * Create a new batch distribution job.
+ * Splits collaborators into chunks of BATCH_SIZE and creates one batch_job row
+ * plus N batch_job_chunks rows.
+ *
+ * @returns {string} batchJobId
+ */
+export function createBatchJob(contractId, walletAddress, tokenId, collaborators) {
+  const batchJobId = crypto.randomUUID();
+  const totalChunks = Math.ceil(collaborators.length / BATCH_SIZE);
+
+  const insertJob = db.prepare(`
+    INSERT INTO batch_jobs (id, contractId, walletAddress, tokenId, totalCollaborators, totalChunks, status, createdAt)
+    VALUES (?, ?, ?, ?, ?, ?, 'queued', CURRENT_TIMESTAMP)
+  `);
+
+  const insertChunk = db.prepare(`
+    INSERT INTO batch_job_chunks (batchJobId, chunkIndex, collaborators, status, createdAt)
+    VALUES (?, ?, ?, 'pending', CURRENT_TIMESTAMP)
+  `);
+
+  db.transaction(() => {
+    insertJob.run(batchJobId, contractId, walletAddress, tokenId, collaborators.length, totalChunks);
+    for (let i = 0; i < totalChunks; i++) {
+      const chunk = collaborators.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE);
+      insertChunk.run(batchJobId, i, JSON.stringify(chunk));
+    }
+  })();
+
+  countWrite();
+  return batchJobId;
+}
+
+/** Get a batch job by ID. */
+export function getBatchJob(batchJobId) {
+  return db.prepare("SELECT * FROM batch_jobs WHERE id = ?").get(batchJobId);
+}
+
+/** List batch jobs for a contract (newest first). */
+export function listBatchJobs(contractId, limit = 20, offset = 0) {
+  return db
+    .prepare("SELECT * FROM batch_jobs WHERE contractId = ? ORDER BY createdAt DESC LIMIT ? OFFSET ?")
+    .all(contractId, limit, offset);
+}
+
+/** Get all chunks for a batch job. */
+export function getBatchJobChunks(batchJobId) {
+  return db
+    .prepare("SELECT * FROM batch_job_chunks WHERE batchJobId = ? ORDER BY chunkIndex ASC")
+    .all(batchJobId);
+}
+
+/** Get pending/failed chunks ready to process (for resume). */
+export function getPendingChunks(batchJobId) {
+  return db
+    .prepare(`SELECT * FROM batch_job_chunks WHERE batchJobId = ? AND status IN ('pending', 'failed') ORDER BY chunkIndex ASC`)
+    .all(batchJobId);
+}
+
+/** Mark a chunk as processing. */
+export function markChunkProcessing(chunkId) {
+  db.prepare("UPDATE batch_job_chunks SET status = 'processing', startedAt = CURRENT_TIMESTAMP WHERE id = ?").run(chunkId);
+  countWrite();
+}
+
+/** Mark a chunk as completed. */
+export function markChunkCompleted(chunkId, transactionId) {
+  db.prepare(`UPDATE batch_job_chunks SET status = 'completed', transactionId = ?, completedAt = CURRENT_TIMESTAMP WHERE id = ?`).run(transactionId, chunkId);
+  _refreshJobStatus(db.prepare("SELECT batchJobId FROM batch_job_chunks WHERE id = ?").get(chunkId)?.batchJobId);
+  countWrite();
+}
+
+/** Mark a chunk as failed. */
+export function markChunkFailed(chunkId, errorMessage) {
+  db.prepare(`UPDATE batch_job_chunks SET status = 'failed', errorMessage = ?, completedAt = CURRENT_TIMESTAMP WHERE id = ?`).run(errorMessage, chunkId);
+  _refreshJobStatus(db.prepare("SELECT batchJobId FROM batch_job_chunks WHERE id = ?").get(chunkId)?.batchJobId);
+  countWrite();
+}
+
+/** Recompute and update the parent batch_job status from chunk statuses. */
+function _refreshJobStatus(batchJobId) {
+  if (!batchJobId) return;
+  const chunks = db.prepare("SELECT status FROM batch_job_chunks WHERE batchJobId = ?").all(batchJobId);
+  const statuses = chunks.map((c) => c.status);
+  let jobStatus;
+  if (statuses.every((s) => s === "completed")) {
+    jobStatus = "completed";
+  } else if (statuses.some((s) => s === "processing" || s === "pending")) {
+    jobStatus = "processing";
+  } else if (statuses.every((s) => s === "failed")) {
+    jobStatus = "failed";
+  } else {
+    // mixed completed/failed
+    jobStatus = "partial";
+  }
+  const completedChunks = statuses.filter((s) => s === "completed").length;
+  const completedAt = jobStatus === "completed" || jobStatus === "partial" || jobStatus === "failed"
+    ? "CURRENT_TIMESTAMP"
+    : "NULL";
+  db.prepare(`
+    UPDATE batch_jobs SET status = ?, completedChunks = ?, completedAt = ${completedAt} WHERE id = ?
+  `).run(jobStatus, completedChunks, batchJobId);
+}
+
+/** Get monitoring stats (counts by status). */
+export function getBatchMonitoringStats() {
+  const jobStats = db.prepare(`
+    SELECT status, COUNT(*) as count FROM batch_jobs GROUP BY status
+  `).all();
+  const chunkStats = db.prepare(`
+    SELECT status, COUNT(*) as count FROM batch_job_chunks GROUP BY status
+  `).all();
+  return { jobs: jobStats, chunks: chunkStats };
+}

--- a/backend/src/database/core.js
+++ b/backend/src/database/core.js
@@ -354,6 +354,42 @@ export function initializeDatabase() {
           ON transactions(contractId, timestamp DESC);
       `,
     },
+    {
+      // Issue #521: batch processing for large distributions
+      version: 11,
+      sql: `
+        CREATE TABLE IF NOT EXISTS batch_jobs (
+          id TEXT PRIMARY KEY,
+          contractId TEXT NOT NULL,
+          walletAddress TEXT NOT NULL,
+          tokenId TEXT NOT NULL,
+          totalCollaborators INTEGER NOT NULL,
+          totalChunks INTEGER NOT NULL,
+          completedChunks INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK(status IN ('queued', 'processing', 'completed', 'failed', 'partial')),
+          createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+          completedAt DATETIME
+        );
+        CREATE INDEX IF NOT EXISTS idx_batch_jobs_contractId ON batch_jobs(contractId);
+        CREATE INDEX IF NOT EXISTS idx_batch_jobs_status ON batch_jobs(status);
+
+        CREATE TABLE IF NOT EXISTS batch_job_chunks (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          batchJobId TEXT NOT NULL,
+          chunkIndex INTEGER NOT NULL,
+          collaborators TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'processing', 'completed', 'failed')),
+          transactionId INTEGER,
+          errorMessage TEXT,
+          createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+          startedAt DATETIME,
+          completedAt DATETIME,
+          FOREIGN KEY(batchJobId) REFERENCES batch_jobs(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_batch_job_chunks_batchJobId ON batch_job_chunks(batchJobId);
+        CREATE INDEX IF NOT EXISTS idx_batch_job_chunks_status ON batch_job_chunks(status);
+      `,
+    },
   ];
 
   const applied = db

--- a/backend/src/database/index.js
+++ b/backend/src/database/index.js
@@ -76,6 +76,19 @@ export {
 // Analytics
 export { getAnalyticsData } from "./analytics.js";
 
+// Batch processing (#521)
+export {
+  createBatchJob,
+  getBatchJob,
+  listBatchJobs,
+  getBatchJobChunks,
+  getPendingChunks,
+  markChunkProcessing,
+  markChunkCompleted,
+  markChunkFailed,
+  getBatchMonitoringStats,
+} from "./batch-jobs.js";
+
 // Query profiling (#500)
 export { getQueryProfilerMetrics, resetQueryProfilerMetrics } from "../query-profiler.js";
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -39,6 +39,7 @@ import { getConfiguredContractId } from "./stellar.js";
 import { startRecoveryJob, stopRecoveryJob } from "./jobs/secondary-royalty-recovery.js";
 import { verifySignedWriteRequest } from "./request-signature.js";
 import eventsRouter from "./routes/events.js";
+import { batchRouter } from "./routes/batch-distribute.js";
 
 // Initialize database on startup
 initializeDatabase();
@@ -224,6 +225,7 @@ app.use("/api/v1/distribute", writeLimiter);
 app.use("/api/v1/secondary-royalty", writeLimiter);
 app.use("/api/v1/transaction", writeLimiter);
 app.use("/api/v1/audit", writeLimiter);
+app.use("/api/v1/batch-distribute", writeLimiter);
 
 // Require Ed25519 request signatures for mutating client API operations.
 app.use("/api/v1/initialize", verifySignedWriteRequest);
@@ -231,9 +233,11 @@ app.use("/api/v1/distribute", verifySignedWriteRequest);
 app.use("/api/v1/secondary-royalty", verifySignedWriteRequest);
 app.use("/api/v1/transaction", verifySignedWriteRequest);
 app.use("/api/v1/audit", verifySignedWriteRequest);
+app.use("/api/v1/batch-distribute", verifySignedWriteRequest);
 
 app.use("/api/v1/initialize", initializeRouter);
 app.use("/api/v1/distribute", distributeRouter);
+app.use("/api/v1/batch-distribute", batchRouter);
 app.use("/api/v1/collaborators", collaboratorsRouter);
 app.use("/api/v1/secondary-royalty", secondaryRoyaltyRouter);
 app.use("/api/v1/simulate", simulateRouter);

--- a/backend/src/routes/batch-distribute.js
+++ b/backend/src/routes/batch-distribute.js
@@ -1,0 +1,176 @@
+import { Router } from "express";
+import { z } from "zod";
+import { validate, contractAddress, stellarAddress } from "../validation.js";
+import { sendError } from "../error-response.js";
+import { createRequestLogger } from "../logger.js";
+import {
+  createBatchJob,
+  getBatchJob,
+  getBatchJobChunks,
+  getPendingChunks,
+  listBatchJobs,
+  markChunkProcessing,
+  markChunkCompleted,
+  markChunkFailed,
+  getBatchMonitoringStats,
+} from "../database/index.js";
+import { buildAndRecordTransaction } from "./_shared.js";
+import { addressToScVal, vecToScVal } from "../stellar.js";
+
+export const batchRouter = Router();
+
+const createBatchSchema = z.object({
+  contractId: contractAddress,
+  walletAddress: stellarAddress,
+  tokenId: contractAddress,
+  collaborators: z
+    .array(stellarAddress)
+    .min(1, "At least one collaborator is required")
+    .max(10000, "Cannot batch more than 10000 collaborators"),
+});
+
+const resumeSchema = z.object({
+  walletAddress: stellarAddress,
+});
+
+/**
+ * POST /api/v1/batch-distribute
+ * Enqueue a large distribution job split into chunks of 100 collaborators.
+ * Body: { contractId, walletAddress, tokenId, collaborators: string[] }
+ * Returns: { batchJobId, totalChunks, totalCollaborators }
+ */
+batchRouter.post("/", validate(createBatchSchema), async (req, res, next) => {
+  const log = createRequestLogger(req);
+  try {
+    const { contractId, walletAddress, tokenId, collaborators } = req.body;
+
+    log.info("batch distribute enqueued", {
+      contractId,
+      walletAddress,
+      tokenId,
+      collaborators: collaborators.length,
+    });
+
+    const batchJobId = createBatchJob(contractId, walletAddress, tokenId, collaborators);
+    const job = getBatchJob(batchJobId);
+
+    res.status(202).json({
+      batchJobId,
+      totalChunks: job.totalChunks,
+      totalCollaborators: job.totalCollaborators,
+      status: job.status,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /api/v1/batch-distribute/:batchJobId
+ * Get status of a batch job including per-chunk details.
+ */
+batchRouter.get("/:batchJobId", async (req, res) => {
+  const job = getBatchJob(req.params.batchJobId);
+  if (!job) return sendError(res, 404, "not_found", "Batch job not found");
+
+  const chunks = getBatchJobChunks(job.id);
+  res.json({ ...job, chunks });
+});
+
+/**
+ * POST /api/v1/batch-distribute/:batchJobId/process
+ * Process pending chunks of a batch job (one chunk per call, or all pending).
+ * Body: { walletAddress }
+ * Returns: { processed: number, failed: number }
+ */
+batchRouter.post("/:batchJobId/process", validate(resumeSchema), async (req, res, next) => {
+  const log = createRequestLogger(req);
+  const job = getBatchJob(req.params.batchJobId);
+  if (!job) return sendError(res, 404, "not_found", "Batch job not found");
+
+  const { walletAddress } = req.body;
+  const chunks = getPendingChunks(job.id);
+  if (chunks.length === 0) {
+    return res.json({ processed: 0, failed: 0, message: "No pending chunks" });
+  }
+
+  let processed = 0;
+  let failed = 0;
+
+  for (const chunk of chunks) {
+    markChunkProcessing(chunk.id);
+    try {
+      const collaborators = JSON.parse(chunk.collaborators);
+      const scVals = collaborators.map(addressToScVal);
+      const collaboratorsVec = vecToScVal(scVals);
+      const tokenScVal = addressToScVal(job.tokenId);
+
+      const { transactionId } = await buildAndRecordTransaction({
+        contractId: job.contractId,
+        walletAddress,
+        transactionType: "distribute",
+        contractMethod: "batch_distribute",
+        scvlArgs: [tokenScVal, collaboratorsVec],
+        auditAction: "batch_chunk_initiated",
+        auditMetadata: {
+          batchJobId: job.id,
+          chunkIndex: chunk.chunkIndex,
+          collaboratorCount: collaborators.length,
+        },
+        transactionMetadata: { tokenId: job.tokenId },
+        correlationId: req.correlationId,
+      });
+
+      markChunkCompleted(chunk.id, transactionId);
+      processed++;
+      log.info("batch chunk processed", { batchJobId: job.id, chunkIndex: chunk.chunkIndex });
+    } catch (err) {
+      markChunkFailed(chunk.id, err.message ?? String(err));
+      failed++;
+      log.error("batch chunk failed", { batchJobId: job.id, chunkIndex: chunk.chunkIndex, error: err.message });
+    }
+  }
+
+  const updatedJob = getBatchJob(job.id);
+  res.json({ processed, failed, status: updatedJob.status });
+});
+
+/**
+ * POST /api/v1/batch-distribute/:batchJobId/resume
+ * Resume failed chunks of a batch job (alias for /process that only retries failed chunks).
+ * Body: { walletAddress }
+ */
+batchRouter.post("/:batchJobId/resume", validate(resumeSchema), async (req, res, next) => {
+  const log = createRequestLogger(req);
+  const job = getBatchJob(req.params.batchJobId);
+  if (!job) return sendError(res, 404, "not_found", "Batch job not found");
+  if (!["failed", "partial"].includes(job.status)) {
+    return sendError(res, 409, "invalid_state", `Job is in '${job.status}' state, only 'failed' or 'partial' jobs can be resumed`);
+  }
+
+  // Delegate to the same processing logic by forwarding to /process
+  req.url = `/${req.params.batchJobId}/process`;
+  return batchRouter.handle(req, res, next);
+});
+
+/**
+ * GET /api/v1/batch-distribute
+ * List batch jobs for a contract.
+ * Query: contractId, limit, offset
+ */
+batchRouter.get("/", async (req, res) => {
+  const { contractId, limit = 20, offset = 0 } = req.query;
+  if (!contractId) return sendError(res, 400, "missing_param", "contractId query param is required");
+
+  const jobs = listBatchJobs(contractId, Number(limit), Number(offset));
+  res.json({ jobs });
+});
+
+/**
+ * GET /api/v1/batch-distribute/monitoring/stats
+ * Aggregate monitoring stats across all batch jobs.
+ */
+batchRouter.get("/monitoring/stats", async (_req, res) => {
+  const stats = getBatchMonitoringStats();
+  res.json(stats);
+});

--- a/backend/tests/batch-distribute.test.js
+++ b/backend/tests/batch-distribute.test.js
@@ -1,0 +1,508 @@
+/**
+ * Tests for batch distribution (#521):
+ * - Queue a batch job
+ * - Retrieve status
+ * - Process chunks
+ * - Resume failed batches
+ * - Monitoring stats
+ */
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const retryBuildTx = jest.fn();
+
+await jest.unstable_mockModule("@stellar/stellar-sdk", () => ({
+  default: {},
+  Address: { fromScVal: jest.fn((v) => ({ toString: () => v })) },
+  Contract: jest.fn().mockImplementation(() => ({ call: jest.fn((m) => ({ method: m })) })),
+  SorobanRpc: { Api: { isSimulationError: jest.fn(() => false) } },
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  BASE_FEE: "100",
+  Account: jest.fn(),
+  scValToNative: jest.fn((v) => v),
+}));
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  retryBuildTx,
+  isContractInitialized: jest.fn(),
+  addressToScVal: jest.fn((a) => `scval:${a}`),
+  vecToScVal: jest.fn((v) => `vec:${JSON.stringify(v)}`),
+  getNetworkLabel: jest.fn(() => "Testnet"),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: jest.fn(() => ({ valid: true, errors: [] })),
+}));
+
+// In-memory store for batch jobs and chunks
+const batchJobsStore = new Map();
+const batchChunksStore = new Map();
+let chunkIdCounter = 1;
+
+const createBatchJob = jest.fn((contractId, walletAddress, tokenId, collaborators) => {
+  const id = `batch-${Date.now()}`;
+  const BATCH_SIZE = 100;
+  const totalChunks = Math.ceil(collaborators.length / BATCH_SIZE);
+  const job = {
+    id,
+    contractId,
+    walletAddress,
+    tokenId,
+    totalCollaborators: collaborators.length,
+    totalChunks,
+    completedChunks: 0,
+    status: "queued",
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+  };
+  batchJobsStore.set(id, job);
+  for (let i = 0; i < totalChunks; i++) {
+    const chunkId = chunkIdCounter++;
+    batchChunksStore.set(chunkId, {
+      id: chunkId,
+      batchJobId: id,
+      chunkIndex: i,
+      collaborators: JSON.stringify(collaborators.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE)),
+      status: "pending",
+      transactionId: null,
+      errorMessage: null,
+    });
+  }
+  return id;
+});
+
+const getBatchJob = jest.fn((id) => batchJobsStore.get(id) ?? null);
+
+const getBatchJobChunks = jest.fn((id) =>
+  [...batchChunksStore.values()].filter((c) => c.batchJobId === id)
+);
+
+const getPendingChunks = jest.fn((id) =>
+  [...batchChunksStore.values()].filter(
+    (c) => c.batchJobId === id && ["pending", "failed"].includes(c.status)
+  )
+);
+
+const markChunkProcessing = jest.fn((chunkId) => {
+  const c = batchChunksStore.get(chunkId);
+  if (c) c.status = "processing";
+});
+
+const markChunkCompleted = jest.fn((chunkId, txId) => {
+  const c = batchChunksStore.get(chunkId);
+  if (c) {
+    c.status = "completed";
+    c.transactionId = txId;
+    const job = batchJobsStore.get(c.batchJobId);
+    if (job) {
+      job.completedChunks++;
+      job.status = job.completedChunks === job.totalChunks ? "completed" : "processing";
+    }
+  }
+});
+
+const markChunkFailed = jest.fn((chunkId, errorMessage) => {
+  const c = batchChunksStore.get(chunkId);
+  if (c) {
+    c.status = "failed";
+    c.errorMessage = errorMessage;
+    const job = batchJobsStore.get(c.batchJobId);
+    if (job) job.status = "failed";
+  }
+});
+
+const listBatchJobs = jest.fn((contractId) =>
+  [...batchJobsStore.values()].filter((j) => j.contractId === contractId)
+);
+
+const getBatchMonitoringStats = jest.fn(() => ({
+  jobs: [{ status: "queued", count: 1 }],
+  chunks: [{ status: "pending", count: 2 }],
+}));
+
+const recordTransaction = jest.fn(() => 999);
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  createBatchJob,
+  getBatchJob,
+  getBatchJobChunks,
+  getPendingChunks,
+  markChunkProcessing,
+  markChunkCompleted,
+  markChunkFailed,
+  listBatchJobs,
+  getBatchMonitoringStats,
+  recordTransaction,
+  addAuditLog: jest.fn(),
+  initializeDatabase: jest.fn(),
+  getMigrationVersion: jest.fn(() => 11),
+}));
+
+const { batchRouter } = await import("../src/routes/batch-distribute.js");
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+app.use("/api/v1/batch-distribute", batchRouter);
+app.use((err, _req, res, _next) => {
+  res.status(500).json({ error: err.message ?? "Internal server error" });
+});
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const WALLET   = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN    = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+// Generate N valid Stellar public addresses (G + 55 base32 chars A-Z2-7)
+function makeCollaborators(n) {
+  const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  return Array.from({ length: n }, (_, i) => {
+    // encode i as base32-like suffix (5 chars), rest padded with 'A'
+    let rem = i;
+    let suffix = "";
+    for (let s = 0; s < 5; s++) {
+      suffix = CHARS[rem % CHARS.length] + suffix;
+      rem = Math.floor(rem / CHARS.length);
+    }
+    return `G${"A".repeat(50)}${suffix}`;
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/v1/batch-distribute — queue batch job", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    batchJobsStore.clear();
+    batchChunksStore.clear();
+    chunkIdCounter = 1;
+  });
+
+  test("1. enqueues a batch job and returns 202 with batchJobId", async () => {
+    const collaborators = makeCollaborators(250);
+    createBatchJob.mockImplementationOnce((cId, wAddr, tId, colls) => {
+      const id = "batch-test-1";
+      batchJobsStore.set(id, {
+        id,
+        contractId: cId,
+        walletAddress: wAddr,
+        tokenId: tId,
+        totalCollaborators: colls.length,
+        totalChunks: 3,
+        completedChunks: 0,
+        status: "queued",
+        createdAt: new Date().toISOString(),
+        completedAt: null,
+      });
+      return id;
+    });
+
+    const res = await request(app)
+      .post("/api/v1/batch-distribute")
+      .send({ contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN, collaborators });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toMatchObject({
+      batchJobId: "batch-test-1",
+      totalChunks: 3,
+      totalCollaborators: 250,
+      status: "queued",
+    });
+    expect(createBatchJob).toHaveBeenCalledWith(CONTRACT, WALLET, TOKEN, collaborators);
+  });
+
+  test("2. splits 100 collaborators into exactly 1 chunk", async () => {
+    const collaborators = makeCollaborators(100);
+    createBatchJob.mockImplementationOnce((cId, wAddr, tId, colls) => {
+      const id = "batch-test-2";
+      batchJobsStore.set(id, {
+        id,
+        contractId: cId,
+        walletAddress: wAddr,
+        tokenId: tId,
+        totalCollaborators: colls.length,
+        totalChunks: 1,
+        completedChunks: 0,
+        status: "queued",
+        createdAt: new Date().toISOString(),
+        completedAt: null,
+      });
+      return id;
+    });
+
+    const res = await request(app)
+      .post("/api/v1/batch-distribute")
+      .send({ contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN, collaborators });
+
+    expect(res.status).toBe(202);
+    expect(res.body.totalChunks).toBe(1);
+  });
+
+  test("3. validates required fields — returns 400 when contractId missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/batch-distribute")
+      .send({ walletAddress: WALLET, tokenId: TOKEN, collaborators: makeCollaborators(5) });
+
+    expect(res.status).toBe(400);
+    expect(createBatchJob).not.toHaveBeenCalled();
+  });
+
+  test("4. validates collaborators array — returns 400 when empty", async () => {
+    const res = await request(app)
+      .post("/api/v1/batch-distribute")
+      .send({ contractId: CONTRACT, walletAddress: WALLET, tokenId: TOKEN, collaborators: [] });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/batch-distribute/:batchJobId — status", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    batchJobsStore.clear();
+    batchChunksStore.clear();
+    chunkIdCounter = 1;
+  });
+
+  test("5. returns batch job status with chunks", async () => {
+    const jobId = "status-test-1";
+    batchJobsStore.set(jobId, {
+      id: jobId,
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 150,
+      totalChunks: 2,
+      completedChunks: 1,
+      status: "processing",
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    batchChunksStore.set(1, { id: 1, batchJobId: jobId, chunkIndex: 0, status: "completed", collaborators: "[]" });
+    batchChunksStore.set(2, { id: 2, batchJobId: jobId, chunkIndex: 1, status: "pending", collaborators: "[]" });
+
+    const res = await request(app).get(`/api/v1/batch-distribute/${jobId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(jobId);
+    expect(res.body.status).toBe("processing");
+    expect(res.body.chunks).toHaveLength(2);
+  });
+
+  test("6. returns 404 for unknown batch job", async () => {
+    getBatchJob.mockReturnValueOnce(null);
+
+    const res = await request(app).get("/api/v1/batch-distribute/nonexistent-id");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+});
+
+describe("POST /api/v1/batch-distribute/:batchJobId/process — process chunks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    batchJobsStore.clear();
+    batchChunksStore.clear();
+    chunkIdCounter = 1;
+  });
+
+  test("7. processes pending chunks and returns processed count", async () => {
+    const jobId = "process-test-1";
+    batchJobsStore.set(jobId, {
+      id: jobId,
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 2,
+      totalChunks: 1,
+      completedChunks: 0,
+      status: "queued",
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    batchChunksStore.set(1, {
+      id: 1,
+      batchJobId: jobId,
+      chunkIndex: 0,
+      status: "pending",
+      collaborators: JSON.stringify(makeCollaborators(2)),
+      transactionId: null,
+      errorMessage: null,
+    });
+
+    retryBuildTx.mockResolvedValue("mock-xdr");
+
+    const res = await request(app)
+      .post(`/api/v1/batch-distribute/${jobId}/process`)
+      .send({ walletAddress: WALLET });
+
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(1);
+    expect(res.body.failed).toBe(0);
+    expect(markChunkCompleted).toHaveBeenCalledWith(1, expect.anything());
+  });
+
+  test("8. marks chunk as failed when Stellar RPC throws", async () => {
+    const jobId = "process-fail-1";
+    batchJobsStore.set(jobId, {
+      id: jobId,
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 1,
+      totalChunks: 1,
+      completedChunks: 0,
+      status: "queued",
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    batchChunksStore.set(2, {
+      id: 2,
+      batchJobId: jobId,
+      chunkIndex: 0,
+      status: "pending",
+      collaborators: JSON.stringify(makeCollaborators(1)),
+      transactionId: null,
+      errorMessage: null,
+    });
+
+    retryBuildTx.mockRejectedValue(new Error("RPC unavailable"));
+
+    const res = await request(app)
+      .post(`/api/v1/batch-distribute/${jobId}/process`)
+      .send({ walletAddress: WALLET });
+
+    expect(res.status).toBe(200);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.processed).toBe(0);
+    expect(markChunkFailed).toHaveBeenCalledWith(2, "RPC unavailable");
+  });
+
+  test("9. returns 404 for unknown job", async () => {
+    getBatchJob.mockReturnValueOnce(null);
+
+    const res = await request(app)
+      .post("/api/v1/batch-distribute/unknown/process")
+      .send({ walletAddress: WALLET });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/v1/batch-distribute/:batchJobId/resume — resume failed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    batchJobsStore.clear();
+    batchChunksStore.clear();
+    chunkIdCounter = 1;
+  });
+
+  test("10. resumes a failed job and retries failed chunks", async () => {
+    const jobId = "resume-test-1";
+    batchJobsStore.set(jobId, {
+      id: jobId,
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 1,
+      totalChunks: 1,
+      completedChunks: 0,
+      status: "failed",
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+    batchChunksStore.set(3, {
+      id: 3,
+      batchJobId: jobId,
+      chunkIndex: 0,
+      status: "failed",
+      collaborators: JSON.stringify(makeCollaborators(1)),
+      transactionId: null,
+      errorMessage: "previous error",
+    });
+
+    retryBuildTx.mockResolvedValue("resume-xdr");
+
+    // Resume delegates to /process which uses getPendingChunks (includes 'failed')
+    const res = await request(app)
+      .post(`/api/v1/batch-distribute/${jobId}/resume`)
+      .send({ walletAddress: WALLET });
+
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(1);
+  });
+
+  test("11. returns 409 when job is not in failed/partial state", async () => {
+    const jobId = "resume-conflict-1";
+    batchJobsStore.set(jobId, {
+      id: jobId,
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 1,
+      totalChunks: 1,
+      completedChunks: 1,
+      status: "completed",
+      createdAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/batch-distribute/${jobId}/resume`)
+      .send({ walletAddress: WALLET });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("GET /api/v1/batch-distribute/monitoring/stats — monitoring", () => {
+  test("12. returns job and chunk stats", async () => {
+    const res = await request(app).get("/api/v1/batch-distribute/monitoring/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("jobs");
+    expect(res.body).toHaveProperty("chunks");
+    expect(getBatchMonitoringStats).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/v1/batch-distribute — list jobs", () => {
+  test("13. returns jobs for a given contractId", async () => {
+    batchJobsStore.clear();
+    batchJobsStore.set("j1", {
+      id: "j1",
+      contractId: CONTRACT,
+      walletAddress: WALLET,
+      tokenId: TOKEN,
+      totalCollaborators: 50,
+      totalChunks: 1,
+      completedChunks: 0,
+      status: "queued",
+      createdAt: new Date().toISOString(),
+      completedAt: null,
+    });
+
+    const res = await request(app).get(`/api/v1/batch-distribute?contractId=${CONTRACT}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.jobs).toHaveLength(1);
+    expect(listBatchJobs).toHaveBeenCalledWith(CONTRACT, 20, 0);
+  });
+
+  test("14. returns 400 when contractId is missing", async () => {
+    const res = await request(app).get("/api/v1/batch-distribute");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/contractId/i);
+  });
+});


### PR DESCRIPTION
## Summary

Implements batch processing for large distributions as described in issue #521.

Closes #521

## Changes

- **** — new DB module with helpers for creating and tracking batch jobs and chunks
- **** — migration v11: adds `batch_jobs` and `batch_job_chunks` tables
- **** — new route with 6 endpoints
- **** — mounts `/api/v1/batch-distribute` with rate-limit + signature verification

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/v1/batch-distribute` | Enqueue a batch job (202) |
| GET | `/api/v1/batch-distribute/:id` | Job status + per-chunk detail |
| POST | `/api/v1/batch-distribute/:id/process` | Process pending chunks |
| POST | `/api/v1/batch-distribute/:id/resume` | Resume failed/partial jobs |
| GET | `/api/v1/batch-distribute` | List jobs by contractId |
| GET | `/api/v1/batch-distribute/monitoring/stats` | Aggregate stats |

## Acceptance Criteria

- [x] Batching implemented — max 100 collaborators per chunk, splits automatically
- [x] Queue working — POST returns 202 with `batchJobId`
- [x] Resume working — retries failed/partial jobs; 409 if not resumable
- [x] 5+ batch tests — 14 tests, all passing
- [x] Monitoring dashboard — `GET /monitoring/stats` returns job/chunk counts by status

## Tests

14 new tests in `backend/tests/batch-distribute.test.js` — all passing. No regressions in existing suite.