### PR TITLE
feat(archive): implement contract event archival strategy with retention policy

### DIFF
--- a/backend/API.md
+++ b/backend/API.md
@@ -255,7 +255,54 @@ See route module `src/routes/secondary-royalty.js` for pool, sales, and distribu
 ## History & analytics
 
 - `GET /api/v1/history/:contractId`
+- `GET /api/v1/archive/:contractId`
+- `GET /api/v1/archive/policy`
+- `POST /api/v1/archive/policy`
+- `POST /api/v1/archive/run`
 - `GET /api/v1/analytics/:contractId`
+
+Contract event archival moves `transactions` rows older than the configured retention period into `contract_event_archive`.
+The default policy is enabled with a 90 day retention period.
+
+### `GET /api/v1/archive/:contractId`
+
+Query archived contract events for a contract.
+
+Query params:
+
+| Param | Default | Max | Description |
+| ----- | ------- | --- | ----------- |
+| `limit` | `50` | `200` | Number of archived events to return |
+| `offset` | `0` | — | Pagination offset |
+
+### `GET /api/v1/archive/policy`
+
+Returns the current archive policy:
+
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": true,
+    "retentionDays": 90,
+    "updatedAt": "2026-06-30 12:00:00"
+  }
+}
+```
+
+### `POST /api/v1/archive/policy`
+
+Update archive retention configuration.
+
+**Body:** `{ "enabled": true, "retentionDays": 90 }`
+
+### `POST /api/v1/archive/run`
+
+Runs one bounded archival batch. Events with `COALESCE(blockTime, timestamp)` older than the policy cutoff are copied into `contract_event_archive` with payout details and then removed from active `transactions`.
+
+**Body (optional):** `{ "batchSize": 500 }`
+
+**Response:** `{ "success": true, "data": { "archived": 12, "enabled": true, "retentionDays": 90, "cutoff": "2026-04-01T00:00:00.000Z", "durationMs": 8 } }`
 
 ## Transaction confirmation
 

--- a/backend/src/database/archive.js
+++ b/backend/src/database/archive.js
@@ -1,0 +1,226 @@
+/**
+ * Contract event archival functions.
+ * Moves old transaction-history events into a dedicated archive table.
+ */
+
+import { db, countWrite } from "./core.js";
+
+export const DEFAULT_ARCHIVE_RETENTION_DAYS = 90;
+export const DEFAULT_ARCHIVE_BATCH_SIZE = 500;
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBoolean(value, fallback) {
+  if (value == null) return fallback;
+  if (["1", "true", "yes", "on"].includes(String(value).toLowerCase())) return true;
+  if (["0", "false", "no", "off"].includes(String(value).toLowerCase())) return false;
+  return fallback;
+}
+
+export function getArchivePolicy() {
+  const row = db
+    .prepare(
+      `
+        SELECT enabled, retentionDays, updatedAt
+        FROM event_archive_policy
+        WHERE id = 1
+      `,
+    )
+    .get();
+
+  const envEnabled = parseBoolean(process.env.EVENT_ARCHIVE_ENABLED, null);
+  const envRetentionDays = process.env.EVENT_ARCHIVE_RETENTION_DAYS
+    ? parsePositiveInteger(process.env.EVENT_ARCHIVE_RETENTION_DAYS, DEFAULT_ARCHIVE_RETENTION_DAYS)
+    : null;
+
+  return {
+    enabled: envEnabled ?? Boolean(row?.enabled ?? 1),
+    retentionDays: envRetentionDays ?? row?.retentionDays ?? DEFAULT_ARCHIVE_RETENTION_DAYS,
+    updatedAt: row?.updatedAt ?? null,
+  };
+}
+
+export function updateArchivePolicy({ enabled, retentionDays }) {
+  const current = getArchivePolicy();
+  const nextEnabled = enabled == null ? current.enabled : Boolean(enabled);
+  const nextRetentionDays =
+    retentionDays == null
+      ? current.retentionDays
+      : parsePositiveInteger(retentionDays, current.retentionDays);
+
+  db.prepare(
+    `
+      INSERT INTO event_archive_policy (id, enabled, retentionDays, updatedAt)
+      VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+      ON CONFLICT(id) DO UPDATE SET
+        enabled = excluded.enabled,
+        retentionDays = excluded.retentionDays,
+        updatedAt = CURRENT_TIMESTAMP
+    `,
+  ).run(nextEnabled ? 1 : 0, nextRetentionDays);
+  countWrite();
+
+  return getArchivePolicy();
+}
+
+export function getArchiveCutoffDate(retentionDays, now = new Date()) {
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+  return cutoff.toISOString();
+}
+
+function mapArchiveRows(rows) {
+  return rows.map((row) => {
+    let payouts = [];
+    try {
+      payouts = JSON.parse(row.payoutsJson || "[]");
+    } catch (_) {
+      payouts = [];
+    }
+    return {
+      ...row,
+      payouts,
+      payoutsJson: undefined,
+    };
+  });
+}
+
+export function getArchivedEventCount(contractId) {
+  const stmt = db.prepare(
+    `SELECT COUNT(*) as total FROM contract_event_archive WHERE contractId = ?`,
+  );
+  return stmt.get(contractId).total;
+}
+
+export function getArchivedEvents(contractId, limit = 50, offset = 0) {
+  const stmt = db.prepare(
+    `
+      SELECT
+        id,
+        originalTransactionId,
+        txHash,
+        contractId,
+        type,
+        initiatorAddress,
+        requestedAmount,
+        tokenId,
+        timestamp,
+        blockTime,
+        status,
+        errorMessage,
+        payoutCount,
+        payoutsJson,
+        archivedAt
+      FROM contract_event_archive
+      WHERE contractId = ?
+      ORDER BY COALESCE(blockTime, timestamp) DESC, id DESC
+      LIMIT ? OFFSET ?
+    `,
+  );
+
+  return mapArchiveRows(stmt.all(contractId, limit, offset));
+}
+
+export function archiveContractEvents(options = {}) {
+  const policy = options.policy ?? getArchivePolicy();
+  const batchSize = parsePositiveInteger(options.batchSize, DEFAULT_ARCHIVE_BATCH_SIZE);
+
+  if (!policy.enabled) {
+    return {
+      archived: 0,
+      enabled: false,
+      retentionDays: policy.retentionDays,
+      cutoff: null,
+      durationMs: 0,
+    };
+  }
+
+  const cutoff = options.cutoff ?? getArchiveCutoffDate(policy.retentionDays, options.now ?? new Date());
+  const startedAt = Date.now();
+
+  const archiveBatch = db.transaction(() => {
+    const candidates = db
+      .prepare(
+        `
+          SELECT id
+          FROM transactions
+          WHERE COALESCE(blockTime, timestamp) < ?
+          ORDER BY COALESCE(blockTime, timestamp) ASC, id ASC
+          LIMIT ?
+        `,
+      )
+      .all(cutoff, batchSize);
+
+    if (candidates.length === 0) {
+      return 0;
+    }
+
+    const ids = candidates.map((row) => row.id);
+    const placeholders = ids.map(() => "?").join(",");
+
+    db.prepare(
+      `
+        INSERT OR IGNORE INTO contract_event_archive (
+          originalTransactionId,
+          txHash,
+          contractId,
+          type,
+          initiatorAddress,
+          requestedAmount,
+          tokenId,
+          timestamp,
+          blockTime,
+          status,
+          errorMessage,
+          payoutCount,
+          payoutsJson
+        )
+        SELECT
+          t.id,
+          t.txHash,
+          t.contractId,
+          t.type,
+          t.initiatorAddress,
+          t.requestedAmount,
+          t.tokenId,
+          t.timestamp,
+          t.blockTime,
+          t.status,
+          t.errorMessage,
+          COUNT(dp.id) as payoutCount,
+          COALESCE(
+            json_group_array(
+              CASE
+                WHEN dp.id IS NULL THEN NULL
+                ELSE json_object(
+                  'collaboratorAddress', dp.collaboratorAddress,
+                  'amountReceived', dp.amountReceived
+                )
+              END
+            ) FILTER (WHERE dp.id IS NOT NULL),
+            '[]'
+          ) as payoutsJson
+        FROM transactions t
+        LEFT JOIN distribution_payouts dp ON t.id = dp.transactionId
+        WHERE t.id IN (${placeholders})
+        GROUP BY t.id
+      `,
+    ).run(...ids);
+
+    db.prepare(`DELETE FROM transactions WHERE id IN (${placeholders})`).run(...ids);
+    return ids.length;
+  });
+
+  const archived = archiveBatch();
+  if (archived > 0) countWrite();
+
+  return {
+    archived,
+    enabled: true,
+    retentionDays: policy.retentionDays,
+    cutoff,
+    durationMs: Date.now() - startedAt,
+  };
+}

--- a/backend/src/database/core.js
+++ b/backend/src/database/core.js
@@ -116,6 +116,46 @@ export function initializeDatabase() {
         PRAGMA foreign_keys = ON;
       `,
     },
+    {
+      version: 4,
+      sql: `
+        CREATE TABLE IF NOT EXISTS contract_event_archive (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          originalTransactionId INTEGER NOT NULL,
+          txHash TEXT,
+          contractId TEXT NOT NULL,
+          type TEXT NOT NULL,
+          initiatorAddress TEXT NOT NULL,
+          requestedAmount TEXT,
+          tokenId TEXT,
+          timestamp DATETIME,
+          blockTime DATETIME,
+          status TEXT NOT NULL,
+          errorMessage TEXT,
+          payoutCount INTEGER NOT NULL DEFAULT 0,
+          payoutsJson TEXT NOT NULL DEFAULT '[]',
+          archivedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(originalTransactionId)
+        );
+
+        CREATE TABLE IF NOT EXISTS event_archive_policy (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          enabled INTEGER NOT NULL DEFAULT 1,
+          retentionDays INTEGER NOT NULL DEFAULT 90,
+          updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+
+        INSERT OR IGNORE INTO event_archive_policy (id, enabled, retentionDays)
+        VALUES (1, 1, 90);
+
+        CREATE INDEX IF NOT EXISTS idx_contract_event_archive_contractId
+          ON contract_event_archive(contractId);
+        CREATE INDEX IF NOT EXISTS idx_contract_event_archive_timestamp
+          ON contract_event_archive(COALESCE(blockTime, timestamp));
+        CREATE INDEX IF NOT EXISTS idx_contract_event_archive_contract_time
+          ON contract_event_archive(contractId, COALESCE(blockTime, timestamp));
+      `,
+    },
   ];
 
   const applied = db
@@ -192,6 +232,7 @@ export function initializeDatabase() {
     CREATE INDEX IF NOT EXISTS idx_transactions_contractId ON transactions(contractId);
     CREATE INDEX IF NOT EXISTS idx_transactions_txHash ON transactions(txHash);
     CREATE INDEX IF NOT EXISTS idx_transactions_status ON transactions(status);
+    CREATE INDEX IF NOT EXISTS idx_transactions_event_time ON transactions(COALESCE(blockTime, timestamp));
     CREATE INDEX IF NOT EXISTS idx_secondary_sales_contractId ON secondary_sales(contractId);
     CREATE INDEX IF NOT EXISTS idx_secondary_sales_nftId ON secondary_sales(nftId);
     CREATE INDEX IF NOT EXISTS idx_secondary_sales_timestamp ON secondary_sales(timestamp);
@@ -199,6 +240,38 @@ export function initializeDatabase() {
     CREATE INDEX IF NOT EXISTS idx_audit_contractId ON audit_log(contractId);
     CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_secondary_sales_dedup ON secondary_sales(contractId, nftId, previousOwner, newOwner, salePrice, saleToken);
+
+    CREATE TABLE IF NOT EXISTS contract_event_archive (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      originalTransactionId INTEGER NOT NULL,
+      txHash TEXT,
+      contractId TEXT NOT NULL,
+      type TEXT NOT NULL,
+      initiatorAddress TEXT NOT NULL,
+      requestedAmount TEXT,
+      tokenId TEXT,
+      timestamp DATETIME,
+      blockTime DATETIME,
+      status TEXT NOT NULL,
+      errorMessage TEXT,
+      payoutCount INTEGER NOT NULL DEFAULT 0,
+      payoutsJson TEXT NOT NULL DEFAULT '[]',
+      archivedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(originalTransactionId)
+    );
+
+    CREATE TABLE IF NOT EXISTS event_archive_policy (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      enabled INTEGER NOT NULL DEFAULT 1,
+      retentionDays INTEGER NOT NULL DEFAULT 90,
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+
+    INSERT OR IGNORE INTO event_archive_policy (id, enabled, retentionDays)
+    VALUES (1, 1, 90);
+    CREATE INDEX IF NOT EXISTS idx_contract_event_archive_contractId ON contract_event_archive(contractId);
+    CREATE INDEX IF NOT EXISTS idx_contract_event_archive_timestamp ON contract_event_archive(COALESCE(blockTime, timestamp));
+    CREATE INDEX IF NOT EXISTS idx_contract_event_archive_contract_time ON contract_event_archive(contractId, COALESCE(blockTime, timestamp));
   `);
 
   // Migration guards for existing databases

--- a/backend/src/database/index.js
+++ b/backend/src/database/index.js
@@ -45,6 +45,18 @@ export {
 // Analytics
 export { getAnalyticsData } from "./analytics.js";
 
+// Contract event archival
+export {
+  DEFAULT_ARCHIVE_BATCH_SIZE,
+  DEFAULT_ARCHIVE_RETENTION_DAYS,
+  archiveContractEvents,
+  getArchiveCutoffDate,
+  getArchivePolicy,
+  getArchivedEventCount,
+  getArchivedEvents,
+  updateArchivePolicy,
+} from "./archive.js";
+
 // Default export for backwards compatibility
 import { db } from "./core.js";
 export default db;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -21,8 +21,6 @@ import { closeDatabase, initializeDatabase } from "./database/index.js";
 import { createGracefulShutdownHandler } from "./shutdown.js";
 import { adminRouter } from "./routes/admin.js";
 import { metricsRouter } from "./routes/metrics.js";
-import { initializeDatabase } from "./database/index.js";
-import db from "./database/index.js";
 import { initializeSigningKey } from "./signing-key.js";
 import { sendError, normalizeErrorCode } from "./error-response.js";
 

--- a/backend/src/routes/history.js
+++ b/backend/src/routes/history.js
@@ -8,6 +8,11 @@ import {
   addAuditLog,
   updateTransactionStatus,
   updateTransactionHash,
+  archiveContractEvents,
+  getArchivePolicy,
+  getArchivedEventCount,
+  getArchivedEvents,
+  updateArchivePolicy,
 } from "../database/index.js";
 import {
   validateContractId,
@@ -46,6 +51,102 @@ router.get("/history/:contractId", validateContractIdMiddleware, (req, res) => {
   } catch (error) {
     logger.error("Error fetching transaction history:", error);
     sendError(res, 500, "internal_server_error", error.message ?? "Failed to fetch transaction history");
+  }
+});
+
+/**
+ * GET /api/archive/policy
+ * Get contract event archive retention policy.
+ */
+router.get("/archive/policy", (_req, res) => {
+  try {
+    res.json({
+      success: true,
+      data: getArchivePolicy(),
+    });
+  } catch (error) {
+    logger.error("Error fetching archive policy:", error);
+    sendError(res, 500, "internal_server_error", error.message ?? "Failed to fetch archive policy");
+  }
+});
+
+/**
+ * POST /api/archive/policy
+ * Update contract event archive retention policy.
+ */
+router.post("/archive/policy", (req, res) => {
+  try {
+    const { enabled, retentionDays } = req.body ?? {};
+
+    if (enabled != null && typeof enabled !== "boolean") {
+      return sendError(res, 400, "bad_request", "enabled must be a boolean");
+    }
+
+    if (retentionDays != null) {
+      const parsedRetentionDays = Number.parseInt(retentionDays, 10);
+      if (!Number.isInteger(parsedRetentionDays) || parsedRetentionDays <= 0) {
+        return sendError(res, 400, "bad_request", "retentionDays must be a positive integer");
+      }
+    }
+
+    res.json({
+      success: true,
+      data: updateArchivePolicy({ enabled, retentionDays }),
+    });
+  } catch (error) {
+    logger.error("Error updating archive policy:", error);
+    sendError(res, 500, "internal_server_error", error.message ?? "Failed to update archive policy");
+  }
+});
+
+/**
+ * POST /api/archive/run
+ * Archive old contract events according to the configured policy.
+ */
+router.post("/archive/run", (req, res) => {
+  try {
+    const { batchSize } = req.body ?? {};
+    const parsedBatchSize = batchSize == null ? undefined : Number.parseInt(batchSize, 10);
+
+    if (batchSize != null && (!Number.isInteger(parsedBatchSize) || parsedBatchSize <= 0)) {
+      return sendError(res, 400, "bad_request", "batchSize must be a positive integer");
+    }
+
+    res.json({
+      success: true,
+      data: archiveContractEvents({ batchSize: parsedBatchSize }),
+    });
+  } catch (error) {
+    logger.error("Error archiving contract events:", error);
+    sendError(res, 500, "internal_server_error", error.message ?? "Failed to archive contract events");
+  }
+});
+
+/**
+ * GET /api/archive/:contractId
+ * Query archived contract events.
+ * Query params: limit (default 50), offset (default 0)
+ */
+router.get("/archive/:contractId", validateContractIdMiddleware, (req, res) => {
+  try {
+    const { contractId } = req.params;
+    if (!validateContractId(contractId, res)) return;
+
+    const pagination = parsePagination(req.query, res, 50, 200);
+    if (!pagination) return;
+    const { limit, offset } = pagination;
+
+    const archive = getArchivedEvents(contractId, limit, offset);
+    const total = getArchivedEventCount(contractId);
+
+    res.json({
+      success: true,
+      data: archive,
+      pagination: { limit, offset, total },
+    });
+  } catch (error) {
+    logger.error("Error fetching archived contract events:", error);
+    sendError(res, 500, "internal_server_error", error.message ?? "Failed to fetch archived events");
   }
 });
 

--- a/backend/tests/archival.test.js
+++ b/backend/tests/archival.test.js
@@ -1,0 +1,238 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+
+const prepare = jest.fn();
+const transaction = jest.fn((fn) => () => fn());
+const countWrite = jest.fn();
+
+await jest.unstable_mockModule("../src/database/core.js", () => ({
+  db: {
+    prepare,
+    transaction,
+  },
+  countWrite,
+}));
+
+const {
+  archiveContractEvents,
+  getArchiveCutoffDate,
+  getArchivedEvents,
+  updateArchivePolicy,
+} = await import("../src/database/archive.js");
+
+describe("contract event archival database strategy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.EVENT_ARCHIVE_ENABLED;
+    delete process.env.EVENT_ARCHIVE_RETENTION_DAYS;
+  });
+
+  test("calculates the default 90 day archive cutoff", () => {
+    const cutoff = getArchiveCutoffDate(90, new Date("2026-06-30T00:00:00.000Z"));
+
+    expect(cutoff).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  test("skips archival when retention policy is disabled", () => {
+    const result = archiveContractEvents({
+      policy: { enabled: false, retentionDays: 90 },
+    });
+
+    expect(result).toMatchObject({
+      archived: 0,
+      enabled: false,
+      retentionDays: 90,
+      cutoff: null,
+    });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  test("moves old events into the archive table in a bounded transaction", () => {
+    const run = jest.fn();
+    const all = jest.fn().mockReturnValue([{ id: 10 }, { id: 11 }]);
+
+    prepare.mockImplementation((sql) => {
+      if (sql.includes("SELECT id") && sql.includes("FROM transactions")) {
+        return { all };
+      }
+      return { run };
+    });
+
+    const result = archiveContractEvents({
+      policy: { enabled: true, retentionDays: 90 },
+      cutoff: "2026-04-01T00:00:00.000Z",
+      batchSize: 2,
+    });
+
+    expect(result).toMatchObject({
+      archived: 2,
+      enabled: true,
+      retentionDays: 90,
+      cutoff: "2026-04-01T00:00:00.000Z",
+    });
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(all).toHaveBeenCalledWith("2026-04-01T00:00:00.000Z", 2);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(prepare.mock.calls.some(([sql]) => sql.includes("INSERT OR IGNORE INTO contract_event_archive"))).toBe(true);
+    expect(prepare.mock.calls.some(([sql]) => sql.includes("DELETE FROM transactions"))).toBe(true);
+    expect(countWrite).toHaveBeenCalledTimes(1);
+  });
+
+  test("queries archived events and reconstructs payout JSON", () => {
+    prepare.mockReturnValue({
+      all: jest.fn().mockReturnValue([
+        {
+          id: 1,
+          originalTransactionId: 22,
+          contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          payoutCount: 1,
+          payoutsJson: JSON.stringify([
+            {
+              collaboratorAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+              amountReceived: "100",
+            },
+          ]),
+        },
+      ]),
+    });
+
+    const rows = getArchivedEvents("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 10, 0);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payouts).toEqual([
+      {
+        collaboratorAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        amountReceived: "100",
+      },
+    ]);
+    expect(rows[0].payoutsJson).toBeUndefined();
+  });
+
+  test("updates retention policy configuration", () => {
+    const get = jest
+      .fn()
+      .mockReturnValueOnce({ enabled: 1, retentionDays: 90, updatedAt: "old" })
+      .mockReturnValueOnce({ enabled: 0, retentionDays: 120, updatedAt: "new" });
+    const run = jest.fn();
+
+    prepare.mockImplementation((sql) => {
+      if (sql.includes("FROM event_archive_policy")) return { get };
+      return { run };
+    });
+
+    const policy = updateArchivePolicy({ enabled: false, retentionDays: 120 });
+
+    expect(run).toHaveBeenCalledWith(0, 120);
+    expect(policy).toMatchObject({
+      enabled: false,
+      retentionDays: 120,
+      updatedAt: "new",
+    });
+  });
+});
+
+const routeGetArchivedEvents = jest.fn();
+const routeGetArchivedEventCount = jest.fn();
+const routeGetArchivePolicy = jest.fn();
+const routeUpdateArchivePolicy = jest.fn();
+const routeArchiveContractEvents = jest.fn();
+
+await jest.unstable_mockModule("../src/database/index.js", () => ({
+  getTransactionHistory: jest.fn(),
+  getTransactionCount: jest.fn(),
+  getTransactionDetails: jest.fn(),
+  getTransactionById: jest.fn(),
+  getAuditLog: jest.fn(),
+  addAuditLog: jest.fn(),
+  updateTransactionStatus: jest.fn(),
+  updateTransactionHash: jest.fn(),
+  archiveContractEvents: routeArchiveContractEvents,
+  getArchivePolicy: routeGetArchivePolicy,
+  getArchivedEventCount: routeGetArchivedEventCount,
+  getArchivedEvents: routeGetArchivedEvents,
+  updateArchivePolicy: routeUpdateArchivePolicy,
+}));
+
+await jest.unstable_mockModule("../src/stellar.js", () => ({
+  pollHorizonTransaction: jest.fn(),
+}));
+
+await jest.unstable_mockModule("../src/webhook-delivery.js", () => ({
+  deliverDistributeWebhooks: jest.fn(),
+}));
+
+const { default: historyRouter } = await import("../src/routes/history.js");
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1", historyRouter);
+
+describe("contract event archival routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns archived events through the archive query endpoint", async () => {
+    routeGetArchivedEvents.mockReturnValue([{ id: 1, contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }]);
+    routeGetArchivedEventCount.mockReturnValue(1);
+
+    const res = await request(app)
+      .get("/api/v1/archive/CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+      .query({ limit: 10, offset: 0 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      pagination: { limit: 10, offset: 0, total: 1 },
+    });
+    expect(routeGetArchivedEvents).toHaveBeenCalledWith(
+      "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      10,
+      0,
+    );
+  });
+
+  test("runs archival and reports performance duration", async () => {
+    routeArchiveContractEvents.mockReturnValue({
+      archived: 500,
+      enabled: true,
+      retentionDays: 90,
+      cutoff: "2026-04-01T00:00:00.000Z",
+      durationMs: 18,
+    });
+
+    const res = await request(app)
+      .post("/api/v1/archive/run")
+      .send({ batchSize: 500 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      archived: 500,
+      durationMs: 18,
+    });
+    expect(routeArchiveContractEvents).toHaveBeenCalledWith({ batchSize: 500 });
+  });
+
+  test("updates archive retention policy through configuration endpoint", async () => {
+    routeUpdateArchivePolicy.mockReturnValue({
+      enabled: false,
+      retentionDays: 120,
+      updatedAt: "2026-06-30T00:00:00.000Z",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/archive/policy")
+      .send({ enabled: false, retentionDays: 120 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      enabled: false,
+      retentionDays: 120,
+    });
+    expect(routeUpdateArchivePolicy).toHaveBeenCalledWith({
+      enabled: false,
+      retentionDays: 120,
+    });
+  });
+});

--- a/backend/tests/transaction-confirm.test.js
+++ b/backend/tests/transaction-confirm.test.js
@@ -23,6 +23,11 @@ await jest.unstable_mockModule("../src/database/index.js", () => ({
   addAuditLog: jest.fn(),
   updateTransactionStatus,
   updateTransactionHash,
+  archiveContractEvents: jest.fn(),
+  getArchivePolicy: jest.fn(),
+  getArchivedEventCount: jest.fn(),
+  getArchivedEvents: jest.fn(),
+  updateArchivePolicy: jest.fn(),
   initializeDatabase: jest.fn(),
   getMigrationVersion: jest.fn(() => 3),
 }));


### PR DESCRIPTION
Closes #505
What was done
Re-implemented the contract event archival strategy to prevent unbounded event log growth, with configurable retention and dedicated archive storage.
Changes

Archive tables — contract_event_archive and event_archive_policy config table
Archival logic — moves events older than the configured retention period (default 90 days) out of active history; archived transactions store payout details in archive JSON
Endpoints:

GET /api/v1/archive/:contractId
GET /api/v1/archive/policy
POST /api/v1/archive/policy
POST /api/v1/archive/run


API docs added
8 archival tests — covers archival logic and policy behavior
Lint fix — removed a duplicate initializeDatabase import in backend/src/index.js that was blocking lint parsing

Test results

12 tests passing across archival.test.js and transaction-confirm.test.js ✅
npm run lint passing (existing warnings only) ✅

Notes

Full npm test has a pre-existing, unrelated timeout in tests/stellar.test.js (withTimeout #273)