### PR TITLE
feat(verification): add contract state consistency verification job a…

### DIFF
--- a/backend/src/contract-state-consistency.js
+++ b/backend/src/contract-state-consistency.js
@@ -1,0 +1,240 @@
+import logger from "./logger.js";
+import { getContractStateSnapshot } from "./stellar.js";
+import { addAuditLog, db } from "./database/index.js";
+import { recordContractConsistencyCheck } from "./metrics.js";
+
+const INITIALIZE_ACTIONS = new Set(["contract_initialized", "initialize_revealed"]);
+
+function parseDetails(details) {
+  if (!details) return null;
+  if (typeof details === "object") return details;
+
+  try {
+    return JSON.parse(details);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRecipients(collaborators = [], shares = []) {
+  return collaborators
+    .map((address, index) => ({
+      address,
+      basisPoints: Number(shares[index] ?? 0),
+    }))
+    .sort((a, b) => a.address.localeCompare(b.address));
+}
+
+function normalizeOnChainRecipients(recipients = []) {
+  return recipients
+    .map((recipient) => ({
+      address: recipient.address,
+      basisPoints: Number(recipient.basisPoints),
+    }))
+    .sort((a, b) => a.address.localeCompare(b.address));
+}
+
+function decimalStringToIntegerString(value) {
+  if (value == null) return "0";
+  const raw = String(value);
+  if (!raw.includes(".")) return raw;
+
+  const number = Number(raw);
+  return Number.isFinite(number) ? String(Math.trunc(number)) : raw;
+}
+
+export function getKnownContractIds() {
+  const rows = db
+    .prepare(
+      `
+        SELECT contractId FROM transactions
+        UNION
+        SELECT contractId FROM secondary_sales
+        UNION
+        SELECT contractId FROM audit_log
+      `,
+    )
+    .all();
+
+  return rows.map((row) => row.contractId).filter(Boolean);
+}
+
+export function getExpectedContractStateFromDb(contractId) {
+  const initRows = db
+    .prepare(
+      `
+        SELECT user, details, timestamp
+        FROM audit_log
+        WHERE contractId = ?
+          AND action IN ('contract_initialized', 'initialize_revealed')
+        ORDER BY id DESC
+        LIMIT 1
+      `,
+    )
+    .all(contractId);
+  const initDetails = parseDetails(initRows[0]?.details);
+  const collaborators = initDetails?.collaborators ?? null;
+  const shares = initDetails?.shares ?? null;
+
+  const rateRow = db
+    .prepare(
+      `
+        SELECT details
+        FROM audit_log
+        WHERE contractId = ?
+          AND action = 'royalty_rate_set'
+        ORDER BY id DESC
+        LIMIT 1
+      `,
+    )
+    .get(contractId);
+  const rateDetails = parseDetails(rateRow?.details);
+
+  const pendingPoolRow = db
+    .prepare(
+      `
+        SELECT COALESCE(SUM(CAST(royaltyAmount AS INTEGER)), 0) AS pendingPool
+        FROM secondary_sales
+        WHERE contractId = ?
+          AND distributed = 0
+      `,
+    )
+    .get(contractId);
+
+  return {
+    contractId,
+    hasInitializationRecord: Array.isArray(collaborators) && Array.isArray(shares),
+    initialized: Array.isArray(collaborators) && Array.isArray(shares),
+    adminAddress: Array.isArray(collaborators) ? collaborators[0] ?? null : null,
+    recipients:
+      Array.isArray(collaborators) && Array.isArray(shares)
+        ? normalizeRecipients(collaborators, shares)
+        : null,
+    totalShares: Array.isArray(shares)
+      ? shares.reduce((sum, share) => sum + Number(share ?? 0), 0)
+      : null,
+    royaltyRate:
+      rateDetails?.royaltyRate == null ? null : Number(rateDetails.royaltyRate),
+    secondaryPool: decimalStringToIntegerString(pendingPoolRow?.pendingPool ?? "0"),
+  };
+}
+
+function pushMismatch(discrepancies, field, expected, actual, severity = "warning") {
+  discrepancies.push({ field, expected, actual, severity });
+}
+
+export function compareContractStates(expected, actual) {
+  const discrepancies = [];
+
+  if (expected.initialized !== actual.initialized) {
+    pushMismatch(discrepancies, "initialized", expected.initialized, actual.initialized, "critical");
+  }
+
+  if (expected.adminAddress && expected.adminAddress !== actual.adminAddress) {
+    pushMismatch(discrepancies, "adminAddress", expected.adminAddress, actual.adminAddress, "critical");
+  }
+
+  if (expected.recipients) {
+    const onChainRecipients = normalizeOnChainRecipients(actual.recipients);
+    if (JSON.stringify(expected.recipients) !== JSON.stringify(onChainRecipients)) {
+      pushMismatch(discrepancies, "recipients", expected.recipients, onChainRecipients, "critical");
+    }
+  }
+
+  if (expected.totalShares != null && expected.totalShares !== actual.totalShares) {
+    pushMismatch(discrepancies, "totalShares", expected.totalShares, actual.totalShares, "critical");
+  }
+
+  if (expected.royaltyRate != null && expected.royaltyRate !== actual.royaltyRate) {
+    pushMismatch(discrepancies, "royaltyRate", expected.royaltyRate, actual.royaltyRate);
+  }
+
+  if (expected.secondaryPool !== actual.secondaryPool) {
+    pushMismatch(discrepancies, "secondaryPool", expected.secondaryPool, actual.secondaryPool, "critical");
+  }
+
+  return discrepancies;
+}
+
+export async function verifyContractStateConsistency(contractId, options = {}) {
+  const {
+    expectedStateReader = getExpectedContractStateFromDb,
+    onChainStateReader = getContractStateSnapshot,
+    audit = true,
+    log = logger,
+  } = options;
+
+  try {
+    const [expected, actual] = await Promise.all([
+      expectedStateReader(contractId),
+      onChainStateReader(contractId),
+    ]);
+    const discrepancies = compareContractStates(expected, actual);
+    const consistent = discrepancies.length === 0;
+
+    const result = {
+      contractId,
+      checkedAt: new Date().toISOString(),
+      consistent,
+      discrepancyCount: discrepancies.length,
+      discrepancies,
+      expected,
+      actual,
+    };
+
+    recordContractConsistencyCheck({
+      success: true,
+      discrepancyCount: discrepancies.length,
+    });
+
+    if (!consistent) {
+      log.error("Contract state consistency discrepancies detected", {
+        contractId,
+        discrepancyCount: discrepancies.length,
+        discrepancies,
+      });
+
+      if (audit) {
+        addAuditLog(contractId, "contract_state_discrepancy_detected", "system", {
+          discrepancyCount: discrepancies.length,
+          discrepancies,
+        });
+      }
+    } else {
+      log.info("Contract state consistency verification passed", { contractId });
+    }
+
+    return result;
+  } catch (err) {
+    recordContractConsistencyCheck({ success: false, discrepancyCount: 0 });
+    log.error("Contract state consistency verification failed", {
+      contractId,
+      error: err.message ?? String(err),
+    });
+    throw err;
+  }
+}
+
+export async function verifyAllContractStateConsistency(contractIds, options = {}) {
+  const uniqueIds = [...new Set(contractIds.filter(Boolean))];
+  const results = [];
+
+  for (const contractId of uniqueIds) {
+    results.push(await verifyContractStateConsistency(contractId, options));
+  }
+
+  return {
+    checkedAt: new Date().toISOString(),
+    contractCount: uniqueIds.length,
+    inconsistentCount: results.filter((result) => !result.consistent).length,
+    results,
+  };
+}
+
+export const _test = {
+  INITIALIZE_ACTIONS,
+  parseDetails,
+  normalizeRecipients,
+  normalizeOnChainRecipients,
+  decimalStringToIntegerString,
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -37,6 +37,10 @@ import { AdminEventListener } from "./events/adminEventListener.js";
 import EventIndexer from "./events/EventIndexer.js";
 import { getConfiguredContractId } from "./stellar.js";
 import { startRecoveryJob, stopRecoveryJob } from "./jobs/secondary-royalty-recovery.js";
+import {
+  startContractStateConsistencyJob,
+  stopContractStateConsistencyJob,
+} from "./jobs/contract-state-consistency.js";
 import { verifySignedWriteRequest } from "./request-signature.js";
 import eventsRouter from "./routes/events.js";
 
@@ -335,6 +339,18 @@ if (process.env.NODE_ENV !== "test" && !process.env.DISABLE_RECOVERY_JOB) {
   }
 }
 
+// Start hourly contract state consistency verification (#510)
+if (process.env.NODE_ENV !== "test" && !process.env.DISABLE_CONSISTENCY_JOB) {
+  try {
+    startContractStateConsistencyJob();
+    logger.info("[Startup] Contract state consistency job started");
+  } catch (err) {
+    logger.error("[Startup] Failed to start contract state consistency job", {
+      error: err.message,
+    });
+  }
+}
+
 // Graceful shutdown — include event indexer, admin event listener, cache cleanup, and recovery job
 const originalShutdown = createGracefulShutdownHandler({
   server,
@@ -351,6 +367,7 @@ const handleShutdown = (signal) => {
     adminEventListener.stop();
   }
   stopRecoveryJob();
+  stopContractStateConsistencyJob();
   const cache = getCacheManager();
   cache.disconnect().catch(() => {});
   originalShutdown(signal);

--- a/backend/src/jobs/contract-state-consistency.js
+++ b/backend/src/jobs/contract-state-consistency.js
@@ -1,0 +1,95 @@
+import logger from "../logger.js";
+import { getConfiguredContractId } from "../stellar.js";
+import {
+  getKnownContractIds,
+  verifyAllContractStateConsistency,
+} from "../contract-state-consistency.js";
+
+export const CONTRACT_STATE_CONSISTENCY_INTERVAL_MS = 60 * 60 * 1000;
+
+let consistencyInterval = null;
+let isRunning = false;
+
+function getContractsToVerify() {
+  const configured = getConfiguredContractId();
+  return [...new Set([configured, ...getKnownContractIds()].filter(Boolean))];
+}
+
+async function runConsistencyBatch() {
+  if (isRunning) {
+    logger.debug("Contract state consistency job already running, skipping cycle");
+    return null;
+  }
+
+  isRunning = true;
+  try {
+    const contractIds = getContractsToVerify();
+    if (contractIds.length === 0) {
+      logger.info("Contract state consistency job skipped: no contracts found");
+      return { contractCount: 0, results: [] };
+    }
+
+    logger.info("Contract state consistency job started", {
+      contractCount: contractIds.length,
+    });
+
+    const result = await verifyAllContractStateConsistency(contractIds);
+    logger.info("Contract state consistency job finished", {
+      contractCount: result.contractCount,
+      inconsistentCount: result.inconsistentCount,
+    });
+
+    return result;
+  } catch (err) {
+    logger.error("Contract state consistency job failed", {
+      error: err.message ?? String(err),
+    });
+    throw err;
+  } finally {
+    isRunning = false;
+  }
+}
+
+export function startContractStateConsistencyJob() {
+  if (consistencyInterval) {
+    logger.warn("Contract state consistency job already running");
+    return;
+  }
+
+  logger.info("Starting contract state consistency job", {
+    intervalMs: CONTRACT_STATE_CONSISTENCY_INTERVAL_MS,
+  });
+
+  consistencyInterval = setInterval(
+    () => runConsistencyBatch().catch(() => {}),
+    CONTRACT_STATE_CONSISTENCY_INTERVAL_MS,
+  );
+  runConsistencyBatch().catch(() => {});
+}
+
+export function stopContractStateConsistencyJob() {
+  if (!consistencyInterval) return;
+
+  clearInterval(consistencyInterval);
+  consistencyInterval = null;
+  logger.info("Stopped contract state consistency job");
+}
+
+export async function triggerContractStateConsistencyCheck(contractIds = null) {
+  if (Array.isArray(contractIds) && contractIds.length > 0) {
+    return verifyAllContractStateConsistency(contractIds);
+  }
+
+  return runConsistencyBatch();
+}
+
+export const _test = {
+  getContractsToVerify,
+  runConsistencyBatch,
+  get isRunning() {
+    return isRunning;
+  },
+  get consistencyInterval() {
+    return consistencyInterval;
+  },
+};

--- a/backend/src/metrics.js
+++ b/backend/src/metrics.js
@@ -36,6 +36,13 @@ const metrics = {
   // ── #422: RPC response cache hit/miss tracking ─────────────────────────
   /** Map<cacheName> → { hits, misses } */
   cacheStats: new Map(),
+
+  // #510: Contract state consistency verification
+  contractConsistencyChecksTotal: 0,
+  contractConsistencyFailuresTotal: 0,
+  contractConsistencyDiscrepanciesTotal: 0,
+  contractConsistencyLastDiscrepancyCount: 0,
+  contractConsistencyLastRunTimestamp: 0,
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -143,6 +150,19 @@ export function recordCacheMiss(cacheName) {
   getCacheEntry(cacheName).misses += 1;
 }
 
+export function recordContractConsistencyCheck({ success, discrepancyCount = 0 } = {}) {
+  const count = Number.isFinite(discrepancyCount) ? Math.max(0, discrepancyCount) : 0;
+
+  metrics.contractConsistencyChecksTotal += 1;
+  metrics.contractConsistencyLastRunTimestamp = Math.floor(Date.now() / 1000);
+  metrics.contractConsistencyLastDiscrepancyCount = count;
+  metrics.contractConsistencyDiscrepanciesTotal += count;
+
+  if (!success) {
+    metrics.contractConsistencyFailuresTotal += 1;
+  }
+}
+
 // ── Snapshot ──────────────────────────────────────────────────────────────
 
 export function getMetricsSnapshot() {
@@ -179,6 +199,14 @@ export function getMetricsSnapshot() {
 
     // #422
     cacheStats: Object.fromEntries(metrics.cacheStats),
+
+    // #510
+    contractConsistencyChecksTotal: metrics.contractConsistencyChecksTotal,
+    contractConsistencyFailuresTotal: metrics.contractConsistencyFailuresTotal,
+    contractConsistencyDiscrepanciesTotal: metrics.contractConsistencyDiscrepanciesTotal,
+    contractConsistencyLastDiscrepancyCount:
+      metrics.contractConsistencyLastDiscrepancyCount,
+    contractConsistencyLastRunTimestamp: metrics.contractConsistencyLastRunTimestamp,
   };
 }
 
@@ -272,6 +300,25 @@ export function prometheusMetrics() {
     lines.push(`stellar_cache_misses_total{cache="${cache}"} ${v.misses}`);
   }
 
+  // #510 — contract state consistency alerts
+  lines.push(
+    "# HELP stellar_contract_consistency_checks_total Contract state consistency verification runs.",
+    "# TYPE stellar_contract_consistency_checks_total counter",
+    `stellar_contract_consistency_checks_total ${snapshot.contractConsistencyChecksTotal}`,
+    "# HELP stellar_contract_consistency_failures_total Contract state consistency verification runs that failed before comparison completed.",
+    "# TYPE stellar_contract_consistency_failures_total counter",
+    `stellar_contract_consistency_failures_total ${snapshot.contractConsistencyFailuresTotal}`,
+    "# HELP stellar_contract_consistency_discrepancies_total Total DB versus on-chain state discrepancies found.",
+    "# TYPE stellar_contract_consistency_discrepancies_total counter",
+    `stellar_contract_consistency_discrepancies_total ${snapshot.contractConsistencyDiscrepanciesTotal}`,
+    "# HELP stellar_contract_consistency_last_discrepancy_count Discrepancies found during the latest consistency verification run.",
+    "# TYPE stellar_contract_consistency_last_discrepancy_count gauge",
+    `stellar_contract_consistency_last_discrepancy_count ${snapshot.contractConsistencyLastDiscrepancyCount}`,
+    "# HELP stellar_contract_consistency_last_run_timestamp_seconds Unix timestamp for the latest consistency verification run.",
+    "# TYPE stellar_contract_consistency_last_run_timestamp_seconds gauge",
+    `stellar_contract_consistency_last_run_timestamp_seconds ${snapshot.contractConsistencyLastRunTimestamp}`,
+  );
+
   lines.push("");
   return lines.join("\n");
 }
@@ -290,4 +337,9 @@ export function resetMetrics() {
   metrics.responseBytesTotal = 0;
   metrics.stellarRpcCalls.clear();
   metrics.cacheStats.clear();
+  metrics.contractConsistencyChecksTotal = 0;
+  metrics.contractConsistencyFailuresTotal = 0;
+  metrics.contractConsistencyDiscrepanciesTotal = 0;
+  metrics.contractConsistencyLastDiscrepancyCount = 0;
+  metrics.contractConsistencyLastRunTimestamp = 0;
 }

--- a/backend/src/routes/contract.js
+++ b/backend/src/routes/contract.js
@@ -260,6 +260,71 @@ contractRouter.get("/info", async (req, res, next) => {
   }
 });
 
+/**
+ * GET /api/v1/contract/verify?contractId=...
+ * Manually verifies DB-derived contract state against live on-chain state.
+ */
+contractRouter.get("/verify", async (req, res, next) => {
+  try {
+    const contractId = firstQueryValue(req.query.contractId) ?? getConfiguredContractId();
+    if (!contractId) {
+      return sendError(
+        res,
+        400,
+        "bad_request",
+        "contractId query param required when no default contract is configured",
+      );
+    }
+    if (!validateContractId(contractId, res)) return;
+
+    const { verifyContractStateConsistency } = await import(
+      "../contract-state-consistency.js"
+    );
+    const result = await verifyContractStateConsistency(contractId, {
+      audit: req.query.audit !== "false",
+    });
+    res.status(result.consistent ? 200 : 409).json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/v1/contract/verify
+ * Body: { contractIds?: string[], audit?: boolean }
+ * Manual batch consistency verification endpoint.
+ */
+contractRouter.post("/verify", async (req, res, next) => {
+  try {
+    const contractIds = Array.isArray(req.body?.contractIds)
+      ? req.body.contractIds
+      : [req.body?.contractId ?? getConfiguredContractId()].filter(Boolean);
+
+    if (contractIds.length === 0) {
+      return sendError(
+        res,
+        400,
+        "bad_request",
+        "contractId or contractIds required when no default contract is configured",
+      );
+    }
+
+    for (const contractId of contractIds) {
+      if (!validateContractId(contractId, res)) return;
+    }
+
+    const { verifyAllContractStateConsistency } = await import(
+      "../contract-state-consistency.js"
+    );
+    const result = await verifyAllContractStateConsistency(contractIds, {
+      audit: req.body?.audit !== false,
+    });
+    res.status(result.inconsistentCount === 0 ? 200 : 409).json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
 contractRouter.get("/status/:contractId", validateContractIdMiddleware, async (req, res, next) => {
   try {
     const { contractId } = req.params;

--- a/backend/src/stellar.js
+++ b/backend/src/stellar.js
@@ -911,6 +911,106 @@ export async function getContractVersionFromContract(contractId) {
   }
 }
 
+async function simulateReadOnlyContractCall(contractId, method, args = []) {
+  const contract = new Contract(contractId);
+  const dummyAccount = new Account(
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    "0",
+  );
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await withTimeout(
+    server.simulateTransaction(tx),
+    SOROBAN_RPC_TIMEOUT_MS,
+    `Soroban simulateTransaction ${method}`,
+  );
+
+  if (SorobanRpc.Api.isSimulationError(sim)) {
+    const error = new Error(sim.error ?? `${method} simulation failed`);
+    error.status = 400;
+    throw error;
+  }
+
+  return sim.result?.retval ?? null;
+}
+
+function i128ScValToString(scVal) {
+  const native = StellarSdk.scValToNative(scVal);
+  if (typeof native === "bigint") return native.toString();
+  if (typeof native === "number") return String(native);
+
+  const i128 = scVal?.i128?.();
+  if (!i128) return "0";
+  const hi = BigInt(i128.hi());
+  const lo = BigInt(i128.lo());
+  return ((hi << 64n) | lo).toString();
+}
+
+function decodeRecipientShares(scVal) {
+  const native = StellarSdk.scValToNative(scVal);
+  if (native instanceof Map) {
+    return [...native.entries()].map(([address, basisPoints]) => ({
+      address: String(address),
+      basisPoints: Number(basisPoints),
+    }));
+  }
+
+  const mapEntries = scVal?.map?.()?.entries ?? [];
+  return mapEntries.map((entry) => ({
+    address: Address.fromScVal(entry.key()).toString(),
+    basisPoints: entry.val().u32(),
+  }));
+}
+
+export async function getContractStateSnapshot(contractId) {
+  const initialized = await isContractInitialized(contractId);
+  if (!initialized) {
+    return {
+      contractId,
+      initialized: false,
+      adminAddress: null,
+      version: null,
+      royaltyRate: 0,
+      recipients: [],
+      totalShares: 0,
+      secondaryPool: "0",
+    };
+  }
+
+  const [
+    adminVal,
+    versionVal,
+    royaltyRateVal,
+    recipientsVal,
+    totalSharesVal,
+    secondaryPoolVal,
+  ] = await Promise.all([
+    simulateReadOnlyContractCall(contractId, "get_admin"),
+    simulateReadOnlyContractCall(contractId, "get_version"),
+    simulateReadOnlyContractCall(contractId, "get_royalty_rate"),
+    simulateReadOnlyContractCall(contractId, "get_all_shares"),
+    simulateReadOnlyContractCall(contractId, "get_total_shares"),
+    simulateReadOnlyContractCall(contractId, "get_secondary_pool"),
+  ]);
+
+  return {
+    contractId,
+    initialized: true,
+    adminAddress: adminVal ? Address.fromScVal(adminVal).toString() : null,
+    version: versionVal ? StellarSdk.scValToNative(versionVal)?.toString?.() ?? null : null,
+    royaltyRate: royaltyRateVal?.u32?.() ?? Number(StellarSdk.scValToNative(royaltyRateVal) ?? 0),
+    recipients: decodeRecipientShares(recipientsVal),
+    totalShares: totalSharesVal?.u32?.() ?? Number(StellarSdk.scValToNative(totalSharesVal) ?? 0),
+    secondaryPool: i128ScValToString(secondaryPoolVal),
+  };
+}
+
 // ── Test exports ───────────────────────────────────────────────────────────
 // Internal config snapshot for the test layer.
 export const _config = {

--- a/backend/tests/contract-state-consistency.test.js
+++ b/backend/tests/contract-state-consistency.test.js
@@ -1,0 +1,257 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+
+const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const ADMIN = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const COLLAB1 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const COLLAB2 = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+const addAuditLog = jest.fn();
+const recordContractConsistencyCheck = jest.fn();
+const getContractStateSnapshot = jest.fn();
+const getConfiguredContractId = jest.fn(() => CONTRACT);
+const dbPrepare = jest.fn();
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  addAuditLog,
+  db: { prepare: dbPrepare },
+}));
+
+await jest.unstable_mockModule("../src/metrics.js", () => ({
+  recordCacheHit: jest.fn(),
+  recordCacheMiss: jest.fn(),
+  recordContractConsistencyCheck,
+}));
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  getContractStateSnapshot,
+  getConfiguredContractId,
+  isContractInitialized: jest.fn(),
+  server: { simulateTransaction: jest.fn() },
+  networkPassphrase: "Test SDF Network ; September 2015",
+  addressToScVal: jest.fn((value) => value),
+  getContractVersionFromContract: jest.fn(),
+  getNetworkLabel: jest.fn(() => "Testnet"),
+}));
+
+await jest.unstable_mockModule("@stellar/stellar-sdk", () => ({
+  default: {
+    Address: {
+      fromScVal: jest.fn((value) => ({ toString: () => String(value) })),
+    },
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn((method, ...args) => ({ method, args })),
+    })),
+    SorobanRpc: {
+      Api: { isSimulationError: jest.fn(() => false) },
+    },
+    TransactionBuilder: jest.fn(),
+    BASE_FEE: "100",
+    Account: jest.fn(),
+  },
+}));
+
+const {
+  compareContractStates,
+  getExpectedContractStateFromDb,
+  verifyContractStateConsistency,
+} = await import("../src/contract-state-consistency.js");
+const { resetMetrics } = await import("../src/metrics.js").catch(() => ({ resetMetrics: null }));
+const { contractRouter } = await import("../src/routes/contract.js");
+
+function expectedState(overrides = {}) {
+  return {
+    contractId: CONTRACT,
+    initialized: true,
+    adminAddress: ADMIN,
+    recipients: [
+      { address: COLLAB1, basisPoints: 6000 },
+      { address: COLLAB2, basisPoints: 4000 },
+    ],
+    totalShares: 10000,
+    royaltyRate: 750,
+    secondaryPool: "125",
+    ...overrides,
+  };
+}
+
+function actualState(overrides = {}) {
+  return {
+    contractId: CONTRACT,
+    initialized: true,
+    adminAddress: ADMIN,
+    recipients: [
+      { address: COLLAB2, basisPoints: 4000 },
+      { address: COLLAB1, basisPoints: 6000 },
+    ],
+    totalShares: 10000,
+    royaltyRate: 750,
+    secondaryPool: "125",
+    ...overrides,
+  };
+}
+
+function mockExpectedDbQueries() {
+  dbPrepare.mockImplementation((sql) => {
+    if (sql.includes("action IN")) {
+      return {
+        all: jest.fn(() => [
+          {
+            user: ADMIN,
+            details: JSON.stringify({
+              collaborators: [ADMIN, COLLAB2],
+              shares: [7000, 3000],
+            }),
+          },
+        ]),
+      };
+    }
+
+    if (sql.includes("action = 'royalty_rate_set'")) {
+      return {
+        get: jest.fn(() => ({
+          details: JSON.stringify({ royaltyRate: 650 }),
+        })),
+      };
+    }
+
+    if (sql.includes("SUM(CAST(royaltyAmount AS INTEGER))")) {
+      return {
+        get: jest.fn(() => ({ pendingPool: 42 })),
+      };
+    }
+
+    return { all: jest.fn(() => []), get: jest.fn(() => null) };
+  });
+}
+
+describe("contract state consistency verification", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMetrics?.();
+  });
+
+  test("treats equivalent DB and on-chain states as consistent", () => {
+    const discrepancies = compareContractStates(expectedState(), actualState());
+
+    expect(discrepancies).toEqual([]);
+  });
+
+  test("detects collaborator share mismatches", () => {
+    const discrepancies = compareContractStates(
+      expectedState(),
+      actualState({
+        recipients: [
+          { address: COLLAB1, basisPoints: 5000 },
+          { address: COLLAB2, basisPoints: 5000 },
+        ],
+      }),
+    );
+
+    expect(discrepancies).toEqual([
+      expect.objectContaining({
+        field: "recipients",
+        severity: "critical",
+      }),
+    ]);
+  });
+
+  test("detects royalty-rate and pending-pool mismatches", () => {
+    const discrepancies = compareContractStates(
+      expectedState(),
+      actualState({ royaltyRate: 500, secondaryPool: "0" }),
+    );
+
+    expect(discrepancies.map((d) => d.field)).toEqual(["royaltyRate", "secondaryPool"]);
+  });
+
+  test("reconstructs expected state from audit and secondary-sales tables", () => {
+    mockExpectedDbQueries();
+
+    const expected = getExpectedContractStateFromDb(CONTRACT);
+
+    expect(expected).toMatchObject({
+      contractId: CONTRACT,
+      initialized: true,
+      adminAddress: ADMIN,
+      totalShares: 10000,
+      royaltyRate: 650,
+      secondaryPool: "42",
+      recipients: [
+        { address: ADMIN, basisPoints: 7000 },
+        { address: COLLAB2, basisPoints: 3000 },
+      ],
+    });
+  });
+
+  test("logs, audits, and records metrics when discrepancies are found", async () => {
+    const log = { error: jest.fn(), info: jest.fn() };
+
+    const result = await verifyContractStateConsistency(CONTRACT, {
+      expectedStateReader: jest.fn(() => expectedState()),
+      onChainStateReader: jest.fn(() => actualState({ totalShares: 9000 })),
+      log,
+    });
+
+    expect(result.consistent).toBe(false);
+    expect(result.discrepancies).toEqual([
+      expect.objectContaining({ field: "totalShares" }),
+    ]);
+    expect(log.error).toHaveBeenCalledWith(
+      "Contract state consistency discrepancies detected",
+      expect.objectContaining({ contractId: CONTRACT, discrepancyCount: 1 }),
+    );
+    expect(addAuditLog).toHaveBeenCalledWith(
+      CONTRACT,
+      "contract_state_discrepancy_detected",
+      "system",
+      expect.objectContaining({ discrepancyCount: 1 }),
+    );
+    expect(recordContractConsistencyCheck).toHaveBeenCalledWith({
+      success: true,
+      discrepancyCount: 1,
+    });
+  });
+
+  test("manual verify endpoint returns 409 with discrepancy details", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use("/api/v1/contract", contractRouter);
+    app.use((err, _req, res, _next) => {
+      res.status(500).json({ error: err.message });
+    });
+
+    getContractStateSnapshot.mockResolvedValue(
+      actualState({ adminAddress: COLLAB1, secondaryPool: "0" }),
+    );
+    dbPrepare.mockImplementation((sql) => {
+      if (sql.includes("action IN")) {
+        return {
+          all: jest.fn(() => [
+            {
+              details: JSON.stringify({
+                collaborators: [COLLAB1, COLLAB2],
+                shares: [6000, 4000],
+              }),
+            },
+          ]),
+        };
+      }
+      if (sql.includes("action = 'royalty_rate_set'")) {
+        return { get: jest.fn(() => ({ details: JSON.stringify({ royaltyRate: 750 }) })) };
+      }
+      return { get: jest.fn(() => ({ pendingPool: 125 })), all: jest.fn(() => []) };
+    });
+
+    const res = await request(app).get(`/api/v1/contract/verify?contractId=${CONTRACT}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      contractId: CONTRACT,
+      consistent: false,
+      discrepancyCount: 1,
+      discrepancies: [expect.objectContaining({ field: "secondaryPool" })],
+    });
+  });
+});

--- a/infra/grafana/provisioning/alerting/alerts.yml
+++ b/infra/grafana/provisioning/alerting/alerts.yml
@@ -226,3 +226,39 @@ groups:
         labels:
           severity: info
           team: backend
+
+      # ── Contract state consistency ────────────────────────────────────────
+      - uid: srs-contract-state-inconsistent
+        title: Contract State Inconsistency Detected
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: stellar_contract_consistency_last_discrepancy_count
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 1m
+        annotations:
+          summary: "DB state differs from on-chain contract state"
+          description: "Latest consistency check found {{ $values.A.Value | printf \"%.0f\" }} discrepancy/discrepancies. Inspect backend logs for contract_state_discrepancy_detected."
+          runbook: "Run GET /api/v1/contract/verify?contractId=<contract_id> and compare expected vs actual fields."
+        labels:
+          severity: critical
+          team: backend


### PR DESCRIPTION
Closes #510
What was done
Implemented a contract state consistency verification system to detect and log drift between the backend DB and on-chain contract state.
Changes

Verification engine — compares DB state vs on-chain contract state, logs all discrepancies found
Hourly job — runs automatically every hour, wired into app startup and graceful shutdown
Manual endpoints — trigger or check verification on demand

GET /api/v1/contract/verify?contractId=...
POST /api/v1/contract/verify


On-chain snapshot reader — added to stellar.js to read live contract state
Alerts — Prometheus metrics + Grafana alert for discrepancies
6 tests — all passing, covers core consistency logic

Test results

contract-state-consistency.test.js ✅
contract-info.test.js ✅
metrics.test.js ✅

Full npm test has pre-existing failures unrelated to this issue (better-sqlite3 Jest parsing, XDR mock failures)
Lint errors in routes/admin.js, routes/analytics.js, routes/events.js are pre-existing — no new lint errors introduced