### PR TITLE
fixing missing xdr

### DIFF
--- a/backend/src/routes/_shared.js
+++ b/backend/src/routes/_shared.js
@@ -3,6 +3,31 @@ import { recordTransaction, addAuditLog } from "../database/index.js";
 import { validateXdrStructure } from "../xdr-validation.js";
 
 /**
+ * Validate freshly built transaction XDR before it is returned to the client.
+ *
+ * Every route that builds an unsigned transaction must funnel its XDR through
+ * here so invalid XDR is never handed back to the frontend (where it would be
+ * signed and submitted, wasting user fees on a transaction the network rejects).
+ *
+ * Throws a structured `{ status, code, message }` error — picked up by the
+ * central error handler in index.js — when validation fails.
+ *
+ * @param {string} txXdr - base64 transaction envelope produced by buildTx/retryBuildTx
+ * @returns {string} the same XDR, unchanged, when it is valid
+ */
+export function assertValidXdr(txXdr) {
+  const validation = validateXdrStructure(txXdr, networkPassphrase);
+  if (!validation.valid) {
+    throw {
+      status: 500,
+      code: "xdr_validation_error",
+      message: `Invalid transaction XDR: ${validation.errors.join("; ")}`,
+    };
+  }
+  return txXdr;
+}
+
+/**
  * Shared pattern for transaction-building routes:
  * 1. Record transaction in database
  * 2. Build transaction XDR (with correlation ID threaded through RPC calls)
@@ -40,14 +65,7 @@ export async function buildAndRecordTransaction({
     correlationId,
   );
 
-  const validation = validateXdrStructure(txXdr, networkPassphrase);
-  if (!validation.valid) {
-    throw {
-      status: 500,
-      code: "xdr_validation_error",
-      message: `Invalid transaction XDR: ${validation.errors.join("; ")}`,
-    };
-  }
+  assertValidXdr(txXdr);
 
   // Log the audit event
   addAuditLog(contractId, auditAction, walletAddress, {

--- a/backend/src/routes/secondary-royalty.js
+++ b/backend/src/routes/secondary-royalty.js
@@ -26,6 +26,7 @@ import {
   getDeadLetterItems,
 } from "../database/index.js";
 import { idempotencyMiddleware } from "../idempotency.js";
+import { assertValidXdr } from "./_shared.js";
 import {
   validate,
   recordSecondarySaleSchema,
@@ -150,6 +151,9 @@ secondaryRoyaltyRouter.post("/", idempotencyMiddleware, validate(recordSecondary
       i128ToScVal(salePrice),
     ]);
 
+    // Reject invalid XDR before it ever reaches the client (#XDR validation).
+    assertValidXdr(txXdr);
+
     addAuditLog(contractId, "secondary_sale_recorded", walletAddress, {
       transactionId,
       nftId,
@@ -201,6 +205,9 @@ secondaryRoyaltyRouter.post("/set-rate", validate(setRoyaltyRateSchema), async (
     const txXdr = await buildTx(walletAddress, contractId, "set_royalty_rate", [
       u32ToScVal(royaltyRate),
     ]);
+
+    // Reject invalid XDR before it ever reaches the client (#XDR validation).
+    assertValidXdr(txXdr);
 
     addAuditLog(contractId, "royalty_rate_set", walletAddress, {
       transactionId,
@@ -325,6 +332,11 @@ secondaryRoyaltyRouter.post(
           `Distribution failed and queued for retry: ${errorMessage}`
         );
       }
+
+      // Reject invalid XDR before committing any DB state or returning it to
+      // the client. An invalid envelope is a deterministic failure, so it is
+      // surfaced as an error rather than queued for retry.
+      assertValidXdr(txXdr);
 
       // All DB writes are atomic: if any step fails, the transaction rolls back
       // and pending sales remain undistributed (#471).

--- a/backend/tests/secondary-royalty-atomic.test.js
+++ b/backend/tests/secondary-royalty-atomic.test.js
@@ -24,6 +24,13 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+// --- XDR validation mock --------------------------------------------------
+// Placeholder XDR strings used in these tests aren't real envelopes, so stub
+// the validator to accept them; dedicated tests cover the validation itself.
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: () => ({ valid: true }),
+}));
+
 // --- Database mock --------------------------------------------------------
 const getSecondarySales = jest.fn();
 const commitSecondaryDistributionAtomic = jest.fn();

--- a/backend/tests/secondary-royalty-constraint.test.js
+++ b/backend/tests/secondary-royalty-constraint.test.js
@@ -18,6 +18,13 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   i128ToScVal: jest.fn((n) => n),
   u32ToScVal: jest.fn((n) => n),
   server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+// Placeholder XDR strings used in these tests aren't real envelopes, so stub
+// the validator to accept them; dedicated tests cover the validation itself.
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: () => ({ valid: true }),
 }));
 
 await jest.unstable_mockModule("../src/logger.js", () => ({

--- a/backend/tests/secondary-royalty-idempotency.test.js
+++ b/backend/tests/secondary-royalty-idempotency.test.js
@@ -27,6 +27,13 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+// --- XDR validation mock --------------------------------------------------
+// Placeholder XDR strings used in these tests aren't real envelopes, so stub
+// the validator to accept them; dedicated tests cover the validation itself.
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: () => ({ valid: true }),
+}));
+
 // --- Database mock --------------------------------------------------------
 const getSecondarySales = jest.fn();
 const commitSecondaryDistributionAtomic = jest.fn();

--- a/backend/tests/secondary-royalty-pagination.test.js
+++ b/backend/tests/secondary-royalty-pagination.test.js
@@ -22,6 +22,13 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   i128ToScVal: jest.fn((n) => n),
   u32ToScVal: jest.fn((n) => n),
   server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+// secondary-royalty.js now pulls in the XDR validator via _shared.js; stub it
+// so these GET-route tests don't depend on real envelope parsing.
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: () => ({ valid: true }),
 }));
 
 await jest.unstable_mockModule("../src/logger.js", () => ({

--- a/backend/tests/secondary-royalty-recovery.test.js
+++ b/backend/tests/secondary-royalty-recovery.test.js
@@ -26,6 +26,13 @@ await jest.unstable_mockModule("../src/stellar.js", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+// --- XDR validation mock --------------------------------------------------
+// Placeholder XDR strings used in these tests aren't real envelopes, so stub
+// the validator to accept them; dedicated tests cover the validation itself.
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure: () => ({ valid: true }),
+}));
+
 // --- Database mock --------------------------------------------------------
 const getSecondarySales = jest.fn();
 const commitSecondaryDistributionAtomic = jest.fn();

--- a/backend/tests/secondary-royalty-xdr-validation.test.js
+++ b/backend/tests/secondary-royalty-xdr-validation.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests for XDR validation on the secondary-royalty transaction routes.
+ *
+ * The secondary-royalty endpoints build unsigned transaction XDR with
+ * `buildTx` and return it to the client. Before this change those three
+ * endpoints returned the XDR without validating it, so a malformed envelope
+ * could reach the frontend, be signed by Freighter, and waste user fees when
+ * the network rejected it.
+ *
+ * These tests verify that every XDR-returning secondary-royalty route now runs
+ * the freshly built XDR through `validateXdrStructure` and rejects invalid XDR
+ * with a clear `xdr_validation_error` before returning or committing any state.
+ */
+
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+
+const CONTRACT_ID = "C" + "A".repeat(55);
+const WALLET = "G" + "A".repeat(55);
+const TOKEN_ID = "C" + "B".repeat(55);
+const SALE_TOKEN = "C" + "C".repeat(55);
+
+// --- Stellar mock ---------------------------------------------------------
+const buildTx = jest.fn().mockResolvedValue("built-xdr");
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  buildTx,
+  retryBuildTx: jest.fn().mockResolvedValue("built-xdr"),
+  addressToScVal: jest.fn((a) => a),
+  i128ToScVal: jest.fn((n) => n),
+  u32ToScVal: jest.fn((n) => n),
+  getRoyaltyRateFromContract: jest.fn().mockResolvedValue(500),
+  server: {},
+  networkPassphrase: "Test SDF Network ; September 2015",
+}));
+
+// --- XDR validation mock (controllable per test) --------------------------
+const validateXdrStructure = jest.fn(() => ({ valid: true }));
+
+await jest.unstable_mockModule("../src/xdr-validation.js", () => ({
+  validateXdrStructure,
+}));
+
+// --- Idempotency middleware: pass-through ---------------------------------
+await jest.unstable_mockModule("../src/idempotency.js", () => ({
+  idempotencyMiddleware: (_req, _res, next) => next(),
+  clearCache: jest.fn(),
+}));
+
+// --- Logger mock ----------------------------------------------------------
+await jest.unstable_mockModule("../src/logger.js", () => ({
+  default: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// --- Database mock --------------------------------------------------------
+const recordTransaction = jest.fn(() => 1);
+const recordSecondarySale = jest.fn();
+const addAuditLog = jest.fn();
+const getSecondarySales = jest.fn(() => [{ id: 1, royaltyAmount: "1000" }]);
+const commitSecondaryDistributionAtomic = jest.fn(() => 42);
+const applyLargestRemainder = jest.fn(() => []);
+const addToRetryQueue = jest.fn();
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  db: { transaction: (fn) => fn },
+  recordTransaction,
+  recordSecondarySale,
+  addAuditLog,
+  getSecondarySales,
+  commitSecondaryDistributionAtomic,
+  applyLargestRemainder,
+  addToRetryQueue,
+  getSecondaryRoyaltyDistributions: jest.fn(() => []),
+  getRoyaltyStatistics: jest.fn(() => ({})),
+  countSecondarySales: jest.fn(() => 0),
+  getRetryQueueStats: jest.fn(() => ({ count: 0 })),
+  getDeadLetterQueueStats: jest.fn(() => ({ count: 0 })),
+  getDeadLetterItems: jest.fn(() => []),
+}));
+
+const { secondaryRoyaltyRouter } = await import("../src/routes/secondary-royalty.js");
+const { assertValidXdr } = await import("../src/routes/_shared.js");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: "10kb" }));
+  app.use("/api/secondary-royalty", secondaryRoyaltyRouter);
+  // Mirror the central error handler shape from index.js
+  app.use((err, _req, res, _next) => {
+    res.status(err.status || 500).json({ code: err.code, error: err.message });
+  });
+  return app;
+}
+
+const app = buildApp();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  buildTx.mockResolvedValue("built-xdr");
+  validateXdrStructure.mockReturnValue({ valid: true });
+  getSecondarySales.mockReturnValue([{ id: 1, royaltyAmount: "1000" }]);
+  recordTransaction.mockReturnValue(1);
+  commitSecondaryDistributionAtomic.mockReturnValue(42);
+});
+
+describe("assertValidXdr helper", () => {
+  test("returns the XDR unchanged when validation passes", () => {
+    validateXdrStructure.mockReturnValue({ valid: true });
+    expect(assertValidXdr("built-xdr")).toBe("built-xdr");
+  });
+
+  test("throws a structured xdr_validation_error when validation fails", () => {
+    validateXdrStructure.mockReturnValue({
+      valid: false,
+      errors: ["Fee too high: 999999 stroops (maximum 100000)"],
+    });
+    expect(() => assertValidXdr("bad-xdr")).toThrow();
+    try {
+      assertValidXdr("bad-xdr");
+    } catch (err) {
+      expect(err.status).toBe(500);
+      expect(err.code).toBe("xdr_validation_error");
+      expect(err.message).toMatch(/Fee too high/);
+    }
+  });
+});
+
+describe("POST /api/secondary-royalty/set-rate XDR validation", () => {
+  const body = { contractId: CONTRACT_ID, walletAddress: WALLET, royaltyRate: 500 };
+
+  test("returns XDR when the built transaction is valid", async () => {
+    const res = await request(app).post("/api/secondary-royalty/set-rate").send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.xdr).toBe("built-xdr");
+    expect(validateXdrStructure).toHaveBeenCalledWith("built-xdr", expect.any(String));
+  });
+
+  test("rejects invalid XDR with a clear xdr_validation_error", async () => {
+    validateXdrStructure.mockReturnValue({
+      valid: false,
+      errors: ["Transaction missing time bounds"],
+    });
+    const res = await request(app).post("/api/secondary-royalty/set-rate").send(body);
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("xdr_validation_error");
+    expect(res.body.error).toMatch(/time bounds/);
+  });
+});
+
+describe("POST /api/secondary-royalty (record) XDR validation", () => {
+  const body = {
+    contractId: CONTRACT_ID,
+    walletAddress: WALLET,
+    nftId: "NFT_1",
+    previousOwner: WALLET,
+    newOwner: WALLET,
+    salePrice: 10000,
+    saleToken: SALE_TOKEN,
+    royaltyRate: 500,
+  };
+
+  test("rejects invalid XDR and never returns it to the client", async () => {
+    validateXdrStructure.mockReturnValue({
+      valid: false,
+      errors: ["Invalid XDR: corrupt envelope"],
+    });
+    const res = await request(app).post("/api/secondary-royalty").send(body);
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("xdr_validation_error");
+    expect(res.body.xdr).toBeUndefined();
+  });
+});
+
+describe("POST /api/secondary-royalty/distribute XDR validation", () => {
+  const body = { contractId: CONTRACT_ID, walletAddress: WALLET, tokenId: TOKEN_ID };
+
+  test("rejects invalid XDR before committing any distribution state", async () => {
+    validateXdrStructure.mockReturnValue({
+      valid: false,
+      errors: ["Transaction must contain at least one operation"],
+    });
+    const res = await request(app).post("/api/secondary-royalty/distribute").send(body);
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("xdr_validation_error");
+    // Invalid XDR is a deterministic failure: no DB commit, no retry queue.
+    expect(commitSecondaryDistributionAtomic).not.toHaveBeenCalled();
+    expect(addToRetryQueue).not.toHaveBeenCalled();
+  });
+
+  test("commits and returns XDR when valid", async () => {
+    const res = await request(app).post("/api/secondary-royalty/distribute").send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.xdr).toBe("built-xdr");
+    expect(commitSecondaryDistributionAtomic).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Close #517 
---

## Summary
The backend builds unsigned transaction XDR and returns it to the frontend, where
Freighter signs and submits it. XDR validation was already in place for the
`distribute`, `initialize`, and `admin` routes (via the shared
`buildAndRecordTransaction` helper), but the **secondary-royalty** routes build
their XDR directly with `buildTx` and returned it **without any validation**.

An invalid envelope from those endpoints could reach the user, be signed, and
waste fees on a transaction the network rejects.
---
## Root cause
XDR validation lived only inside `buildAndRecordTransaction`. The three
XDR-returning secondary-royalty endpoints bypass that helper and call the
lower-level `buildTx` directly, so their output was never validated before being
returned:
- `POST /api/secondary-royalty` (`record_secondary_royalty`)
- `POST /api/secondary-royalty/set-rate` (`set_royalty_rate`)
- `POST /api/secondary-royalty/distribute` (`distribute_secondary_royalties`)
---
## Solution
- Extracted a single reusable guard, `assertValidXdr()`, in `routes/_shared.js`.
  It runs the existing `validateXdrStructure` (stellar-sdk parser) and throws a
  structured `xdr_validation_error` on failure. `buildAndRecordTransaction` now
  uses it too, so there's one source of truth.
- Call `assertValidXdr()` in all three secondary-royalty routes before returning
  the XDR. In `/distribute` the check runs **before** the atomic DB commit, so an
  invalid envelope never commits distribution state and is reported as an error
  (not silently retry-queued).
---
## Key changes
- `backend/src/routes/_shared.js` — add `assertValidXdr()` helper; refactor
  `buildAndRecordTransaction` to use it (behavior-preserving).
- `backend/src/routes/secondary-royalty.js` — validate built XDR in the record,
  set-rate, and distribute routes.
- `backend/tests/secondary-royalty-xdr-validation.test.js` — new suite (7 tests):
  helper behavior + each route rejecting invalid XDR with a clear error, and
  `/distribute` not committing on invalid XDR.
- Updated existing secondary-royalty test mocks to stub the validator and supply
  `networkPassphrase`, preventing regressions from the new validation path.
---
## Trade-offs / considerations
- Validation reuses the existing `validateXdrStructure` (transaction structure,
  source account, fee bounds, operations, sequence, time bounds) — no new
  validation semantics were introduced, keeping the change minimal and
  consistent with the existing distribute/initialize routes.
- Existing route unit tests feed placeholder XDR strings, so the validator is
  stubbed there (with a plain function so `resetAllMocks` can't clear it). Real
  envelope parsing is covered by the dedicated `xdr-validation` unit tests.
- Note for follow-up: the fee upper bound (`MAX_FEE = 100_000`) in
  `xdr-validation.js` may be tight for Soroban transactions whose resource fee is
  folded into the envelope fee; worth revisiting separately if false rejections
  appear on mainnet.
---
## Testing steps
1. `cd backend && npm install`
2. `npm test` — full suite (152 existing + new tests) should pass.
3. Targeted: `npm test -- --testPathPatterns="tests/(secondary-royalty|xdr-validation)"`
4. Manual: POST to `/api/secondary-royalty/set-rate` (or `/distribute`) and confirm
   a valid build returns `{ xdr, transactionId }`; force an invalid build and
   confirm a `500` with `code: "xdr_validation_error"` and a clear message, with
   no XDR returned and no distribution state committed.

---

please review my pr and please let me hear from your review about the task, thank you very much!
