### PR TITLE
fix(security): enforce parameterized queries and strict contract ID v…

### DIFF
--- a/backend/src/contract-id.js
+++ b/backend/src/contract-id.js
@@ -1,0 +1,12 @@
+export const CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
+
+export function isValidContractId(contractId) {
+  return typeof contractId === "string" && CONTRACT_ID_PATTERN.test(contractId);
+}
+
+export function assertValidContractId(contractId) {
+  if (!isValidContractId(contractId)) {
+    throw new TypeError("Invalid contract ID format");
+  }
+  return contractId;
+}

--- a/backend/src/database.js
+++ b/backend/src/database.js
@@ -2,6 +2,7 @@ import Database from "better-sqlite3";
 import path from "path";
 import { fileURLToPath } from "url";
 import logger from "./logger.js";
+import { assertValidContractId } from "./contract-id.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dbPath = process.env.DATABASE_PATH ?? path.join(__dirname, "..", "audit.db");
@@ -88,15 +89,16 @@ export function initializeDatabase() {
     },
   ];
 
-  const applied = db
+  const applied = new Set(db
     .prepare("SELECT version FROM schema_migrations")
     .all()
-    .map((r) => r.version);
+    .map((r) => r.version));
 
   for (const migration of migrations) {
-    if (!applied.includes(migration.version)) {
+    if (!applied.has(migration.version)) {
       db.exec(migration.sql);
       db.prepare("INSERT INTO schema_migrations (version) VALUES (?)").run(migration.version);
+      applied.add(migration.version);
       logger.info(`Applied migration v${migration.version}`);
     }
   }
@@ -187,6 +189,7 @@ export function initializeDatabase() {
 
 // Transaction tracking functions
 export function recordTransaction(contractId, type, initiatorAddress, data) {
+  assertValidContractId(contractId);
   const { requestedAmount, tokenId } = data;
 
   const stmt = db.prepare(`
@@ -228,6 +231,7 @@ export function addDistributionPayout(
   collaboratorAddress,
   amountReceived
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO distribution_payouts 
     (transactionId, contractId, collaboratorAddress, amountReceived)
@@ -239,11 +243,13 @@ export function addDistributionPayout(
 }
 
 export function getTransactionCount(contractId) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`SELECT COUNT(*) as total FROM transactions WHERE contractId = ?`);
   return stmt.get(contractId).total;
 }
 
 export function getTransactionHistory(contractId, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       t.id,
@@ -308,6 +314,7 @@ export function getTransactionDetails(txHash) {
 }
 
 export function getAuditLog(contractId, limit = 100, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       id,
@@ -334,6 +341,9 @@ export function getAuditLog(contractId, limit = 100, offset = 0) {
 }
 
 export function addAuditLog(contractId, action, user, details) {
+  if (contractId !== "global") {
+    assertValidContractId(contractId);
+  }
   const stmt = db.prepare(`
     INSERT INTO audit_log 
     (contractId, action, user, details)
@@ -361,6 +371,7 @@ export function recordSecondarySale(
   royaltyRate,
   transactionHash = null
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO secondary_sales 
     (contractId, nftId, previousOwner, newOwner, salePrice, saleToken, royaltyAmount, royaltyRate, transactionHash)
@@ -396,8 +407,31 @@ export function getSecondarySales(
   startDate = null,
   endDate = null
 ) {
-  let query = `
-    SELECT 
+  assertValidContractId(contractId);
+  const conditions = ["contractId = ?"];
+  const params = [contractId];
+
+  if (nftId) {
+    conditions.push("nftId = ?");
+    params.push(nftId);
+  }
+
+  if (undistributedOnly) {
+    conditions.push("distributed = 0");
+  }
+
+  if (startDate) {
+    conditions.push("timestamp >= ?");
+    params.push(startDate);
+  }
+
+  if (endDate) {
+    conditions.push("timestamp <= ?");
+    params.push(endDate);
+  }
+
+  const query = `
+    SELECT
       id,
       nftId,
       previousOwner,
@@ -410,30 +444,9 @@ export function getSecondarySales(
       timestamp,
       transactionHash
     FROM secondary_sales
-    WHERE contractId = ?
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY timestamp DESC LIMIT ? OFFSET ?
   `;
-  const params = [contractId];
-
-  if (nftId) {
-    query += ` AND nftId = ?`;
-    params.push(nftId);
-  }
-
-  if (undistributedOnly) {
-    query += ` AND distributed = 0`;
-  }
-
-  if (startDate) {
-    query += ` AND timestamp >= ?`;
-    params.push(startDate);
-  }
-
-  if (endDate) {
-    query += ` AND timestamp <= ?`;
-    params.push(endDate);
-  }
-
-  query += ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`;
   params.push(limit, offset);
 
   return db.prepare(query).all(...params);
@@ -444,24 +457,26 @@ export function getSecondarySales(
  * Supports optional date range filtering with startDate and endDate.
  */
 export function countSecondarySales(contractId, nftId = null, startDate = null, endDate = null) {
-  let query = `SELECT COUNT(*) as total FROM secondary_sales WHERE contractId = ?`;
+  assertValidContractId(contractId);
+  const conditions = ["contractId = ?"];
   const params = [contractId];
 
   if (nftId) {
-    query += ` AND nftId = ?`;
+    conditions.push("nftId = ?");
     params.push(nftId);
   }
 
   if (startDate) {
-    query += ` AND timestamp >= ?`;
+    conditions.push("timestamp >= ?");
     params.push(startDate);
   }
 
   if (endDate) {
-    query += ` AND timestamp <= ?`;
+    conditions.push("timestamp <= ?");
     params.push(endDate);
   }
 
+  const query = `SELECT COUNT(*) as total FROM secondary_sales WHERE ${conditions.join(" AND ")}`;
   return db.prepare(query).get(...params).total;
 }
 
@@ -469,10 +484,11 @@ export function countSecondarySales(contractId, nftId = null, startDate = null, 
  * Mark an array of secondary sale IDs as distributed.
  */
 export function markSalesDistributed(ids) {
-  const placeholders = ids.map(() => "?").join(",");
-  db.prepare(`UPDATE secondary_sales SET distributed = 1 WHERE id IN (${placeholders})`).run(
-    ...ids
-  );
+  db.prepare(`
+    UPDATE secondary_sales
+    SET distributed = 1
+    WHERE id IN (SELECT value FROM json_each(?))
+  `).run(JSON.stringify(ids));
   countWrite();
 }
 
@@ -485,6 +501,7 @@ export function recordSecondaryRoyaltyDistribution(
   totalRoyaltiesDistributed,
   numberOfSales
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO secondary_royalty_distributions 
     (transactionId, contractId, totalRoyaltiesDistributed, numberOfSales)
@@ -505,6 +522,7 @@ export function recordSecondaryRoyaltyDistribution(
  * Get secondary royalty distribution history for a contract.
  */
 export function getSecondaryRoyaltyDistributions(contractId, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       srd.id,
@@ -531,6 +549,7 @@ export function getSecondaryRoyaltyDistributions(contractId, limit = 50, offset 
  * counts are integers, and null is never returned for aggregates.
  */
 export function getRoyaltyStatistics(contractId) {
+  assertValidContractId(contractId);
   const totalSalesStmt = db.prepare(`
     SELECT
       COUNT(*) as count,
@@ -575,6 +594,7 @@ export function getRoyaltyStatistics(contractId) {
  * SQL-aggregated analytics — replaces in-memory JS loops in the route handler.
  */
 export function getAnalyticsData(contractId, startDate, endDate) {
+  assertValidContractId(contractId);
   const summary = db
     .prepare(
       `SELECT

--- a/backend/src/database/analytics.js
+++ b/backend/src/database/analytics.js
@@ -10,6 +10,7 @@
  */
 
 import { db } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
 
 const CACHE_TTL_MS = 60 * 1000; // 60 seconds
 const analyticsCache = new Map();
@@ -29,6 +30,7 @@ export function _clearAnalyticsCache() {
  * @param {number} [collaboratorLimit=10] cap on rows returned in collaboratorStats
  */
 export function getAnalyticsData(contractId, startDate, endDate, collaboratorLimit = 10) {
+  assertValidContractId(contractId);
   const cacheKey = `${contractId}|${startDate}|${endDate}|${collaboratorLimit}`;
   const cached = analyticsCache.get(cacheKey);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {

--- a/backend/src/database/audit.js
+++ b/backend/src/database/audit.js
@@ -5,8 +5,12 @@
  */
 
 import { db, countWrite, computeAuditEntryHash } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
+
+const GLOBAL_AUDIT_SCOPE = "global";
 
 export function getAuditLog(contractId, limit = 100, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       id,
@@ -35,6 +39,9 @@ export function getAuditLog(contractId, limit = 100, offset = 0) {
 }
 
 export function addAuditLog(contractId, action, user, details) {
+  if (contractId !== GLOBAL_AUDIT_SCOPE) {
+    assertValidContractId(contractId);
+  }
   const timestamp = new Date().toISOString();
   const detailsJson = JSON.stringify(details);
   
@@ -71,6 +78,7 @@ export function exportAuditLogs(filters = {}, limit = 10000, offset = 0) {
   const params = [];
 
   if (filters.contractId) {
+    assertValidContractId(filters.contractId);
     conditions.push("contractId = ?");
     params.push(filters.contractId);
   }
@@ -90,7 +98,8 @@ export function exportAuditLogs(filters = {}, limit = 10000, offset = 0) {
     params.push(filters.end);
   }
 
-  let sql = `
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `
     SELECT 
       timestamp,
       action,
@@ -98,13 +107,9 @@ export function exportAuditLogs(filters = {}, limit = 10000, offset = 0) {
       user AS actor,
       details
     FROM audit_log
+    ${whereClause}
+    ORDER BY timestamp DESC LIMIT ? OFFSET ?
   `;
-
-  if (conditions.length > 0) {
-    sql += " WHERE " + conditions.join(" AND ");
-  }
-
-  sql += " ORDER BY timestamp DESC LIMIT ? OFFSET ?";
   params.push(limit, offset);
 
   const stmt = db.prepare(sql);

--- a/backend/src/database/core.js
+++ b/backend/src/database/core.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import crypto from "crypto";
 import logger from "../logger.js";
 import { instrumentDatabase } from "../query-profiler.js";
+import { assertValidContractId } from "../contract-id.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const dbPath = process.env.DATABASE_PATH ?? path.join(__dirname, "..", "..", "audit.db");
@@ -356,15 +357,16 @@ export function initializeDatabase() {
     },
   ];
 
-  const applied = db
+  const applied = new Set(db
     .prepare("SELECT version FROM schema_migrations")
     .all()
-    .map((r) => r.version);
+    .map((r) => r.version));
 
   for (const migration of migrations) {
-    if (!applied.includes(migration.version)) {
+    if (!applied.has(migration.version)) {
       db.exec(migration.sql);
       db.prepare("INSERT INTO schema_migrations (version) VALUES (?)").run(migration.version);
+      applied.add(migration.version);
       logger.info(`Applied migration v${migration.version}`);
     }
   }
@@ -497,18 +499,18 @@ export function computeAuditEntryHash(contractId, action, user, details, timesta
  */
 export function verifyAuditLogIntegrity(contractId = null) {
   try {
-    let query = `
+    if (contractId !== null) {
+      assertValidContractId(contractId);
+    }
+
+    const whereClause = contractId ? "WHERE contractId = ?" : "";
+    const query = `
       SELECT id, contractId, action, user, details, entry_hash, prev_hash, timestamp
       FROM audit_log
+      ${whereClause}
+      ORDER BY id ASC
     `;
-    const params = [];
-    
-    if (contractId) {
-      query += ` WHERE contractId = ?`;
-      params.push(contractId);
-    }
-    
-    query += ` ORDER BY id ASC`;
+    const params = contractId ? [contractId] : [];
     
     const entries = db.prepare(query).all(...params);
     

--- a/backend/src/database/request-nonces.js
+++ b/backend/src/database/request-nonces.js
@@ -9,12 +9,14 @@
  */
 
 import { db, countWrite } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
 
 /**
  * Record a nonce for a contract if it hasn't been seen before.
  * Returns true if newly recorded, false if (contractId, nonce) already exists.
  */
 export function recordNonceIfNew(contractId, nonce) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO request_nonces (contractId, nonce)
     VALUES (?, ?)

--- a/backend/src/database/roles.js
+++ b/backend/src/database/roles.js
@@ -1,4 +1,5 @@
 import { db, countWrite } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
 
 /**
  * Get a user's role for a specific contract or global.
@@ -9,6 +10,7 @@ import { db, countWrite } from "./core.js";
 export function dbGetUserRole(contractId, walletAddress) {
   // Check contract-specific role first
   if (contractId) {
+    assertValidContractId(contractId);
     const stmt = db.prepare("SELECT role FROM user_roles WHERE contractId = ? AND walletAddress = ?");
     const row = stmt.get(contractId, walletAddress);
     if (row) return row.role;
@@ -27,6 +29,9 @@ export function dbGetUserRole(contractId, walletAddress) {
  * @param {string|null} assignedBy 
  */
 export function dbAssignUserRole(contractId, walletAddress, role, assignedBy) {
+  if (contractId) {
+    assertValidContractId(contractId);
+  }
   const stmt = db.prepare(`
     INSERT INTO user_roles (contractId, walletAddress, role, assignedBy)
     VALUES (?, ?, ?, ?)

--- a/backend/src/database/secondary-royalties.js
+++ b/backend/src/database/secondary-royalties.js
@@ -7,6 +7,7 @@ import { db, countWrite } from "./core.js";
 import { addAuditLog } from "./audit.js";
 import { recordTransaction } from "./transactions.js";
 import logger from "../logger.js";
+import { assertValidContractId } from "../contract-id.js";
 
 // ---------------------------------------------------------------------------
 // Largest-remainder rounding algorithm (#427)
@@ -88,6 +89,7 @@ export function recordSecondarySale(
   royaltyRate,
   transactionHash = null
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO secondary_sales 
     (contractId, nftId, previousOwner, newOwner, salePrice, saleToken, royaltyAmount, royaltyRate, transactionHash)
@@ -123,8 +125,31 @@ export function getSecondarySales(
   startDate = null,
   endDate = null
 ) {
-  let query = `
-    SELECT 
+  assertValidContractId(contractId);
+  const conditions = ["contractId = ?"];
+  const params = [contractId];
+
+  if (nftId) {
+    conditions.push("nftId = ?");
+    params.push(nftId);
+  }
+
+  if (undistributedOnly) {
+    conditions.push("distributed = 0");
+  }
+
+  if (startDate) {
+    conditions.push("timestamp >= ?");
+    params.push(startDate);
+  }
+
+  if (endDate) {
+    conditions.push("timestamp <= ?");
+    params.push(endDate);
+  }
+
+  const query = `
+    SELECT
       id,
       nftId,
       previousOwner,
@@ -137,30 +162,9 @@ export function getSecondarySales(
       timestamp,
       transactionHash
     FROM secondary_sales
-    WHERE contractId = ?
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY timestamp DESC LIMIT ? OFFSET ?
   `;
-  const params = [contractId];
-
-  if (nftId) {
-    query += ` AND nftId = ?`;
-    params.push(nftId);
-  }
-
-  if (undistributedOnly) {
-    query += ` AND distributed = 0`;
-  }
-
-  if (startDate) {
-    query += ` AND timestamp >= ?`;
-    params.push(startDate);
-  }
-
-  if (endDate) {
-    query += ` AND timestamp <= ?`;
-    params.push(endDate);
-  }
-
-  query += ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`;
   params.push(limit, offset);
 
   return db.prepare(query).all(...params);
@@ -171,24 +175,26 @@ export function getSecondarySales(
  * Supports optional date range filtering with startDate and endDate.
  */
 export function countSecondarySales(contractId, nftId = null, startDate = null, endDate = null) {
-  let query = `SELECT COUNT(*) as total FROM secondary_sales WHERE contractId = ?`;
+  assertValidContractId(contractId);
+  const conditions = ["contractId = ?"];
   const params = [contractId];
 
   if (nftId) {
-    query += ` AND nftId = ?`;
+    conditions.push("nftId = ?");
     params.push(nftId);
   }
 
   if (startDate) {
-    query += ` AND timestamp >= ?`;
+    conditions.push("timestamp >= ?");
     params.push(startDate);
   }
 
   if (endDate) {
-    query += ` AND timestamp <= ?`;
+    conditions.push("timestamp <= ?");
     params.push(endDate);
   }
 
+  const query = `SELECT COUNT(*) as total FROM secondary_sales WHERE ${conditions.join(" AND ")}`;
   return db.prepare(query).get(...params).total;
 }
 
@@ -196,10 +202,11 @@ export function countSecondarySales(contractId, nftId = null, startDate = null, 
  * Mark an array of secondary sale IDs as distributed.
  */
 export function markSalesDistributed(ids) {
-  const placeholders = ids.map(() => "?").join(",");
-  db.prepare(`UPDATE secondary_sales SET distributed = 1 WHERE id IN (${placeholders})`).run(
-    ...ids
-  );
+  db.prepare(`
+    UPDATE secondary_sales
+    SET distributed = 1
+    WHERE id IN (SELECT value FROM json_each(?))
+  `).run(JSON.stringify(ids));
   countWrite();
 }
 
@@ -216,6 +223,7 @@ export function recordSecondaryRoyaltyDistribution(
   numberOfSales,
   dustAllocated = 0
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO secondary_royalty_distributions
     (transactionId, contractId, totalRoyaltiesDistributed, numberOfSales, dustAllocated)
@@ -237,6 +245,7 @@ export function recordSecondaryRoyaltyDistribution(
  * Get secondary royalty distribution history for a contract.
  */
 export function getSecondaryRoyaltyDistributions(contractId, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       srd.id,
@@ -329,6 +338,7 @@ const STATS_CACHE_TTL_MS = 60_000;
 
 export function _invalidateStatsCache(contractId) {
   if (contractId) {
+    assertValidContractId(contractId);
     _statsCache.delete(contractId);
   } else {
     _statsCache.clear();
@@ -396,6 +406,7 @@ function getStatsStatement() {
  * counts are integers, and null is never returned for aggregates.
  */
 export function getRoyaltyStatistics(contractId) {
+  assertValidContractId(contractId);
   const cached = _statsCache.get(contractId);
   if (cached && Date.now() - cached.ts < STATS_CACHE_TTL_MS) {
     return cached.data;
@@ -461,6 +472,7 @@ export function addToRetryQueue(params) {
     dustAuditData,
     errorMessage,
   } = params;
+  assertValidContractId(contractId);
 
   const stmt = db.prepare(`
     INSERT INTO secondary_royalty_retry_queue
@@ -624,6 +636,7 @@ export function moveToDeadLetterQueue(id, failureReason) {
  * Get dead-letter queue items for a contract.
  */
 export function getDeadLetterItems(contractId, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT
       id,

--- a/backend/src/database/transactions.js
+++ b/backend/src/database/transactions.js
@@ -4,8 +4,10 @@
  */
 
 import { db, countWrite } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
 
 export function recordTransaction(contractId, type, initiatorAddress, data) {
+  assertValidContractId(contractId);
   const { requestedAmount, tokenId } = data;
 
   const stmt = db.prepare(`
@@ -47,6 +49,7 @@ export function addDistributionPayout(
   collaboratorAddress,
   amountReceived
 ) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO distribution_payouts 
     (transactionId, contractId, collaboratorAddress, amountReceived)
@@ -58,11 +61,13 @@ export function addDistributionPayout(
 }
 
 export function getTransactionCount(contractId) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`SELECT COUNT(*) as total FROM transactions WHERE contractId = ?`);
   return stmt.get(contractId).total;
 }
 
 export function getTransactionHistory(contractId, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       t.id,

--- a/backend/src/database/webhooks.js
+++ b/backend/src/database/webhooks.js
@@ -3,8 +3,10 @@
  */
 
 import { db, countWrite } from "./core.js";
+import { assertValidContractId } from "../contract-id.js";
 
 export function registerWebhook(contractId, url) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     INSERT INTO webhooks (contractId, url, enabled)
     VALUES (?, ?, 1)
@@ -25,6 +27,7 @@ export function registerWebhook(contractId, url) {
 }
 
 export function listWebhooks(contractId) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT id, contractId, url, enabled, createdAt
     FROM webhooks
@@ -36,6 +39,7 @@ export function listWebhooks(contractId) {
 }
 
 export function deleteWebhook(contractId, webhookId) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     UPDATE webhooks
     SET enabled = 0
@@ -52,6 +56,7 @@ export function deleteWebhook(contractId, webhookId) {
 // ---------------------------------------------------------------------------
 
 export function enqueueDeadLetter(webhookId, contractId, url, payload, errorMessage) {
+  assertValidContractId(contractId);
   db.prepare(`
     INSERT INTO webhook_dead_letters (webhookId, contractId, url, payload, errorMessage)
     VALUES (?, ?, ?, ?, ?)
@@ -60,6 +65,7 @@ export function enqueueDeadLetter(webhookId, contractId, url, payload, errorMess
 }
 
 export function listDeadLetters(contractId, limit = 50) {
+  assertValidContractId(contractId);
   return db
     .prepare(
       `SELECT id, webhookId, contractId, url, payload, errorMessage, retryCount, createdAt, lastAttemptAt

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import logger from "../logger.js";
-import { validate, contractAddress, stellarAddress, assignRoleSchema } from "../validation.js";
+import { validate, contractAddress, stellarAddress, assignRoleSchema, validateContractIdMiddleware } from "../validation.js";
 import { sendError, sendValidationError } from "../error-response.js";
 import {
   isAdminRotateTokenValid,
@@ -294,7 +294,7 @@ adminRouter.post(
  * List dead-letter queue entries for a contract.
  * Query params: limit (default 50)
  */
-adminRouter.get("/webhooks/dead-letters/:contractId", requireRequestSignature, requireRole("viewer"), (req, res, next) => {
+adminRouter.get("/webhooks/dead-letters/:contractId", validateContractIdMiddleware, requireRequestSignature, requireRole("viewer"), (req, res, next) => {
   try {
     const { contractId } = req.params;
     const limit = Math.min(parseInt(req.query.limit ?? "50", 10) || 50, 200);

--- a/backend/src/routes/eventDatabase.js
+++ b/backend/src/routes/eventDatabase.js
@@ -4,8 +4,10 @@
  */
 
 import { db } from "../database/index.js";
+import { assertValidContractId } from "../contract-id.js";
 
 export function searchIndexedEvents(contractId, filters = {}, limit = 50, offset = 0) {
+  assertValidContractId(contractId);
   const { eventType, startLedger, endLedger, startDate, endDate, transactionHash, address } = filters;
 
   const whereConditions = [];
@@ -44,7 +46,8 @@ export function searchIndexedEvents(contractId, filters = {}, limit = 50, offset
     params.push(transactionHash);
   }
 
-  let sql = `
+  const whereClause = `WHERE ${whereConditions.join(" AND ")}`;
+  const sql = `
     SELECT 
       event_id,
       ledger_sequence,
@@ -55,13 +58,9 @@ export function searchIndexedEvents(contractId, filters = {}, limit = 50, offset
       event_data,
       raw_event
     FROM indexed_events
+    ${whereClause}
+    ORDER BY timestamp DESC LIMIT ? OFFSET ?
   `;
-
-  if (whereConditions.length > 0) {
-    sql += " WHERE " + whereConditions.join(" AND ");
-  }
-
-  sql += " ORDER BY timestamp DESC LIMIT ? OFFSET ?";
   params.push(limit, offset);
 
   const stmt = db.prepare(sql);
@@ -71,6 +70,7 @@ export function searchIndexedEvents(contractId, filters = {}, limit = 50, offset
 }
 
 export function countIndexedEvents(contractId, filters = {}) {
+  assertValidContractId(contractId);
   const { eventType, startLedger, endLedger, startDate, endDate, transactionHash, address } = filters;
 
   const whereConditions = [];
@@ -109,11 +109,11 @@ export function countIndexedEvents(contractId, filters = {}) {
     params.push(transactionHash);
   }
 
-  let sql = "SELECT COUNT(*) as total FROM indexed_events";
-
-  if (whereConditions.length > 0) {
-    sql += " WHERE " + whereConditions.join(" AND ");
-  }
+  const sql = `
+    SELECT COUNT(*) as total
+    FROM indexed_events
+    WHERE ${whereConditions.join(" AND ")}
+  `;
 
   const stmt = db.prepare(sql);
   const result = stmt.get(...params);
@@ -122,6 +122,7 @@ export function countIndexedEvents(contractId, filters = {}) {
 }
 
 export function getEventStats(contractId) {
+  assertValidContractId(contractId);
   const stmt = db.prepare(`
     SELECT 
       COUNT(*) as totalEvents,

--- a/backend/src/validation.js
+++ b/backend/src/validation.js
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { sendError, sendValidationError } from "./error-response.js";
+import { CONTRACT_ID_PATTERN, isValidContractId } from "./contract-id.js";
 
 export const stellarAddress = z
   .string("Validation failed: walletAddress must be a string")
@@ -7,7 +8,7 @@ export const stellarAddress = z
 
 export const contractAddress = z
   .string("Validation failed: contractId must be a string")
-  .regex(/^C[A-Z2-7]{55}$/, "Validation failed: Invalid contract address");
+  .regex(CONTRACT_ID_PATTERN, "Validation failed: Invalid contract address");
 
 export const basisPoints = z.number().int().min(0).max(10000);
 
@@ -188,7 +189,7 @@ export function validateInitializePayloadSize(req, res, next) {
  */
 export function validateContractIdMiddleware(req, res, next) {
   const contractId = req.params.contractId;
-  if (!contractId || !/^C[A-Z2-7]{55}$/.test(contractId)) {
+  if (!isValidContractId(contractId)) {
     return sendError(res, 400, "invalid_contract_id", "Invalid contract ID format");
   }
   next();
@@ -199,7 +200,7 @@ export function validateContractIdMiddleware(req, res, next) {
  * Returns true if valid, otherwise sends a 400 and returns false.
  */
 export function validateContractId(contractId, res) {
-  if (!/^C[A-Z2-7]{55}$/.test(contractId)) {
+  if (!isValidContractId(contractId)) {
     sendError(res, 400, "invalid_contract_id", "Invalid contract ID format");
     return false;
   }

--- a/backend/tests/analytics-n1.test.js
+++ b/backend/tests/analytics-n1.test.js
@@ -1,6 +1,8 @@
 import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
-import { db } from "../src/database/core.js";
+import { db, initializeDatabase } from "../src/database/core.js";
 import { getAnalyticsData, _clearAnalyticsCache } from "../src/database/analytics.js";
+
+const CONTRACT = `C${"A".repeat(55)}`;
 
 // #503: guards against regressing the analytics endpoint back to an N+1 pattern.
 // The number of DB round-trips must stay constant (it must not scale with the
@@ -8,6 +10,7 @@ import { getAnalyticsData, _clearAnalyticsCache } from "../src/database/analytic
 // from cache rather than re-querying.
 describe("analytics query (N+1 regression)", () => {
   beforeEach(() => {
+    initializeDatabase();
     _clearAnalyticsCache();
   });
 
@@ -17,21 +20,21 @@ describe("analytics query (N+1 regression)", () => {
 
   test("issues a constant, small number of queries regardless of data size", () => {
     const prepareSpy = jest.spyOn(db, "prepare");
-    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    getAnalyticsData(CONTRACT, "2026-01-01", "2026-03-01");
     // summary + trends + topEarners + collaboratorStats = 4 set-based queries.
     expect(prepareSpy).toHaveBeenCalledTimes(4);
   });
 
   test("a second call within the TTL is served from cache (no extra queries)", () => {
     const prepareSpy = jest.spyOn(db, "prepare");
-    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    getAnalyticsData(CONTRACT, "2026-01-01", "2026-03-01");
     prepareSpy.mockClear();
-    getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    getAnalyticsData(CONTRACT, "2026-01-01", "2026-03-01");
     expect(prepareSpy).not.toHaveBeenCalled();
   });
 
   test("returns the expected aggregate shape", () => {
-    const result = getAnalyticsData("CCONTRACT", "2026-01-01", "2026-03-01");
+    const result = getAnalyticsData(CONTRACT, "2026-01-01", "2026-03-01");
     expect(result).toHaveProperty("summary");
     expect(result).toHaveProperty("trends");
     expect(result).toHaveProperty("topEarners");

--- a/backend/tests/contract-id-sql-injection.test.js
+++ b/backend/tests/contract-id-sql-injection.test.js
@@ -1,0 +1,114 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import { db, initializeDatabase } from "../src/database/core.js";
+import { assertValidContractId } from "../src/contract-id.js";
+import {
+  addDistributionPayout,
+  getTransactionCount,
+  getTransactionHistory,
+  recordTransaction,
+} from "../src/database/transactions.js";
+import { addAuditLog, exportAuditLogs, getAuditLog } from "../src/database/audit.js";
+import {
+  countSecondarySales,
+  getSecondarySales,
+  recordSecondarySale,
+} from "../src/database/secondary-royalties.js";
+import { listWebhooks, registerWebhook } from "../src/database/webhooks.js";
+import { recordNonceIfNew } from "../src/database/request-nonces.js";
+import { searchIndexedEvents } from "../src/routes/eventDatabase.js";
+
+const CONTRACT = `C${"A".repeat(55)}`;
+const OTHER_CONTRACT = `C${"B".repeat(55)}`;
+const WALLET = `G${"A".repeat(55)}`;
+const COLLABORATOR = `G${"B".repeat(55)}`;
+const TOKEN = `C${"C".repeat(55)}`;
+
+const INJECTION_ATTEMPTS = [
+  `${CONTRACT}' OR '1'='1`,
+  `${CONTRACT}'; DROP TABLE transactions; --`,
+  `${CONTRACT}" UNION SELECT * FROM audit_log --`,
+  `${CONTRACT}) OR 1=1 --`,
+  `${CONTRACT}\nOR contractId = '${OTHER_CONTRACT}'`,
+  "C'; DELETE FROM secondary_sales; --",
+];
+
+function resetTables() {
+  db.prepare("DELETE FROM indexed_events").run();
+  db.prepare("DELETE FROM request_nonces").run();
+  db.prepare("DELETE FROM webhook_dead_letters").run();
+  db.prepare("DELETE FROM webhooks").run();
+  db.prepare("DELETE FROM secondary_royalty_distributions").run();
+  db.prepare("DELETE FROM secondary_sales").run();
+  db.prepare("DELETE FROM distribution_payouts").run();
+  db.prepare("DELETE FROM transactions").run();
+  db.prepare("DELETE FROM audit_log").run();
+}
+
+function seedRows() {
+  const txId = recordTransaction(CONTRACT, "distribute", WALLET, {
+    requestedAmount: "100",
+    tokenId: TOKEN,
+  });
+  addDistributionPayout(txId, CONTRACT, COLLABORATOR, "100");
+  addAuditLog(CONTRACT, "contract_initialized", WALLET, { collaborators: [COLLABORATOR] });
+  recordSecondarySale(CONTRACT, "nft-1", WALLET, COLLABORATOR, 1000, TOKEN, 50, 500);
+  registerWebhook(CONTRACT, "https://example.com/hook");
+  recordNonceIfNew(CONTRACT, "9a7a4ec5-7c52-4a95-b24e-87d41dbbefcc");
+  db.prepare(`
+    INSERT INTO indexed_events (event_id, ledger_sequence, transaction_hash, event_index, timestamp, contract_id, event_type, event_data, raw_event)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run("evt-1", 1, "a".repeat(64), 0, "2026-06-30T00:00:00.000Z", CONTRACT, "distribute", "{}", "{}");
+}
+
+describe("contract ID SQL injection defenses (#507)", () => {
+  beforeEach(() => {
+    initializeDatabase();
+    resetTables();
+    seedRows();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetTables();
+  });
+
+  test("accepts a strict Stellar contract ID", () => {
+    expect(assertValidContractId(CONTRACT)).toBe(CONTRACT);
+  });
+
+  test.each(INJECTION_ATTEMPTS)("rejects injected contract ID before preparing SQL: %s", (payload) => {
+    const prepareSpy = jest.spyOn(db, "prepare");
+
+    expect(() => getTransactionHistory(payload)).toThrow("Invalid contract ID format");
+    expect(() => getTransactionCount(payload)).toThrow("Invalid contract ID format");
+    expect(() => getAuditLog(payload)).toThrow("Invalid contract ID format");
+    expect(() => exportAuditLogs({ contractId: payload })).toThrow("Invalid contract ID format");
+    expect(() => getSecondarySales(payload)).toThrow("Invalid contract ID format");
+    expect(() => countSecondarySales(payload)).toThrow("Invalid contract ID format");
+    expect(() => listWebhooks(payload)).toThrow("Invalid contract ID format");
+    expect(() => searchIndexedEvents(payload)).toThrow("Invalid contract ID format");
+
+    expect(prepareSpy).not.toHaveBeenCalled();
+  });
+
+  test.each(INJECTION_ATTEMPTS)("rejects injected contract ID on writes without mutating data: %s", (payload) => {
+    expect(() => recordTransaction(payload, "distribute", WALLET, { requestedAmount: "1", tokenId: TOKEN })).toThrow(
+      "Invalid contract ID format"
+    );
+    expect(() => addDistributionPayout(1, payload, COLLABORATOR, "1")).toThrow("Invalid contract ID format");
+    expect(() => addAuditLog(payload, "injected", WALLET, {})).toThrow("Invalid contract ID format");
+    expect(() => recordSecondarySale(payload, "nft-2", WALLET, COLLABORATOR, 1000, TOKEN, 50, 500)).toThrow(
+      "Invalid contract ID format"
+    );
+    expect(() => registerWebhook(payload, "https://example.com/injected")).toThrow("Invalid contract ID format");
+    expect(() => recordNonceIfNew(payload, "63bbca73-2e48-41ec-ab85-c18cd998577f")).toThrow(
+      "Invalid contract ID format"
+    );
+
+    expect(db.prepare("SELECT COUNT(*) AS total FROM transactions").get().total).toBe(1);
+    expect(db.prepare("SELECT COUNT(*) AS total FROM audit_log").get().total).toBe(1);
+    expect(db.prepare("SELECT COUNT(*) AS total FROM secondary_sales").get().total).toBe(1);
+    expect(db.prepare("SELECT COUNT(*) AS total FROM webhooks").get().total).toBe(1);
+    expect(db.prepare("SELECT COUNT(*) AS total FROM request_nonces").get().total).toBe(1);
+  });
+});

--- a/backend/tests/database-integrity.test.js
+++ b/backend/tests/database-integrity.test.js
@@ -8,6 +8,9 @@ import assert from "node:assert";
 import { db, initializeDatabase, verifyAuditLogIntegrity, computeAuditEntryHash } from "../src/database/core.js";
 import { addAuditLog, getAuditLog } from "../src/database/audit.js";
 
+const CONTRACT = `C${"A".repeat(55)}`;
+const OTHER_CONTRACT = `C${"B".repeat(55)}`;
+
 describe("Database Integrity Verification (Issue #395)", () => {
   beforeEach(() => {
     initializeDatabase();
@@ -82,9 +85,9 @@ describe("Database Integrity Verification (Issue #395)", () => {
 
   describe("Audit Log Hash Chain", () => {
     it("should create first entry with null prev_hash", () => {
-      addAuditLog("contract123", "initialize", "admin", { collaborators: ["user1", "user2"] });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1", "user2"] });
       
-      const logs = getAuditLog("contract123");
+      const logs = getAuditLog(CONTRACT);
       assert.strictEqual(logs.length, 1);
       assert.strictEqual(logs[0].prev_hash, null);
       assert.strictEqual(typeof logs[0].entry_hash, "string");
@@ -92,10 +95,10 @@ describe("Database Integrity Verification (Issue #395)", () => {
     });
 
     it("should chain subsequent entries with prev_hash", () => {
-      addAuditLog("contract123", "initialize", "admin", { collaborators: ["user1", "user2"] });
-      addAuditLog("contract123", "distribute", "user1", { amount: "100" });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1", "user2"] });
+      addAuditLog(CONTRACT, "distribute", "user1", { amount: "100" });
       
-      const logs = getAuditLog("contract123");
+      const logs = getAuditLog(CONTRACT);
       assert.strictEqual(logs.length, 2);
       
       // First entry should have null prev_hash
@@ -109,10 +112,10 @@ describe("Database Integrity Verification (Issue #395)", () => {
       const actions = ["initialize", "distribute", "distribute", "secondary_royalty"];
       
       actions.forEach((action, i) => {
-        addAuditLog("contract123", action, "user1", { step: i });
+        addAuditLog(CONTRACT, action, "user1", { step: i });
       });
       
-      const logs = getAuditLog("contract123");
+      const logs = getAuditLog(CONTRACT);
       assert.strictEqual(logs.length, 4);
       
       // Verify chain: each entry's prev_hash should match previous entry's entry_hash
@@ -124,58 +127,58 @@ describe("Database Integrity Verification (Issue #395)", () => {
 
   describe("Integrity Verification", () => {
     it("should pass verification for valid audit log", () => {
-      addAuditLog("contract123", "initialize", "admin", { collaborators: ["user1"] });
-      addAuditLog("contract123", "distribute", "user1", { amount: "100" });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1"] });
+      addAuditLog(CONTRACT, "distribute", "user1", { amount: "100" });
       
-      const result = verifyAuditLogIntegrity("contract123");
+      const result = verifyAuditLogIntegrity(CONTRACT);
       assert.strictEqual(result.valid, true);
       assert.strictEqual(result.brokenAt, null);
       assert.strictEqual(result.error, null);
     });
 
     it("should pass verification for empty audit log", () => {
-      const result = verifyAuditLogIntegrity("contract123");
+      const result = verifyAuditLogIntegrity(CONTRACT);
       assert.strictEqual(result.valid, true);
       assert.strictEqual(result.brokenAt, null);
       assert.strictEqual(result.error, null);
     });
 
     it("should detect broken hash chain", () => {
-      addAuditLog("contract123", "initialize", "admin", { collaborators: ["user1"] });
-      addAuditLog("contract123", "distribute", "user1", { amount: "100" });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1"] });
+      addAuditLog(CONTRACT, "distribute", "user1", { amount: "100" });
 
-      const logs = getAuditLog("contract123");
+      const logs = getAuditLog(CONTRACT);
       const newestLog = logs[0];
 
       // Manually break the chain by updating prev_hash
       db.prepare("UPDATE audit_log SET prev_hash = ? WHERE id = ?").run("fake_hash", newestLog.id);
 
-      const result = verifyAuditLogIntegrity("contract123");
+      const result = verifyAuditLogIntegrity(CONTRACT);
       assert.strictEqual(result.valid, false);
       assert.strictEqual(result.brokenAt, newestLog.id);
       assert(result.error.includes("Hash chain broken"));
     });
 
     it("should detect tampered entry hash", () => {
-      addAuditLog("contract123", "initialize", "admin", { collaborators: ["user1"] });
-      addAuditLog("contract123", "distribute", "user1", { amount: "100" });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1"] });
+      addAuditLog(CONTRACT, "distribute", "user1", { amount: "100" });
 
-      const logs = getAuditLog("contract123");
+      const logs = getAuditLog(CONTRACT);
       const oldestLog = logs[logs.length - 1];
 
       // Manually tamper with entry_hash
       db.prepare("UPDATE audit_log SET entry_hash = ? WHERE id = ?").run("tampered_hash", oldestLog.id);
 
-      const result = verifyAuditLogIntegrity("contract123");
+      const result = verifyAuditLogIntegrity(CONTRACT);
       assert.strictEqual(result.valid, false);
       assert.strictEqual(result.brokenAt, oldestLog.id);
       assert(result.error.includes("Hash mismatch"));
     });
 
     it("should verify integrity across all contracts when contractId is null", () => {
-      addAuditLog("contract1", "initialize", "admin", { collaborators: ["user1"] });
-      addAuditLog("contract2", "initialize", "admin", { collaborators: ["user2"] });
-      addAuditLog("contract1", "distribute", "user1", { amount: "100" });
+      addAuditLog(CONTRACT, "initialize", "admin", { collaborators: ["user1"] });
+      addAuditLog(OTHER_CONTRACT, "initialize", "admin", { collaborators: ["user2"] });
+      addAuditLog(CONTRACT, "distribute", "user1", { amount: "100" });
       
       const result = verifyAuditLogIntegrity(); // No contractId - verify all
       assert.strictEqual(result.valid, true);

--- a/backend/tests/pagination-index.test.js
+++ b/backend/tests/pagination-index.test.js
@@ -2,6 +2,9 @@ import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
 import { db, initializeDatabase, closeDatabase } from "../src/database/core.js";
 import { getTransactionHistory } from "../src/database/transactions.js";
 
+const CONTRACT = `C${"A".repeat(55)}`;
+const WALLET = `G${"A".repeat(55)}`;
+
 describe("Pagination Composite Index (#461)", () => {
   beforeAll(() => {
     // ensure DB is initialized
@@ -22,7 +25,7 @@ describe("Pagination Composite Index (#461)", () => {
       WHERE t.contractId = ?
       ORDER BY t.timestamp DESC
       LIMIT ? OFFSET ?
-    `).all("C123", 50, 0);
+    `).all(CONTRACT, 50, 0);
 
     const plan = JSON.stringify(explain);
     // SQLite should use the idx_transactions_contractId_timestamp_desc index
@@ -30,17 +33,17 @@ describe("Pagination Composite Index (#461)", () => {
   });
 
   test("Pagination performance regression with 10k+ rows", () => {
-    const contractId = "CBENCHMARK10K";
+    const contractId = CONTRACT;
     db.prepare("BEGIN TRANSACTION").run();
     
     // insert 10,000 rows
     const insertTx = db.prepare(`
-      INSERT INTO transactions (contractId, type, initiatorAddress, status, timestamp) 
-      VALUES (?, 'initialize', 'G123', 'confirmed', datetime('now', '-' || ? || ' seconds'))
+      INSERT INTO transactions (contractId, type, initiatorAddress, status, timestamp)
+      VALUES (?, 'initialize', ?, 'confirmed', datetime('now', '-' || ? || ' seconds'))
     `);
     
     for (let i = 0; i < 10000; i++) {
-      insertTx.run(contractId, i);
+      insertTx.run(contractId, WALLET, i);
     }
     db.prepare("COMMIT").run();
 

--- a/backend/tests/secondary-royalty-stats.test.js
+++ b/backend/tests/secondary-royalty-stats.test.js
@@ -63,8 +63,8 @@ const { getRoyaltyStatistics, _invalidateStatsCache } = await import(
   "../src/database/secondary-royalties.js"
 );
 
-const CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const OTHER_CONTRACT = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const CONTRACT = `C${"A".repeat(55)}`;
+const OTHER_CONTRACT = `C${"B".repeat(55)}`;
 
 function makeFullRow(overrides = {}) {
   return {
@@ -114,7 +114,7 @@ describe("getRoyaltyStatistics combined CTE (#462)", () => {
     getRoyaltyStatistics(CONTRACT);
     const callsAfterFirst = mockDb.prepare.mock.calls.length;
 
-    getRoyaltyStatistics(CONTRACT + "X");
+    getRoyaltyStatistics(OTHER_CONTRACT);
 
     const callsAfter = mockDb.prepare.mock.calls.length;
     expect(callsAfterFirst - callsBefore).toBeLessThanOrEqual(1);


### PR DESCRIPTION
Closes #507
What was done
Audited and hardened all contract ID query paths against SQL injection by introducing a shared validator and enforcing prepared statements throughout the backend.
Changes

Shared validator — new backend/src/contract-id.js with strict Stellar contract ID format validation
Parameterized queries — enforced across transactions, audit logs, analytics, webhooks, request nonces, roles, secondary royalties, indexed events, and database.js
No string concatenation — removed all dynamic SQL append patterns
Secondary-sale fix — replaced IN (${placeholders}) with a bound JSON parameter via json_each(?)
Migration fix — duplicate migration versions are now skipped after being applied in the same run
6 injection tests — covering read and write paths with real injection payload variants

Test results

58 tests passing across all affected test files ✅
git diff --check clean ✅

Notes

better-sqlite3 local package had corrupted NUL bytes and was reinstalled — no package files were changed
Pre-existing full suite failures are unrelated to this issue