### PR TITLE
feat(frontend): add 300ms debounced form validation with caching and …

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,7 @@ import { createSignedRequestHeaders } from "./request-signing";
 export { setRequestSigningSecret } from "./request-signing";
 
 const BASE = "/api/v1";
+export const SESSION_EXPIRED_EVENT = "srs:session-expired";
 
 // #279: surface a structured `code + message + details` shape from
 // the backend's error response instead of just `data.error`. The
@@ -36,34 +37,27 @@ async function post<T>(
   walletAddress?: string,
   extraHeaders?: Record<string, string>,
 ): Promise<T> {
+  const requestPath = `${BASE}${path}`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
 
-  if (walletAddress && typeof body === "object" && body !== null) {
-    const signingHeaders = await signWriteRequest({
-      method: "POST",
-      path: `${BASE}${path}`,
-      body,
-      walletAddress,
-    });
-    Object.assign(headers, signingHeaders);
+  if (walletAddress) {
+    Object.assign(
+      headers,
+      createSignedRequestHeaders({
+        method: "POST",
+        path: requestPath,
+        body,
+      }),
+    );
   }
 
   if (extraHeaders) {
     Object.assign(headers, extraHeaders);
   }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
-  const requestPath = `${BASE}${path}`;
-  const res = await fetch(requestPath, {
+  return request<T>(path, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...createSignedRequestHeaders({
-        method: "POST",
-        path: requestPath,
-        body,
-      }),
-    },
+    headers,
     body: JSON.stringify(body),
   });
 }
@@ -78,6 +72,23 @@ export function generateIdempotencyKey(): string {
 
 async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
   return request<T>(path, signal ? { signal } : undefined);
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, init);
+  const data = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    const extracted = extractContractError(data);
+    throw new BackendApiError(
+      res.status,
+      extracted.code,
+      extracted.message || res.statusText,
+      extracted.details,
+    );
+  }
+
+  return data as T;
 }
 
 export interface TransactionRecord {

--- a/frontend/src/components/DistributeForm.tsx
+++ b/frontend/src/components/DistributeForm.tsx
@@ -426,7 +426,7 @@ export default function DistributeForm({
         label="Token contract address"
         placeholder="C..."
         value={tokenId}
-        error={tokenIdError}
+        error={tokenIdError ?? undefined}
         showSuccess={tokenIdValid && !tokenIdError}
         autoComplete="off"
         spellCheck={false}
@@ -451,7 +451,7 @@ export default function DistributeForm({
         placeholder="0"
         value={amount}
         error={exceedsBalance ? `Amount exceeds available balance of ${contractBalance}` : undefined}
-        showSuccess={amount && !isNaN(parsedAmount) && parsedAmount > 0 && !exceedsBalance}
+        showSuccess={Boolean(amount) && !isNaN(parsedAmount) && parsedAmount > 0 && !exceedsBalance}
         onChange={(e) => setAmount(e.target.value)}
         disabled={contractBalance === null || loading}
       />

--- a/frontend/src/components/FormInput.tsx
+++ b/frontend/src/components/FormInput.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes, useState, useEffect } from "react";
+import { InputHTMLAttributes, useState, useEffect } from "react";
 
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: string;
@@ -31,15 +31,20 @@ export default function FormInput({
   ...props
 }: FormInputProps) {
   const [shouldAnimate, setShouldAnimate] = useState(false);
-  const [prevError, setPrevError] = useState(error);
+  const [prevError, setPrevError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (error && error !== prevError) {
-      setShouldAnimate(true);
-      const timer = setTimeout(() => setShouldAnimate(false), 500);
-      return () => clearTimeout(timer);
-    }
+    if (error === prevError) return;
+
     setPrevError(error);
+    if (!error) {
+      setShouldAnimate(false);
+      return;
+    }
+
+    setShouldAnimate(true);
+    const timer = setTimeout(() => setShouldAnimate(false), 500);
+    return () => clearTimeout(timer);
   }, [error, prevError]);
 
   const wrapperClasses = [

--- a/frontend/src/components/InitializeForm.test.tsx
+++ b/frontend/src/components/InitializeForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import InitializeForm from "./InitializeForm";
 
 vi.mock("../context/NetworkContext", () => ({
@@ -9,12 +9,26 @@ vi.mock("../context/NetworkContext", () => ({
   }),
 }));
 
+vi.mock("../api", () => ({
+  api: {
+    lookupCollaborators: vi.fn().mockResolvedValue({ suggestions: [] }),
+    commitInitialize: vi.fn(),
+    revealInitialize: vi.fn(),
+    confirmTransaction: vi.fn(),
+  },
+}));
+
 const VALID_ADDRESS_1 = `G${"A".repeat(55)}`;
 const VALID_ADDRESS_2 = `G${"B".repeat(55)}`;
 
 describe("InitializeForm", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test("renders a collaborator row and action buttons", () => {
@@ -28,6 +42,7 @@ describe("InitializeForm", () => {
   });
 
   test("shows address validation error for invalid Stellar addresses", () => {
+    vi.useFakeTimers();
     render(
       <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
     );
@@ -36,11 +51,18 @@ describe("InitializeForm", () => {
     fireEvent.change(addressInput, { target: { value: "not-a-valid-address" } });
     fireEvent.blur(addressInput);
 
+    expect(screen.queryByText(/Must be a valid Stellar address/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
     expect(screen.getByText(/Must be a valid Stellar address/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Commit initialization/i })).toBeDisabled();
   });
 
   test("shows percentage validation error for too large values", () => {
+    vi.useFakeTimers();
     render(
       <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
     );
@@ -49,11 +71,18 @@ describe("InitializeForm", () => {
     fireEvent.change(percentInput, { target: { value: "101" } });
     fireEvent.blur(percentInput);
 
+    expect(screen.queryByText(/Percentage must be between 0 and 100/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
     expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Commit initialization/i })).toBeDisabled();
   });
 
   test("shows percentage validation error for fractional basis points", () => {
+    vi.useFakeTimers();
     render(
       <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
     );
@@ -63,23 +92,179 @@ describe("InitializeForm", () => {
     // 1. Test with 33.333 (fractional basis points)
     fireEvent.change(percentInput, { target: { value: "33.333" } });
     fireEvent.blur(percentInput);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
     expect(screen.getByText(/Fractional basis points are not allowed/i)).toBeInTheDocument();
     expect(percentInput).toHaveClass("input-error");
 
     // 2. Test with 0.005 (fractional basis points)
     fireEvent.change(percentInput, { target: { value: "0.005" } });
     fireEvent.blur(percentInput);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
     expect(screen.getByText(/Fractional basis points are not allowed/i)).toBeInTheDocument();
 
     // 3. Test with 3333.33 (too large percentage, fractional basis points if it were allowed)
     fireEvent.change(percentInput, { target: { value: "3333.33" } });
     fireEvent.blur(percentInput);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
     expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
 
     // 4. Test with -0.5 (negative decimal percentage)
     fireEvent.change(percentInput, { target: { value: "-0.5" } });
     fireEvent.blur(percentInput);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
     expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
+  });
+
+  test("debounces address errors until 300ms after typing stops", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    const addressInput = screen.getByPlaceholderText(/Wallet address \(G\.\.\./i);
+    fireEvent.change(addressInput, { target: { value: "bad" } });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(screen.queryByText(/Must be a valid Stellar address/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByText(/Must be a valid Stellar address/i)).toBeInTheDocument();
+  });
+
+  test("debounces rapid percentage edits and only validates the latest value", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    const percentInput = screen.getByLabelText(/Royalty percentage for collaborator 1/i);
+    fireEvent.change(percentInput, { target: { value: "101" } });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    fireEvent.change(percentInput, { target: { value: "10" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.queryByText(/Percentage must be between 0 and 100/i)).not.toBeInTheDocument();
+    expect(percentInput).not.toHaveClass("input-error");
+  });
+
+  test("validates changed fields incrementally without touching other rows", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Add collaborator/i }));
+    const [firstAddressInput, secondAddressInput] = screen.getAllByPlaceholderText(/Wallet address \(G\.\.\./i);
+
+    fireEvent.change(secondAddressInput, { target: { value: "bad-row-two" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(secondAddressInput).toHaveClass("input-error");
+    expect(firstAddressInput).not.toHaveClass("input-error");
+    expect(screen.getAllByText(/Must be a valid Stellar address/i)).toHaveLength(1);
+  });
+
+  test("keeps large-form typing responsive while validation waits for the debounce", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    for (let i = 1; i < 50; i += 1) {
+      fireEvent.click(screen.getByRole("button", { name: /Add collaborator/i }));
+    }
+
+    const percentInput = screen.getByLabelText(/Royalty percentage for collaborator 50/i);
+    fireEvent.change(percentInput, { target: { value: "40" } });
+
+    expect(screen.getByTestId("share-total")).toHaveTextContent("40.00%");
+    expect(screen.queryByText(/Percentage/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(percentInput).not.toHaveClass("input-error");
+    expect(screen.getAllByPlaceholderText(/Wallet address \(G\.\.\./i)).toHaveLength(50);
+  });
+
+  test("preserves debounce delay when a validation result is cached", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    const percentInput = screen.getByLabelText(/Royalty percentage for collaborator 1/i);
+    fireEvent.change(percentInput, { target: { value: "101" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
+
+    fireEvent.change(percentInput, { target: { value: "10" } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText(/Percentage must be between 0 and 100/i)).not.toBeInTheDocument();
+
+    fireEvent.change(percentInput, { target: { value: "101" } });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(screen.queryByText(/Percentage must be between 0 and 100/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByText(/Percentage must be between 0 and 100/i)).toBeInTheDocument();
+  });
+
+  test("cleans up pending debounced validation when a row is removed", () => {
+    vi.useFakeTimers();
+    render(
+      <InitializeForm contractId="dummy" walletAddress="GABC" onSuccess={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Add collaborator/i }));
+    fireEvent.change(screen.getAllByPlaceholderText(/Wallet address \(G\.\.\./i)[1], {
+      target: { value: "bad-row-two" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /✕/i })[0]);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.queryByText(/Must be a valid Stellar address/i)).not.toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText(/Wallet address \(G\.\.\./i)).toHaveLength(1);
   });
 
   test("adds a second collaborator row when Add collaborator is clicked", () => {

--- a/frontend/src/components/InitializeForm.tsx
+++ b/frontend/src/components/InitializeForm.tsx
@@ -34,6 +34,9 @@ interface Collaborator {
   basisPoints: string;
 }
 
+type CollaboratorField = "address" | "basisPoints";
+type FieldErrors = Record<number, { address?: string; basisPoints?: string }>;
+
 interface Props {
   contractId: string;
   walletAddress: string;
@@ -43,6 +46,8 @@ interface Props {
 const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
 const MAX_COLLABORATORS = 50;
 const BASIS_POINTS_TOTAL = 10_000;
+const VALIDATION_DEBOUNCE_MS = 300;
+const VALIDATION_CACHE_LIMIT = 500;
 const PERCENTAGE_INPUT_RE = /^(\d+(\.\d*)?|\.\d+)?$/;
 const SIGNED_PERCENTAGE_INPUT_RE = /^-(\d+(\.\d*)?|\.\d+)$/;
 const PERCENTAGE_NAVIGATION_KEYS = [
@@ -116,22 +121,6 @@ function calculateEvenSplit(collaboratorCount: number) {
   );
 }
 
-function updatePercentageError(
-  setErrors: React.Dispatch<
-    React.SetStateAction<Record<number, { address?: string; basisPoints?: string }>>
-  >,
-  i: number,
-  error: string,
-) {
-  setErrors((prev) => ({
-    ...prev,
-    [i]: {
-      ...prev[i],
-      basisPoints: error,
-    },
-  }));
-}
-
 function handlePercentageKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
   if (
     event.ctrlKey ||
@@ -151,6 +140,42 @@ function handlePercentageKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
   }
 }
 
+function getFieldValidationError(field: CollaboratorField, value: string) {
+  if (field === "address") {
+    return value && !STELLAR_ADDRESS_RE.test(value)
+      ? "Must be a valid Stellar address (G..., 56 chars)"
+      : "";
+  }
+
+  return getPercentageError(value);
+}
+
+function setFieldError(
+  setErrors: React.Dispatch<React.SetStateAction<FieldErrors>>,
+  i: number,
+  field: CollaboratorField,
+  error: string,
+) {
+  setErrors((prev) => {
+    const nextRow = { ...(prev[i] ?? {}) };
+
+    if (error) {
+      nextRow[field] = error;
+    } else {
+      delete nextRow[field];
+    }
+
+    const next = { ...prev };
+    if (nextRow.address || nextRow.basisPoints) {
+      next[i] = nextRow;
+    } else {
+      delete next[i];
+    }
+
+    return next;
+  });
+}
+
 export default function InitializeForm({
   contractId,
   walletAddress,
@@ -160,9 +185,7 @@ export default function InitializeForm({
   const [collaborators, setCollaborators] = useState<Collaborator[]>([
     { address: "", basisPoints: "" },
   ]);
-  const [errors, setErrors] = useState<
-    Record<number, { address?: string; basisPoints?: string }>
-  >({});
+  const [errors, setErrors] = useState<FieldErrors>({});
   const { status, setStatus } = useFormStatus();
   const [loading, setLoading] = useState(false);
   const [phase, setPhase] = useState<InitPhase>("form");
@@ -170,6 +193,8 @@ export default function InitializeForm({
   const [suggestions, setSuggestions] = useState<Record<number, CollaboratorSuggestion[]>>({});
   const [focusedAddressIndex, setFocusedAddressIndex] = useState<number | null>(null);
   const [lookupLoading, setLookupLoading] = useState<Record<number, boolean>>({});
+  const validationTimers = React.useRef(new Map<string, number>());
+  const validationCache = React.useRef(new Map<string, string>());
 
   const selectedAddresses = useMemo(
     () => new Set(collaborators.map((collaborator) => collaborator.address.trim()).filter(Boolean)),
@@ -183,6 +208,14 @@ export default function InitializeForm({
       setPhase("committed");
     }
   }, [contractId]);
+
+  useEffect(() => {
+    return () => {
+      validationTimers.current.forEach((timer) => window.clearTimeout(timer));
+      validationTimers.current.clear();
+      validationCache.current.clear();
+    };
+  }, []);
 
   useEffect(() => {
     const timers = collaborators.map((collaborator, index) => {
@@ -217,44 +250,44 @@ export default function InitializeForm({
 
   function selectSuggestion(i: number, address: string) {
     update(i, "address", address);
-    validateRow(i, "address", address);
+    scheduleValidation(i, "address", address);
     setFocusedAddressIndex(null);
   }
 
-  function validateRow(
-    i: number,
-    field: "address" | "basisPoints",
-    value: string,
-  ) {
-    const rowErrors = { ...errors };
-    if (field === "address") {
-      if (value && !STELLAR_ADDRESS_RE.test(value)) {
-        rowErrors[i] = {
-          ...rowErrors[i],
-          address: "Must be a valid Stellar address (G..., 56 chars)",
-        };
-      } else {
-        const { address: _, ...rest } = rowErrors[i] ?? {};
-        rowErrors[i] = rest;
-      }
+  function getCachedFieldError(field: CollaboratorField, value: string) {
+    const cacheKey = `${field}:${value}`;
+    const cached = validationCache.current.get(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const error = getFieldValidationError(field, value);
+    validationCache.current.set(cacheKey, error);
+    if (validationCache.current.size > VALIDATION_CACHE_LIMIT) {
+      const oldestKey = validationCache.current.keys().next().value;
+      if (oldestKey) validationCache.current.delete(oldestKey);
     }
-    if (field === "basisPoints") {
-      const percentageError = getPercentageError(value);
-      if (percentageError) {
-        rowErrors[i] = {
-          ...rowErrors[i],
-          basisPoints: percentageError,
-        };
-      } else {
-        const { basisPoints: _, ...rest } = rowErrors[i] ?? {};
-        rowErrors[i] = rest;
-      }
-    }
-    setErrors(rowErrors);
+
+    return error;
   }
 
-  function handleBlur(i: number, field: "address" | "basisPoints", value: string) {
-    validateRow(i, field, value);
+  function scheduleValidation(
+    i: number,
+    field: CollaboratorField,
+    value: string,
+  ) {
+    const fieldKey = `${i}:${field}`;
+    const existingTimer = validationTimers.current.get(fieldKey);
+    if (existingTimer) window.clearTimeout(existingTimer);
+
+    const timer = window.setTimeout(() => {
+      validationTimers.current.delete(fieldKey);
+      setFieldError(setErrors, i, field, getCachedFieldError(field, value));
+    }, VALIDATION_DEBOUNCE_MS);
+
+    validationTimers.current.set(fieldKey, timer);
+  }
+
+  function handleBlur(i: number, field: CollaboratorField, value: string) {
+    scheduleValidation(i, field, value);
   }
 
   function addRow() {
@@ -263,8 +296,15 @@ export default function InitializeForm({
 
   function removeRow(i: number) {
     setCollaborators((prev: Collaborator[]) => prev.filter((_: Collaborator, idx: number) => idx !== i));
-    setErrors((prev: Record<number, { address?: string; basisPoints?: string }>) => {
-      const next: Record<number, { address?: string; basisPoints?: string }> = {};
+    validationTimers.current.forEach((timer, key) => {
+      const [rowIndex] = key.split(":");
+      if (Number(rowIndex) >= i) {
+        window.clearTimeout(timer);
+        validationTimers.current.delete(key);
+      }
+    });
+    setErrors((prev: FieldErrors) => {
+      const next: FieldErrors = {};
       Object.entries(prev).forEach(([key, val]) => {
         const k = parseInt(key);
         if (k < i) next[k] = val;
@@ -282,6 +322,12 @@ export default function InitializeForm({
         basisPoints: evenShares[index],
       })),
     );
+    validationTimers.current.forEach((timer, key) => {
+      if (key.endsWith(":basisPoints")) {
+        window.clearTimeout(timer);
+        validationTimers.current.delete(key);
+      }
+    });
     setErrors((prev) => {
       const next = { ...prev };
       collaborators.forEach((_, index) => {
@@ -294,7 +340,7 @@ export default function InitializeForm({
 
   const shareSummary = calculateShareSummary(collaborators);
 
-  const hasErrors = Object.values(errors).some((e) => (e as { address?: string; basisPoints?: string })?.address || (e as { address?: string; basisPoints?: string })?.basisPoints);
+  const hasErrors = Object.values(errors).some((e) => e?.address || e?.basisPoints);
   const hasEmptyFields = collaborators.some((c: Collaborator) => !c.address || !c.basisPoints);
   const hasInvalidPercentages = collaborators.some((c: Collaborator) => getPercentageError(c.basisPoints));
   const canSubmit =
@@ -453,13 +499,16 @@ export default function InitializeForm({
                         placeholder="Wallet address (G...)"
                         value={c.address}
                         error={errors[i]?.address}
-                        showSuccess={c.address && STELLAR_ADDRESS_RE.test(c.address) && !errors[i]?.address}
+                        showSuccess={Boolean(c.address) && STELLAR_ADDRESS_RE.test(c.address) && !errors[i]?.address}
                         role="combobox"
                         aria-autocomplete="list"
                         aria-expanded={focusedAddressIndex === i && (suggestions[i]?.length ?? 0) > 0}
                         aria-controls={`collaborator-${i}-suggestions`}
                         aria-label={`Wallet address for collaborator ${i + 1}`}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => update(i, "address", e.target.value)}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          update(i, "address", e.target.value);
+                          scheduleValidation(i, "address", e.target.value);
+                        }}
                         onFocus={() => setFocusedAddressIndex(i)}
                         onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                           handleBlur(i, "address", e.target.value);
@@ -508,19 +557,20 @@ export default function InitializeForm({
                       max={100}
                       step="any"
                       value={c.basisPoints}
+                      className={highlightShare ? "input-error" : ""}
                       error={percentageError}
-                      showSuccess={c.basisPoints && !percentageError && !getPercentageError(c.basisPoints)}
+                      showSuccess={Boolean(c.basisPoints) && !percentageError && !getPercentageError(c.basisPoints)}
                       aria-label={`Royalty percentage for collaborator ${i + 1}`}
                       onKeyDown={handlePercentageKeyDown}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         const { value } = e.target;
                         if (!isAllowedPercentageInput(value)) {
                           update(i, "basisPoints", value);
-                          updatePercentageError(setErrors, i, getPercentageError(value));
+                          scheduleValidation(i, "basisPoints", value);
                           return;
                         }
                         update(i, "basisPoints", value);
-                        validateRow(i, "basisPoints", value);
+                        scheduleValidation(i, "basisPoints", value);
                       }}
                       onBlur={(e: React.FocusEvent<HTMLInputElement>) => handleBlur(i, "basisPoints", e.target.value)}
                     />


### PR DESCRIPTION
Closes #514
What was done
Implemented debounced incremental form validation on InitializeForm to eliminate UI lag when typing with 100+ collaborators, while keeping validation accuracy intact.
Changes

300ms debounce — validation now fires 300ms after the user stops typing, not on every keystroke
Incremental validation — each row validates independently, errors show only after the delay
Cached results — validation results are bounded and cached to avoid redundant re-runs
Timer cleanup — debounce timers are properly cleared on row removal and component unmount
Share totals — still update immediately, unaffected by the debounce delay
TypeScript fixes — resolved strict TS issues in api.ts including broken API client parser path and SESSION_EXPIRED_EVENT
FormInput cleanup — fixed error animation behavior so existing tests pass consistently
5 debounce/performance tests — covering rapid typing, large 50-row forms, incremental row validation, cached-result delay, and cleanup

Test results

57 tests passing across InitializeForm, DistributeForm, FormInput, and api-network ✅
npm run build passing ✅

Notes

Existing Vite warnings for CSS minification syntax and large chunks are pre-existing and unrelated to this issue